### PR TITLE
Cleaner handling of non numerical timestamp data when checking "old" data

### DIFF
--- a/nodes/widgets/ui_chart.js
+++ b/nodes/widgets/ui_chart.js
@@ -15,8 +15,17 @@ module.exports = function (RED) {
                 if (config.chartType === 'line' || config.chartType === 'scatter') {
                     // possible that we haven't received any x-data in the payload,
                     // so let's make sure we append something
-                    const datapoint = addToLine(p, label)
-                    msg._datapoint = datapoint
+
+                    // single point or array of data?
+                    if (Array.isArray(p)) {
+                        // array of data
+                        msg._datapoint = p.map((point) => {
+                            return addToLine(point, label)
+                        })
+                    } else {
+                        // single point
+                        msg._datapoint = addToLine(p, label)
+                    }
                 }
 
                 // function to process a data point being appended to a line/scatter chart
@@ -37,28 +46,44 @@ module.exports = function (RED) {
                 return msg
             },
             onInput: function (msg, send, done) {
+                const wNode = RED.nodes.getNode(node.id)
                 // use our own custom onInput in order to store history of msg payloads
-                if (!node._msg) {
-                    node._msg = []
+                if (!wNode._msg) {
+                    wNode._msg = []
                 }
                 if (Array.isArray(msg.payload) && !msg.payload.length) {
                     // clear history
-                    node._msg = []
+                    wNode._msg = []
                 } else {
-                    // quick clone of msg, and sore in history
-                    node._msg.push({ ...msg })
+                    if (!Array.isArray(msg.payload)) {
+                        // quick clone of msg, and store in history
+                        wNode._msg.push({
+                            ...msg
+                        })
+                    } else {
+                        // we have an array in msg.payload, let's split them
+                        msg.payload.forEach((p, i) => {
+                            const payload = JSON.parse(JSON.stringify(p))
+                            const m = {
+                                ...msg,
+                                payload,
+                                _datapoint: msg._datapoint[i]
+                            }
+                            wNode._msg.push(m)
+                        })
+                    }
 
                     const maxPoints = parseInt(config.removeOlderPoints)
 
                     if (config.xAxisType === 'category') {
                         // filters the node._msg array so that we keep just the latest msg with each category
                         const seen = {}
-                        node._msg.forEach((msg, index) => {
+                        wNode._msg.forEach((msg, index) => {
                             // loop through and record the latest index seen for each topic/label
                             seen[msg.topic] = index
                         })
                         const indices = Object.values(seen)
-                        node._msg = node._msg.filter((msg, index) => {
+                        wNode._msg = wNode._msg.filter((msg, index) => {
                             // return only the msgs with the latest index for each topic/label
                             return indices.includes(index)
                         })
@@ -68,12 +93,12 @@ module.exports = function (RED) {
                         // remove older points
                         const lineCounts = {}
                         // trawl through in reverse order, and only keep the latest points (up to maxPoints) for each label
-                        for (let i = node._msg.length - 1; i >= 0; i--) {
-                            const msg = node._msg[i]
+                        for (let i = wNode._msg.length - 1; i >= 0; i--) {
+                            const msg = wNode._msg[i]
                             const label = msg.topic
                             lineCounts[label] = lineCounts[label] || 0
                             if (lineCounts[label] >= maxPoints) {
-                                node._msg.splice(i, 1)
+                                wNode._msg.splice(i, 1)
                             } else {
                                 lineCounts[label]++
                             }
@@ -86,8 +111,13 @@ module.exports = function (RED) {
                         const removeOlderUnit = parseFloat(config.removeOlderUnit)
                         const ago = (removeOlder * removeOlderUnit) * 1000 // milliseconds ago
                         const cutoff = (new Date()).getTime() - ago
-                        node._msg = node._msg.filter((msg) => {
-                            return msg._datapoint.x > cutoff
+                        wNode._msg = wNode._msg.filter((msg) => {
+                            let timestamp = msg._datapoint.x
+                            // is x already a millisecond timestamp?
+                            if (typeof (msg._datapoint.x) === 'string') {
+                                timestamp = (new Date(msg._datapoint.x)).getTime()
+                            }
+                            return timestamp > cutoff
                         })
                     }
 


### PR DESCRIPTION
## Description

Couple of things were going on here:

1. When checking for "old" data, we assumed that `.x` was already in a numerical timestamp format, however, we'd been passing in valid string representations (e.g. `2023-03-14`), which were accepted by the cart, and drawn, but then removed from the chart history server-side as being "too old" because the age check was failing when comparing against a string.
2. We also hadn't properly accounted for the three types of messages that a `ui-chart` could receive:
    - `msg.payload = 3`: this was already fine
    - `msg.payload = <Array>`: this needed a new handler and wasn't accounted for client-side
    - `msg = <Array>`: This _only_ occurs when loading a chart history from the server, and we receive an array of past `msg` objects to re-draw.

## Related Issue(s)

Closes #237 
Closes #236 - Data was lost because server-side was removing it due to being too "old" (incorrectly).

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)

