### PR TITLE
"Dashboard 2" category label & drive node colours from CSS vars

### DIFF
--- a/nodes/config/locales/en-US/ui_base.json
+++ b/nodes/config/locales/en-US/ui_base.json
@@ -2,13 +2,18 @@
     "ui-base" : {
         "auto": "auto",
         "label": {
-            "category": "dashboard"
+            "category": "dashboard 2"
         },
         "layout": {
             "pages": "Pages",
             "edit": "Edit",
             "collapse": "Collapse",
             "expand": "Expand"
+        },
+        "colors": {
+            "light": "var(--nrdb-node-light)",
+            "medium": "var(--nrdb-node-medium)",
+            "dark": "var(--nrdb-node-dark)"
         }
     }
 }

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1,4 +1,9 @@
 <style>
+    .red-ui-editor {
+        --nrdb-node-light: rgb(176, 223, 227);
+        --nrdb-node-medium: rgb(119, 198, 204);
+        --nrdb-node-dark: rgb(63, 173, 181);
+    }
     .red-ui-editor .form-row-flex {
         display: flex;
         align-items: center;

--- a/nodes/widgets/ui_button.html
+++ b/nodes/widgets/ui_button.html
@@ -5,7 +5,7 @@
         }
         RED.nodes.registerType('ui-button', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(176, 223, 227)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_chart.html
+++ b/nodes/widgets/ui_chart.html
@@ -23,7 +23,7 @@
 
         RED.nodes.registerType('ui-chart', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(119, 198, 204)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.medium'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_dropdown.html
+++ b/nodes/widgets/ui_dropdown.html
@@ -5,7 +5,7 @@
         }
         RED.nodes.registerType('ui-dropdown', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(176, 223, 227)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_form.html
+++ b/nodes/widgets/ui_form.html
@@ -9,7 +9,7 @@
         }
         RED.nodes.registerType('ui-form', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(176, 223, 227)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 name: { value: '' },
                 group: { type: 'ui-group', required: true },

--- a/nodes/widgets/ui_markdown.html
+++ b/nodes/widgets/ui_markdown.html
@@ -7,7 +7,7 @@
 
         RED.nodes.registerType('ui-markdown', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb( 63, 173, 181)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.dark'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_notification.html
+++ b/nodes/widgets/ui_notification.html
@@ -2,7 +2,7 @@
     (function () {
         RED.nodes.registerType('ui-notification', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(119, 198, 204)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.medium'),
             defaults: {
                 ui: { type: 'ui-base', value: '', required: true },
                 position: { value: 'top right' },

--- a/nodes/widgets/ui_radio_group.html
+++ b/nodes/widgets/ui_radio_group.html
@@ -5,7 +5,7 @@
         }
         RED.nodes.registerType('ui-radio-group', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(176, 223, 227)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -5,7 +5,7 @@
         }
         RED.nodes.registerType('ui-slider', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(176, 223, 227)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -5,7 +5,7 @@
         }
         RED.nodes.registerType('ui-switch', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(176, 223, 227)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 name: { value: '' },
                 label: { value: 'switch' },

--- a/nodes/widgets/ui_table.html
+++ b/nodes/widgets/ui_table.html
@@ -2,7 +2,7 @@
     (function () {
         RED.nodes.registerType('ui-table', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(119, 198, 204)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.medium'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_template.html
+++ b/nodes/widgets/ui_template.html
@@ -10,7 +10,7 @@
         }
         RED.nodes.registerType('ui-template', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb( 63, 173, 181)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.dark'),
             defaults: {
                 group: { type: 'ui-group', required: true }, // for when template is scoped to 'local' (default)
                 dashboard: { type: 'ui-base', required: false }, // for when template is scoped to 'site'

--- a/nodes/widgets/ui_text.html
+++ b/nodes/widgets/ui_text.html
@@ -69,7 +69,7 @@
 
         RED.nodes.registerType('ui-text', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(119, 198, 204)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.medium'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 order: { value: 0 },

--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -5,7 +5,7 @@
         }
         RED.nodes.registerType('ui-text-input', {
             category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: 'rgb(176, 223, 227)',
+            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },


### PR DESCRIPTION
## Description

- Changes the category label from "Dashboard" to "Dashboard 2"
- Changes the "color" property of the nodes to use css vars, makes it easier to modify at scale & provides in-browser debug tools to try alternative colour schemes.

## Related Issue(s)

Closes #85 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
