### PR TITLE
Allow definition of ui-notification colour

### DIFF
--- a/nodes/widgets/ui_notification.html
+++ b/nodes/widgets/ui_notification.html
@@ -1,3 +1,13 @@
+<style>
+    #ui-chart-colors input[type="color"] {
+        font-weight: bold;
+    }
+    #ui-chart-colors input[type="color"]::-webkit-color-swatch,
+    #ui-chart-colors input[type="color"]::-moz-color-swatch {
+        border: none;
+    }
+</style>
+
 <script type="text/javascript">
     (function () {
         RED.nodes.registerType('ui-notification', {
@@ -6,6 +16,8 @@
             defaults: {
                 ui: { type: 'ui-base', value: '', required: true },
                 position: { value: 'top right' },
+                colorDefault: { value: true },
+                color: { value: null },
                 displayTime: { value: '3' },
                 showCountdown: { value: true },
                 outputs: { value: 0 },
@@ -35,6 +47,16 @@
                         $('#node-notification-dismissText').show()
                     } else {
                         $('#node-notification-dismissText').hide()
+                    }
+                })
+
+                $('#node-input-colorDefault').on('change', function () {
+                    const defaultColor = $('#node-input-colorDefault').is(':checked')
+                    console.log(defaultColor)
+                    if (defaultColor) {
+                        $('#node-input-color').hide()
+                    } else {
+                        $('#node-input-color').show()
                     }
                 })
     
@@ -70,6 +92,14 @@
             <option value="bottom left">Bottom Left</option>
             <option value="center center">Center</option>
         </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-color"><i class="fa fa-paint-brush"></i> Color</label>
+        <div style="display: inline-flex; gap: 8px; align-items: center;">
+            <input type="checkbox" id="node-input-colorDefault" style="width: auto; margin: 0;">
+            <label for="node-input-colorDefault" style="margin: 0; line-height: 34px;">Default</label>
+            <input type="color" id="node-input-color" placeholder="#FFFFFF">
+        </div>
     </div>
     <div class="form-row" id="node-toast-displaytime">
         <label for="node-input-displayTime"><i class="fa fa-clock-o"></i> Timeout (S)</label>

--- a/ui/src/widgets/ui-notification/UINotification.vue
+++ b/ui/src/widgets/ui-notification/UINotification.vue
@@ -9,7 +9,7 @@
         :style="{'--nrdb-ui-notification-color': color}"
     >
         <div v-if="props.showCountdown" class="nrdb-ui-notification-countdown">
-            <v-progress-linear v-model="countdown" :color="props.colorDefault ? 'primary' : color" style="display: block; width: 100%" />
+            <v-progress-linear v-model="countdown" :color="messages[id]?.color || (props.colorDefault ? 'primary' : color)" style="display: block; width: 100%" />
         </div>
         <div v-if="!props.raw">{{ value }}</div>
         <!-- eslint-disable-next-line vue/no-v-html -->
@@ -125,9 +125,11 @@ export default {
 
 .nrdb-ui-notification-countdown {
     position: absolute;
-    width: 100%;
+    width: calc(100% + 6px);
     top: 0;
     left: 0;
+    margin-left: -6px;
+    border-top-left-radius: 4px;
 }
 
 .nrdb-ui-notification h1,

--- a/ui/src/widgets/ui-notification/UINotification.vue
+++ b/ui/src/widgets/ui-notification/UINotification.vue
@@ -6,9 +6,10 @@
         multi-line
         :timeout="-1"
         :location="props.position"
+        :style="{'--nrdb-ui-notification-color': color}"
     >
         <div v-if="props.showCountdown" class="nrdb-ui-notification-countdown">
-            <v-progress-linear v-model="countdown" color="primary" style="display: block; width: 100%" />
+            <v-progress-linear v-model="countdown" :color="props.colorDefault ? 'primary' : color" style="display: block; width: 100%" />
         </div>
         <div v-if="!props.raw">{{ value }}</div>
         <!-- eslint-disable-next-line vue/no-v-html -->
@@ -51,6 +52,15 @@ export default {
         ...mapState('data', ['messages']),
         value: function () {
             return this.messages[this.id]?.payload
+        },
+        color: function () {
+            if (this.messages[this.id]?.color) {
+                return this.messages[this.id]?.color
+            } else if (this.props.colorDefault) {
+                return 'rgb(var(--v-theme-group-background))'
+            } else {
+                return this.props.color
+            }
         }
     },
     created () {
@@ -99,9 +109,18 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .nrdb-ui-notification {
     padding-top: 64px;
+}
+
+.nrdb-ui-notification .v-snackbar__wrapper {
+    background-color: rgb(var(--v-theme-group-background));
+    color: rgb(var(--v-theme-on-group-background));
+    border-left: 6px solid var(--nrdb-ui-notification-color);
+}
+.nrdb-ui-notification .v-snackbar__content {
+    padding-left: 8px;
 }
 
 .nrdb-ui-notification-countdown {
@@ -110,4 +129,12 @@ export default {
     top: 0;
     left: 0;
 }
+
+.nrdb-ui-notification h1,
+.nrdb-ui-notification h2,
+.nrdb-ui-notification h3,
+.nrdb-ui-notification h4 {
+    margin: 0.5rem 0;
+}
+
 </style>


### PR DESCRIPTION
## Description

Add a new coloured border to the `ui-notification`, this same colour will also be used (if defined) for the timer for when a notification bar will automatically hide itself.

Here a `msg` was injected with `msg.color = 'red'`:

<img width="365" alt="Screenshot 2023-10-11 at 16 43 41" src="https://github.com/FlowFuse/node-red-dashboard/assets/99246719/89d539bc-b990-4ab7-99d0-0255be0d73be">

If "Default" is toggled, then the `primary` colour of the theme is used for the progress bar, and the left-border does not show.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

