### PR TITLE
Rename "Flex" layout to "Fixed"

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -101,8 +101,8 @@ export default ({ mode }) => {
           text: 'Layouts',
           collapsed: false,
           items: [
-            { text: 'Flex', link: '/layouts/flex' },
             { text: 'Grid', link: '/layouts/grid' },
+            { text: 'Fixed', link: '/layouts/fixed' },
             { text: 'Notebook', link: '/layouts/notebook' }
           ]
         },

--- a/docs/layouts/fixed.md
+++ b/docs/layouts/fixed.md
@@ -1,0 +1,10 @@
+# Layout: Fixed
+
+Each "unit" is a fixed width, which was the onlmy lalayout available in Dashboard 1.0. 
+
+It is built as a flexbox layout, with a single row of widgets. Width of each group is a fixed pixel size, calculated as the "width" property of a group, multiplied by 90px (where our default row height is 45px).
+
+It will automatically move widgets to the next row if they don't fit within a given screen width. The height of each row is determined by the tallest widget in that row.
+
+![Fixed Layout](../assets/images/layout-eg-flex.png){data-zoomable}
+*An example UI rendered using the "Fixed" Layout*

--- a/docs/layouts/flex.md
+++ b/docs/layouts/flex.md
@@ -1,8 +1,0 @@
-# Layout: Flex
-
-This is a simple flexbox layout, with a single row of widgets. Width of each group is a fixed pixel size, calculated as the "width" property of a group, multiplied by 90px (where our default row height is 45px).
-
-It will automatically move widgets to the next row if they don't fit within a given screen width. The height of each row is determined by the tallest widget in that row.
-
-![Flex Layout](../assets/images/layout-eg-flex.png){data-zoomable}
-*An example UI rendered using the "Flex" Layout*

--- a/docs/layouts/grid.md
+++ b/docs/layouts/grid.md
@@ -1,6 +1,6 @@
 # Layout: Grid
 
-This is a simple CSS Grid layout with 12 columns.
+Similar to Bootstrap's [Grid](https://getbootstrap.com/docs/4.0/layout/grid/) System, this provides 12 (by default) columns,w ithin which content can be scaled. It is built as a CSS Grid layout.
 
 Each group's width represents the number of columns that it will populate in the overall Page's Grid layout, e.g. a Group, with width 12, will be full width of the screen, even when that screen width is changed.
 

--- a/docs/user/migration.md
+++ b/docs/user/migration.md
@@ -219,7 +219,7 @@ Dashboard 2.0 follows a similar architecture to Dashboard 1.0 for managing hiera
 We currently have three layouts available in Dashboard 2.0:
 
 - [**Grid**](../layouts/grid.md) - Modelled with CSS's `grid` layout, this is the default layout, and uses a fixed 12 column approach, whereby content will scale horiztonally with screen width, making it far more friendly for responsive layouts.
-- [**Flex**](../layouts/flex.md) - This uses a CSS Flex Layout and is the most similar we currently have to the only layout in Dashboard 1.0. Improvements are required here to improve the "packing" nature of the layout though.
+- [**Fixed**](../layouts/fixed.md) - This uses a CSS Flex Layout and is the most similar we currently have to the only layout in Dashboard 1.0. Improvements are required here to improve the "packing" nature of the layout though.
 - [**Notebook**](../layouts/notebook.md) - Mimicking a Jupyter Notebook layout, this provides content with a maxiimum width, scales with mobile devices, and allows for content to be stacked vertically.
 
 We also have future plans to support injection of third-party layouts, and even client-side editable layouts (e.g. drag-and-drop layout design).

--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -36,7 +36,7 @@
                     value: 'layout',
                     options: [
                         { value: 'grid', label: 'Grid' },
-                        { value: 'flex', label: 'Flex' },
+                        { value: 'flex', label: 'Fixed' },
                         { value: 'notebook', label: 'Notebook' }
                     ]
                 }],


### PR DESCRIPTION
## Description

"Flex" only really resonated with users that were familiar with CSS, and even then, wasn't totally clear on what the resulting layout would entail. Instead, we've renamed this to "Fixed", given that each unit of width provides a fixed width widget.
