### PR TITLE
docs: Make example copy+paste able

### DIFF
--- a/docs/nodes/widgets/ui-chart.md
+++ b/docs/nodes/widgets/ui-chart.md
@@ -75,14 +75,14 @@ If you would like to pass in multiple data points at the same time into a chart,
 msg = {
     "topic": "line-1",
     "payload": [{
-        x: 30,
-        y: 43
+        "x": 30,
+        "y": 43
     }, {
-        x: 40,
-        y: 56
+        "x": 40,
+        "y": 56
     }, {
-        x: 50,
-        y: 74
+        "x": 50,
+        "y": 74
     }]
 }
 ```


### PR DESCRIPTION
## Description

I forgot the syntax and copy-pasted the example, which is not valid JSON. Now it is

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

