### PR TITLE
Better handling of route injections & redirects

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -43,11 +43,18 @@ export default {
                     path: route,
                     name: routeName
                 }
-                // navigate to this route, this ensures we navigate to _something_ when the app loads
-                this.$router.push({
-                    name: routeName
-                })
             })
+
+            // add catch all - this ensures we navigate to _something_ when the app loads
+            // default to the first page added (for now)
+            this.$router?.addRoute({
+                path: '/:pathMatch(.*)*',
+                redirect: payload.dashboards[Object.values(payload.pages)[0].ui].path + Object.values(payload.pages)[0].path
+            })
+
+            // if this is the first time we load hte Dashboard, the router hasn't registered the current route properly,
+            // so best we just navigate to the existing URL to let router catch up
+            this.$router.push(this.$route.path)
 
             // loop over the widgets defined in Node-RED,
             // map their respective Vue component for rendering on a page


### PR DESCRIPTION
## Description

- Doesn't force a `router.push` to the last created `ui-page`
- Instead, forces a push to whatever the current URL is in the browser
    - This is required as vue router doesn't recognise the active route on first load given that the App loads first (with the defined URL) and _then_ the routes are all added. Tihis change ensures we then navigate to the created route if there is one.
- Adds a "catch all" route and redirects to the first created page _if_ a route is navigated to that isn't registered with the UI

## Related Issue(s)

Closes #228
Closes #276 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)