### PR TITLE
Update accessibility pointers to @flowfuse

### DIFF
--- a/nodes/widgets/ui_button.html
+++ b/nodes/widgets/ui_button.html
@@ -4,8 +4,8 @@
             return Object.prototype.hasOwnProperty.call(obj, prop)
         }
         RED.nodes.registerType('ui-button', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_chart.html
+++ b/nodes/widgets/ui_chart.html
@@ -45,8 +45,8 @@
         }
 
         RED.nodes.registerType('ui-chart', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.medium'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_dropdown.html
+++ b/nodes/widgets/ui_dropdown.html
@@ -4,8 +4,8 @@
             return Object.prototype.hasOwnProperty.call(obj, prop)
         }
         RED.nodes.registerType('ui-dropdown', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_form.html
+++ b/nodes/widgets/ui_form.html
@@ -2,14 +2,14 @@
     (function () {
         // convert to i18 text
         function c_ (x) {
-            return RED._('@flowforge/node-red-dashboard/ui-form:ui-form.' + x)
+            return RED._('@flowfuse/node-red-dashboard/ui-form:ui-form.' + x)
         }
         function hasProperty (obj, prop) {
             return Object.prototype.hasOwnProperty.call(obj, prop)
         }
         RED.nodes.registerType('ui-form', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 name: { value: '' },
                 group: { type: 'ui-group', required: true },

--- a/nodes/widgets/ui_markdown.html
+++ b/nodes/widgets/ui_markdown.html
@@ -2,12 +2,12 @@
     (function () {
         // convert to i18 text
         function c_ (x) {
-            return RED._('@flowforge/node-red-dashboard/ui-markdown:ui-markdown.' + x)
+            return RED._('@flowfuse/node-red-dashboard/ui-markdown:ui-markdown.' + x)
         }
 
         RED.nodes.registerType('ui-markdown', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.dark'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.dark'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_notification.html
+++ b/nodes/widgets/ui_notification.html
@@ -11,8 +11,8 @@
 <script type="text/javascript">
     (function () {
         RED.nodes.registerType('ui-notification', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.medium'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
             defaults: {
                 ui: { type: 'ui-base', value: '', required: true },
                 position: { value: 'top right' },

--- a/nodes/widgets/ui_radio_group.html
+++ b/nodes/widgets/ui_radio_group.html
@@ -4,8 +4,8 @@
             return Object.prototype.hasOwnProperty.call(obj, prop)
         }
         RED.nodes.registerType('ui-radio-group', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -4,8 +4,8 @@
             return Object.prototype.hasOwnProperty.call(obj, prop)
         }
         RED.nodes.registerType('ui-slider', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -4,8 +4,8 @@
             return Object.prototype.hasOwnProperty.call(obj, prop)
         }
         RED.nodes.registerType('ui-switch', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 name: { value: '' },
                 label: { value: 'switch' },

--- a/nodes/widgets/ui_table.html
+++ b/nodes/widgets/ui_table.html
@@ -1,8 +1,8 @@
 <script type="text/javascript">
     (function () {
         RED.nodes.registerType('ui-table', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.medium'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },

--- a/nodes/widgets/ui_template.html
+++ b/nodes/widgets/ui_template.html
@@ -2,15 +2,15 @@
     (function () {
         // convert to i18 text
         function c_ (x) {
-            return RED._('@flowforge/node-red-dashboard/ui-template:ui-template.' + x)
+            return RED._('@flowfuse/node-red-dashboard/ui-template:ui-template.' + x)
         }
         // TODO: move this to util.js for reuse & unit testing
         function hasProperty (obj, prop) {
             return Object.prototype.hasOwnProperty.call(obj, prop)
         }
         RED.nodes.registerType('ui-template', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.dark'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.dark'),
             defaults: {
                 group: { type: 'ui-group', required: true }, // for when template is scoped to 'local' (default)
                 dashboard: { type: 'ui-base', required: false }, // for when template is scoped to 'site'

--- a/nodes/widgets/ui_text.html
+++ b/nodes/widgets/ui_text.html
@@ -68,8 +68,8 @@
         ]
 
         RED.nodes.registerType('ui-text', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.medium'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 order: { value: 0 },

--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -4,8 +4,8 @@
             return Object.prototype.hasOwnProperty.call(obj, prop)
         }
         RED.nodes.registerType('ui-text-input', {
-            category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.colors.light'),
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
             defaults: {
                 group: { type: 'ui-group', required: true },
                 name: { value: '' },


### PR DESCRIPTION
## Description

We use accessibility pointers to retrieve node colours and category in the Node definitions. With the recent [update to the new npm repository](https://github.com/FlowFuse/node-red-dashboard/pull/298) - this reference needed updating as all nodes were rendering with black backgrounds.