### PR TITLE
Better checking of x value before datetime assignment

### DIFF
--- a/nodes/widgets/ui_chart.js
+++ b/nodes/widgets/ui_chart.js
@@ -38,7 +38,11 @@ module.exports = function (RED) {
                         datapoint.y = payload
                     } else if (typeof payload === 'object' && 'y' in payload) {
                         // may have been given an x/y object already
-                        datapoint.x = payload.x || (new Date()).getTime()
+                        let x = payload.x
+                        if (x === undefined || x === null) {
+                            x = (new Date()).getTime()
+                        }
+                        datapoint.x = x
                         datapoint.y = payload.y
                     }
                     return datapoint


### PR DESCRIPTION
## Description

Had a weak value check of `payload.x` which meant that instead of rendering `x: 0`, it rendered `x: (new Date()).getTime()`

## Related Issue(s)

Closes #145 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)