### PR TITLE
Fix Grid's "rowHeight" definition

### DIFF
--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -48,7 +48,7 @@ export default {
     data () {
         return {
             columns: 12,
-            rowHeight: '48px'
+            rowHeight: 48
         }
     },
     computed: {


### PR DESCRIPTION
## Description

Inconsistency between layouts on how they were storing `rowHeight`, the others just had a number, so when copying/pasting the updated `grid-template-row` style over, this broke the Grid layout.

## Related Issue(s)

Closes #244 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)