### PR TITLE
Fix height of buttons in a form

### DIFF
--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -250,6 +250,7 @@ main {
 /* Make sure Button fills the containing group */
 .v-btn.v-btn--density-default  {
     height: auto;
+    min-height: calc(var(--v-btn-height));
 }
 
 .v-btn-group .v-btn--variant-elevated,


### PR DESCRIPTION
## Description

#305 fixed button heights for when a height is explicitly defined, however, in `ui-form` this meant that the buttons appear very squished.

This fixes that by ensuring the buttons have a min-height.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
