### PR TITLE
Custom State Handler onInput for UI Markdown (better Mermaid handling)

### DIFF
--- a/ui/src/widgets/ui-markdown/UIMarkdown.vue
+++ b/ui/src/widgets/ui-markdown/UIMarkdown.vue
@@ -92,7 +92,7 @@ export default {
                         // let Vue render the dynamic markdown first, then re-render the chart
                         mermaid.run({
                             querySelector: '.mermaid',
-                            suppressErrors: false
+                            suppressErrors: true
                         })
                     })
                 }

--- a/ui/src/widgets/ui-template/UITemplate.vue
+++ b/ui/src/widgets/ui-template/UITemplate.vue
@@ -37,7 +37,6 @@ export default {
                 return false
             },
             head () {
-                console.log('head', this.props)
                 let _props = this.props || props
                 if (_props.props) { _props = _props.props }
 


### PR DESCRIPTION
## Description

More picky handling of when we update `msg` state in our VueX store. Mermaid doesn't seem to enjoy being given the _same_ content to re-render. When navigating between pages, the same state was provided (due to vuex store maintaining it between page changes), but we also emulate an `onInput` on page load to refresh content (something we plan on removing) - and this was causing the crash. Emulated too when I demonstrated that re-injecting the same full chart twice in a row causes the same problem.

## Related Issue(s)

Closes #263 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)