### PR TITLE
Update to new npm org

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ FlowFuse's Node-RED Dashboard 2.0 is available in the Node-RED Palette Manager. 
 - Click "Manage Palette"
 - Switch to the "Install" tab
 - Search `node-red-dashboard`
-- Install the `@flowforge/node-red-dashboard` package (not `node-red-dashboard`)
+- Install the `@flowfuse/node-red-dashboard` package (not `node-red-dashboard`)
 
 The nodes will then be available in your editor for you to get started.
 
 If you want to use `npm` to install your nodes, you can instead [follow these instructions](https://nodered.org/docs/user-guide/runtime/adding-nodes)
+
+*Note*: this package was previously published under the name `@flowforge/node-red-dashboard`. That package has now been deprecated and will not receive any further updates.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "@flowforge/node-red-dashboard",
-    "version": "0.6.1",
+    "name": "@flowfuse/node-red-dashboard",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@flowforge/node-red-dashboard",
-            "version": "0.6.1",
+            "name": "@flowfuse/node-red-dashboard",
+            "version": "0.7.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "chartjs-adapter-luxon": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@flowforge/node-red-dashboard",
+    "name": "@flowfuse/node-red-dashboard",
     "homepage": "https://dashboard.flowfuse.com",
     "version": "0.7.0",
     "description": "A collection of Node-RED nodes that provide functionality to build your own UI applications (inc. forms, buttons, charts) within Node-RED.",


### PR DESCRIPTION
## Description

Update the package name to the new `@flowfuse/node-red-dashboard` org.

Once this has been merged, I will manually publish 0.7.0 to the new package name. From then on, new releases can be created in the usual way and will be published to the new org.