### PR TITLE
Add height/width definitions to ui-markdown & ui-template

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -466,7 +466,7 @@ module.exports = function (RED) {
                 props: widgetConfig,
                 layout: {
                     width: widgetConfig.width || 3,
-                    height: widgetConfig.width || 1,
+                    height: widgetConfig.height || 1,
                     order: widgetConfig.order || 0
                 },
                 state: {

--- a/nodes/widgets/ui_markdown.html
+++ b/nodes/widgets/ui_markdown.html
@@ -40,6 +40,11 @@
                 if (RED.editor.__debug === true) {
                     console.log('ui-markdown: oneditprepare')
                 }
+                $('#node-input-size').elementSizer({
+                    width: '#node-input-width',
+                    height: '#node-input-height',
+                    group: '#node-input-group'
+                })
                 this.editor = RED.editor.createEditor({
                     id: 'node-input-content-editor',
                     mode: 'ace/mode/markdown',
@@ -93,6 +98,12 @@
     <div class="form-row">
         <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
         <input style="flex-grow:1" type="text" id="node-input-group">
+    </div>
+    <div class="form-row">
+        <label><i class="fa fa-object-group"></i> Size</label>
+        <input type="hidden" id="node-input-width">
+        <input type="hidden" id="node-input-height">
+        <button class="editor-button" id="node-input-size"></button>
     </div>
     <div class="form-row">
         <label for="node-input-className"><i class="fa fa-code"></i> Class</label>

--- a/nodes/widgets/ui_template.html
+++ b/nodes/widgets/ui_template.html
@@ -65,11 +65,12 @@
                 }
                 const that = this
                 const $templateScope = $('#node-input-templateScope')
-                // $("#node-input-size").elementSizer({
-                //     width: "#node-input-width",
-                //     height: "#node-input-height",
-                //     group: "#node-input-group"
-                // });
+    
+                $('#node-input-size').elementSizer({
+                    width: '#node-input-width',
+                    height: '#node-input-height',
+                    group: '#node-input-group'
+                })
 
                 if (typeof this.storeOutMessages === 'undefined') {
                     this.storeOutMessages = true
@@ -231,6 +232,12 @@
     <div id="template-row-page" class="form-row">
         <label for="node-input-page"><i class="fa fa-bookmark"></i> Page</label>
         <input type="text" id="node-input-page">
+    </div>
+    <div class="form-row">
+        <label><i class="fa fa-object-group"></i> Size</label>
+        <input type="hidden" id="node-input-width">
+        <input type="hidden" id="node-input-height">
+        <button class="editor-button" id="node-input-size"></button>
     </div>
     <!--<div class="form-row" id="template-row-size">
         <label><i class="fa fa-object-group"></i> <span data-i18n="ui-template.label.size"></span></label>

--- a/ui/src/layouts/Flex.vue
+++ b/ui/src/layouts/Flex.vue
@@ -22,7 +22,7 @@
                                 class="nrdb-ui-widget"
                                 :class="getWidgetClass(w)"
                                 style="display: grid"
-                                :style="`grid-template-rows: repeat(${w.props.height}, ${rowHeight}px); grid-column-end: span ${ w.props.width || g.width }`"
+                                :style="`grid-template-rows: repeat(${w.props.height}, minmax(${rowHeight}px, auto)); grid-column-end: span ${ w.props.width || g.width }`"
                             >
                                 <component :is="w.component" :id="w.id" :props="w.props" :state="w.state" :style="`grid-row-end: span ${w.props.height}`" />
                             </div>

--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -22,7 +22,7 @@
                                 class="nrdb-ui-widget"
                                 :class="getWidgetClass(w)"
                                 style="display: grid"
-                                :style="`grid-template-rows: repeat(${w.props.height}, minmax(${rowHeight}, auto)); grid-column-end: span ${ w.props.width || g.width }`"
+                                :style="`grid-template-rows: repeat(${w.props.height}, minmax(${rowHeight}px, auto)); grid-column-end: span ${ w.props.width || g.width }`"
                             >
                                 <component :is="w.component" :id="w.id" :props="w.props" :state="w.state" :style="`grid-row-end: span ${w.props.height}`" />
                             </div>

--- a/ui/src/layouts/Notebook.vue
+++ b/ui/src/layouts/Notebook.vue
@@ -21,7 +21,7 @@
                                 class="nrdb-ui-widget"
                                 :class="getWidgetClass(w)"
                                 style="display: grid"
-                                :style="`grid-template-rows: repeat(${w.props.height}, ${rowHeight}px); grid-column-end: span ${ w.props.width || g.width }`"
+                                :style="`grid-template-rows: repeat(${w.props.height}, minmax(${rowHeight}px, auto)); grid-column-end: span ${ w.props.width || g.width }`"
                             >
                                 <component :is="w.component" :id="w.id" :props="w.props" :state="w.state" :style="`grid-row-end: span ${w.props.height}`" />
                             </div>


### PR DESCRIPTION
## Description

- Enables height/width definition for `ui-markdown` and `ui-template`
- Fixes a bug in `ui-base` where element width was used for _both_ width & height.
- Enables element stretching height if content exceeds defined height (useful for template/markdown)

## Related Issue(s)

Closes #181

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)

