### PR TITLE
Improve onLoad & onInput behaviours

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -388,7 +388,6 @@ module.exports = function (RED) {
                 if (msg) {
                     // only emit something if we have something to send
                     // and only to this connection, not all connected clients
-                    console.log('on widget load')
                     conn.emit('widget-load:' + id, msg)
                 }
             }

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -379,6 +379,7 @@ module.exports = function (RED) {
 
             const { wNode, widgetEvents } = getWidgetAndConfig(id)
             if (!wNode) {
+                console.log('widget does not exist any more')
                 return // widget does not exist any more (e.g. deleted from NR and deployed BUT the ui page was not refreshed)
             }
             async function handler () {
@@ -387,7 +388,8 @@ module.exports = function (RED) {
                 if (msg) {
                     // only emit something if we have something to send
                     // and only to this connection, not all connected clients
-                    conn.emit('msg-input:' + id, msg)
+                    console.log('on widget load')
+                    conn.emit('widget-load:' + id, msg)
                 }
             }
             // wrap execution in a try/catch to ensure we don't crash Node-RED

--- a/ui/src/widgets/data-tracker.js
+++ b/ui/src/widgets/data-tracker.js
@@ -2,7 +2,7 @@ import { inject, onMounted, onUnmounted } from 'vue'
 import { useStore } from 'vuex'
 
 // by convention, composable function names start with "use"
-export function useDataTracker (widgetId, onInput) {
+export function useDataTracker (widgetId, onInput, onLoad) {
     const store = useStore()
     const socket = inject('$socket')
 
@@ -10,19 +10,19 @@ export function useDataTracker (widgetId, onInput) {
     // lifecycle to setup and teardown side effects.
     onMounted(() => {
         if (socket) {
-            socket.on('widget-load: ' + widgetId, (msg) => {
-                console.log('widget-load: ' + widgetId, msg)
-                this.$store.commit('data/bind', {
-                    widgetId: this.id,
+            socket.on('widget-load:' + widgetId, (msg) => {
+                store.commit('data/bind', {
+                    widgetId,
                     msg
                 })
+                if (onLoad) {
+                    onLoad(msg)
+                }
             })
             // This will on in msg input for ALL components
             socket.on('msg-input:' + widgetId, (msg) => {
-                console.log('msg-input:' + widgetId, msg)
                 // set states if passed into msg
                 if ('enabled' in msg) {
-                    console.log('setting enabled')
                     store.commit('ui/widgetState', {
                         widgetId,
                         enabled: msg.enabled

--- a/ui/src/widgets/data-tracker.js
+++ b/ui/src/widgets/data-tracker.js
@@ -10,8 +10,16 @@ export function useDataTracker (widgetId, onInput) {
     // lifecycle to setup and teardown side effects.
     onMounted(() => {
         if (socket) {
+            socket.on('widget-load: ' + widgetId, (msg) => {
+                console.log('widget-load: ' + widgetId, msg)
+                this.$store.commit('data/bind', {
+                    widgetId: this.id,
+                    msg
+                })
+            })
             // This will on in msg input for ALL components
             socket.on('msg-input:' + widgetId, (msg) => {
+                console.log('msg-input:' + widgetId, msg)
                 // set states if passed into msg
                 if ('enabled' in msg) {
                     console.log('setting enabled')

--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -42,7 +42,7 @@ export default {
     },
     created () {
         // can't do this in setup as we have custom onInput function
-        useDataTracker(this.id, this.onMsgInput)
+        useDataTracker(this.id, this.onMsgInput, this.onLoad)
     },
     mounted () {
         // get a reference to the canvas element
@@ -88,6 +88,12 @@ export default {
         this.chart = shallowRef(chart)
     },
     methods: {
+        onLoad (history) {
+            // we have received a history of data points
+            // we need to add them to the chart - fortunately,
+            // it's just the same process as receiving a new msg
+            this.onMsgInput(history)
+        },
         onMsgInput (msg) {
             if (Array.isArray(msg.payload) && !msg.payload.length) {
                 // clear the chart if msg.payload = [] is received


### PR DESCRIPTION
## Description

No longer treat `onLoad` as if a message has been received. We now have a separate `widget-load` event that _just_ restores state to a widget.

- Add new 'on-load' socket event 
- Remove emission of the `msg-input` event from the onLoad functionality

## Related Issue(s)

Closes #219

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)