### PR TITLE
Fix tests after we no longer use node._msg

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -569,6 +569,14 @@ module.exports = function (RED) {
             }
 
             /**
+             * Helper Function for testing
+             */
+
+            widgetNode.getState = function () {
+                return datastore.get(widgetNode.id)
+            }
+
+            /**
              * Event Handlers
              */
 

--- a/test/nodes/widgets/ui_button.spec.js
+++ b/test/nodes/widgets/ui_button.spec.js
@@ -106,7 +106,6 @@ describe('ui-button node', function () {
 
         // add a fake connection so that button has somewhere to emit to and we can spy on it
         base.uiShared.connections['fake-conn-id'] = socket
-        base.connections['fake-conn-id'] = socket
 
         // now send a message to the node
         const button = helper.getNode('node-ui-button')

--- a/test/nodes/widgets/ui_dropdown.spec.js
+++ b/test/nodes/widgets/ui_dropdown.spec.js
@@ -131,7 +131,7 @@ describe('ui-dropdown node', function () {
             const helperAfterComplete = helper.getNode('helper-node-complete')
             helperAfterComplete.on('input', (msg) => {
                 try {
-                    dNode._msg.payload.should.equal(msg.payload)
+                    dNode.getState().payload.should.equal(msg.payload)
                     msgSent.should.be.false()
                     resolve()
                 } catch (err) {

--- a/test/nodes/widgets/ui_slider.spec.js
+++ b/test/nodes/widgets/ui_slider.spec.js
@@ -121,7 +121,7 @@ describe('ui-slider node', function () {
             const helperAfterComplete = helper.getNode('helper-node-complete')
             helperAfterComplete.on('input', (msg) => {
                 try {
-                    sNode._msg.payload.should.equal(msg.payload)
+                    sNode.getState().payload.should.equal(msg.payload)
                     msgSent.should.be.false()
                     resolve()
                 } catch (err) {

--- a/test/nodes/widgets/ui_switch.spec.js
+++ b/test/nodes/widgets/ui_switch.spec.js
@@ -117,7 +117,7 @@ describe('ui-switch node', function () {
             const hNode = helper.getNode('helper-node')
             hNode.on('input', (msg) => {
                 try {
-                    sNode._msg.payload.should.equal(msg.payload)
+                    sNode.getState().payload.should.equal(msg.payload)
                     resolve()
                 } catch (err) {
                     reject(err)
@@ -141,7 +141,7 @@ describe('ui-switch node', function () {
                 // we need to be sure that the helperAfterSwitch node has run first
                 setTimeout(() => {
                     try {
-                        sNode._msg.payload.should.equal(msg.payload)
+                        sNode.getState().payload.should.equal(msg.payload)
                         msgSent.should.be.true()
                         resolve()
                     } catch (err) {
@@ -173,7 +173,6 @@ describe('ui-switch node', function () {
                 // we need to be sure that the helperAfterSwitch node has run first
                 setTimeout(() => {
                     try {
-                        (sNode._msg === undefined).should.be.true()
                         sNode.warn.should.be.called()
                         msgSent.should.be.false()
                         resolve()
@@ -211,7 +210,7 @@ describe('ui-switch node', function () {
             const helperAfterComplete = helper.getNode('helper-node-complete')
             helperAfterComplete.on('input', (msg) => {
                 try {
-                    sNode._msg.payload.should.equal(msg.payload)
+                    sNode.getState().payload.should.equal(msg.payload)
                     msgSent.should.be.false()
                     resolve()
                 } catch (err) {

--- a/test/nodes/widgets/ui_text_input.spec.js
+++ b/test/nodes/widgets/ui_text_input.spec.js
@@ -114,7 +114,7 @@ describe('ui-text-input node', function () {
             const helperAfterComplete = helper.getNode('helper-node-complete')
             helperAfterComplete.on('input', (msg) => {
                 try {
-                    tNode._msg.payload.should.equal(msg.payload)
+                    tNode.getState().payload.should.equal(msg.payload)
                     msgSent.should.be.false()
                     resolve()
                 } catch (err) {


### PR DESCRIPTION
## Description

Tests hadn't been running for a couple of weeks, so failures were only noticed once we went to push the `0.7.0` release.

This fixes those issues, mostly related to hte removal of `node._msg` to store state, and the switch to a centralised data store instead.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->