### PR TITLE
Compile with full Vue build to allow for runtime compiling of ui-template

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,11 @@ import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+    resolve: {
+        alias: {
+            vue: 'vue/dist/vue.esm-bundler.js'
+        }
+    },
     plugins: [vue()],
     root: 'ui',
     build: {


### PR DESCRIPTION
## Description

Noticed in #340 - when testing the `ui-template` after we switched `main` to use a `vite` build, the templates were entirely broken with no errors reported.

This boiled down to https://vuejs.org/api/options-rendering.html#template:~:text=It%20is%20only%20supported%20when%20using%20a%20build%20of%20Vue%20that%20includes%20the%20template%20compiler.

Fixed by aliasing the `vue` build to be the full build of Vue, not just the `runtime`.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)