### PR TITLE
Fix icon for switch node

### DIFF
--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -42,7 +42,7 @@
             },
             inputs: 1,
             outputs: 1,
-            icon: 'ui_switch.png',
+            icon: 'font-awesome/fa-toggle-on',
             paletteLabel: 'switch',
             label: function () { return this.name || (~this.label.indexOf('{' + '{') ? null : this.label) || 'switch' },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },


### PR DESCRIPTION
## Description
While taking the screenshot, I found that the switch node has an arrow icon because there is no `ui_switch.png` file.
So, I added the Font Awesome icon which is the same as the original Node-RED dashboard.

## Related Issue(s)

## Checklist
 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels
 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label