### PR TITLE
UI Text: Reintroduce the `ui-text` dynamic layout class & make (default) font sizing consistent

### DIFF
--- a/ui/src/widgets/ui-text/UIText.vue
+++ b/ui/src/widgets/ui-text/UIText.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :style="props.style">
+    <div class="nrdb-ui-text" :class="'nrdb-ui-text--' + props.layout" :style="props.style">
         <label class="nrdb-ui-text-label">{{ props.label }}</label>
         <span class="nrdb-ui-text-value">{{ value !== null ? value : 'No Message Received' }}</span>
     </div>
@@ -34,6 +34,7 @@ export default {
     display: flex;
     flex-direction: row;
     gap: 2px;
+    font-size: 1rem;
 }
 .nrdb-ui-text-value {
     font-weight: 600;


### PR DESCRIPTION
## Description

- Reintroducing the dynamic class driven by `props.layout`
- Sets the default font size to be `1rem`, as per the Vuetify components utilised in all other widgets.

## Related Issue(s)

Fixes #184 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)