### PR TITLE
UI Text Input: onEnter, onDelay and onBlur controls

### DIFF
--- a/docs/nodes/widgets/ui-text-input.md
+++ b/docs/nodes/widgets/ui-text-input.md
@@ -5,6 +5,10 @@ props:
     Label: The text shown within the button.
     Mode: The type of HTML input to display. Options - text | password | email | number | tel | color | date | time | week | month | datetime-local
     Passthrough: If this node receives a msg in Node-RED, should it be passed through to the output as if a new value was inserted to the input?
+    Send On "Delay": If true, then a msg will be emitted will be sent after the delay specified in "Delay (ms)".
+    Delay: If "Send on Delay" is true, then the value in the text input will be send after this (ms) delay.
+    Send On "Focus Leave": Sends a msg when the text input loses focus. Will only send if the value has changed from the last msg sent
+    Send On "Press Enter": Sends a msg when the user presses the enter key. Will always send, even if the value has not changed.
 ---
 
 <script setup>

--- a/docs/user/migration/ui_text_input.json
+++ b/docs/user/migration/ui_text_input.json
@@ -39,7 +39,7 @@
         },
         {
             "property": "delay",
-            "changes": -1,
+            "changes": null,
             "notes": null
         },
         {
@@ -49,8 +49,8 @@
         },
         {
             "property": "send on blur",
-            "changes": "modified",
-            "notes": "This is now the default behaviour in Dashboard 2.0. Once an input has it's value changed, and the user moves focus away, a <code>msg</code> is sent on."
+            "changes": null,
+            "notes": null
         },
         {
             "property": "payload",
@@ -61,6 +61,16 @@
             "property": "topic",
             "changes": null,
             "notes": null
+        }
+    ],
+    "new_properties": [
+        {
+            "property": "send on delay",
+            "notes": "This will overrides the 'delay' setting, and provides explcit control over when the message is sent."
+        },
+        {
+            "property": "send on enter",
+            "notes": "This will send a message when the user presses <enter> in the text input."
         }
     ]
 }

--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -26,7 +26,7 @@
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
                 topicType: { value: 'msg' },
                 mode: { value: 'text', required: true },
-                delay: { value: 300, validate: RED.validators.number() },
+                delay: { value: 300, validate: function (v) { return $('#node-input-sendOnDelay').is(':checked') ? RED.validators.number()(v) : true } },
                 passthru: { value: true },
                 sendOnDelay: { value: true },
                 sendOnBlur: { value: true },

--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -28,7 +28,7 @@
                 mode: { value: 'text', required: true },
                 delay: { value: 300, validate: function (v) { return $('#node-input-sendOnDelay').is(':checked') ? RED.validators.number()(v) : true } },
                 passthru: { value: true },
-                sendOnDelay: { value: true },
+                sendOnDelay: { value: false },
                 sendOnBlur: { value: true },
                 sendOnEnter: { value: true },
                 className: { value: '' }

--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -26,7 +26,11 @@
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
                 topicType: { value: 'msg' },
                 mode: { value: 'text', required: true },
+                delay: { value: 300, validate: RED.validators.number() },
                 passthru: { value: true },
+                sendOnDelay: { value: true },
+                sendOnBlur: { value: true },
+                sendOnEnter: { value: true },
                 className: { value: '' }
             },
             inputs: 1,
@@ -52,6 +56,31 @@
                     show: {
                         effect: 'slideDown',
                         delay: 150
+                    }
+                })
+
+                $('#node-input-mode').on('change', (evt) => {
+                    const mode = $('#node-input-mode').find(':selected').val()
+                    if (mode === 'textarea') {
+                        this.sendOnEnter = false
+                        $('#node-input-container-sendOnEnter').hide()
+                    } else {
+                        $('#node-input-container-sendOnEnter').show()
+                    }
+                })
+
+                $('#node-input-delay').on('change', (evt) => {
+                    const delay = $('#node-input-delay').val()
+                    if (delay === '' || delay === '0') {
+                        this.sendOnDelay = false
+                        if ($('#node-input-sendOnDelay').is(':checked')) {
+                            $('#node-input-sendOnDelay').click()
+                        }
+                    } else {
+                        this.sendOnDelay = true
+                        if (!$('#node-input-sendOnDelay').is(':checked')) {
+                            $('#node-input-sendOnDelay').click()
+                        }
                     }
                 })
             },
@@ -95,7 +124,7 @@
             </a>
         </div>
     </div>
-    <div class="form-row">
+    <div class="form-row form-row-flex">
         <label for="node-input-mode"><i class="fa fa-keyboard-o"></i> Mode</label>
         <select id="node-input-mode">
             <option value="text">text input (single line)</option>
@@ -110,33 +139,41 @@
             <option value="week">week picker</option>
             <option value="month">month picker</option>
         </select>
-        <!--<label for="node-input-delay" style="text-align:right; width:100px"><i class="fa fa-clock-o"></i> Delay (ms)</label>
-        <input type="text" style="width:58px" id="node-input-delay">-->
-    </div>
-    <div class="form-row">
-        <label for="node-input-topic" style="padding-left:25px; margin-right:-25px">Topic</label>
-        <input type="text" id="node-input-topic">
-        <input type="hidden" id="node-input-topicType">
     </div>
     <div class="form-row">
         <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
         <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; margin-top: 0; margin-left: 3px;">
     </div>
-    <!--<div class="form-row">
-        <label style="width:auto" for="node-input-sendOnBlur">Send value on focus leave: </label>
+    <div class="form-row">
+        <label style="width:auto" for="node-input-payload"><i class="fa fa-clock-o"></i> Send message on:</label>
+    </div>
+    <div class="form-row form-row-flex" style="padding-left: 25px; align-items: center;">
+        <input type="checkbox" checked id="node-input-sendOnDelay" style="display:inline-block; width:auto; vertical-align:top;">
+        <label style="width:auto" for="node-input-sendOnDelay"> Delay</label>
+        <div id="node-input-delay-box">
+            <input type="text" style="width:58px" id="node-input-delay">
+            <label for="node-input-delay">(ms)</label>
+        </div>
+    </div>
+    <div class="form-row" style="padding-left: 25px;">
         <input type="checkbox" checked id="node-input-sendOnBlur" style="display:inline-block; width:auto; vertical-align:top;">
+        <label style="width:auto" for="node-input-sendOnBlur"> Focus Leave</label>
+    </div>
+    <div id="node-input-container-sendOnEnter" class="form-row" style="padding-left: 25px;">
+        <input type="checkbox" checked id="node-input-sendOnEnter" style="display:inline-block; width:auto; vertical-align:top;">
+        <label style="width:auto" for="node-input-sendOnEnter"> Press Enter</label>
     </div>
     <div class="form-row">
         <label style="width:auto" for="node-input-payload"><i class="fa fa-envelope-o"></i> When changed, send:</label>
     </div>
-    <div class="form-row">
-        <label style="padding-left: 25px; margin-right: -25px">Payload</label>
+    <div class="form-row" style="padding-left: 25px;">
+        <label style="margin-right: -25px">Payload</label>
         <label style="width:auto">Current value</label>
     </div>
-    <div class="form-row">
-        <label for="node-input-topic" style="padding-left: 25px; margin-right: -25px">Topic</label>
+    <div class="form-row" style="padding-left: 25px;">
+        <label for="node-input-topic" style="margin-right:-25px">Topic</label>
         <input type="text" id="node-input-topic">
         <input type="hidden" id="node-input-topicType">
-    </div>-->
-    <div class="form-tips">Setting <b>Delay</b> to 0 waits for Enter or Tab key, to send input.</span></div>
+    </div>
+    <div class="form-tips" style="margin-top: -12px; margin-bottom: 6px;">Delay and "Focus Leave" triggers will only fire if they detect a change in value from the last value sent</span></div>
 </script>

--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -175,5 +175,4 @@
         <input type="text" id="node-input-topic">
         <input type="hidden" id="node-input-topicType">
     </div>
-    <div class="form-tips" style="margin-top: -12px; margin-bottom: 6px;">Delay and "Focus Leave" triggers will only fire if they detect a change in value from the last value sent</span></div>
 </script>

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -2,12 +2,12 @@
     <v-text-field
         v-if="type !== 'textarea'"
         v-model="value" class="nrdb-ui-text-field"
-        :label="label" :type="type" :rules="validation" variant="outlined" hide-details="auto" @blur="onBlur"
+        :label="label" :type="type" :rules="validation" variant="outlined" hide-details="auto" @update:model-value="onChange" @keyup.enter="onEnter" @blur="onBlur"
     />
     <v-textarea
         v-else
         v-model="value" class="nrdb-ui-text-field"
-        :label="label" variant="outlined" hide-details="auto" @blur="onBlur"
+        :label="label" variant="outlined" hide-details="auto" @update:model-value="onChange" @blur="send"
     />
 </template>
 
@@ -25,6 +25,12 @@ export default {
     },
     setup (props) {
         useDataTracker(props.id)
+    },
+    data () {
+        return {
+            lastSent: null,
+            delayTimer: null
+        }
     },
     computed: {
         ...mapState('data', ['messages']),
@@ -56,8 +62,31 @@ export default {
         }
     },
     methods: {
-        onBlur: function () {
+        send: function () {
             this.$socket.emit('widget-change', this.id, this.value)
+            this.lastSent = this.value
+        },
+        onChange: function () {
+            if (this.props.sendOnDelay) {
+                // is send on delay enabled, if so, set a timeout to send the message
+                if (this.delayTimer) {
+                    // reset the timer to count from the latest change
+                    clearTimeout(this.delayTimer)
+                }
+                this.delayTimer = setTimeout(this.send, this.props.delay)
+            }
+        },
+        onBlur: function () {
+            if (this.props.sendOnBlur && this.lastSent !== this.value) {
+                // check if this value has already been sent, as not going to want it sent twice
+                this.send()
+            }
+        },
+        onEnter: function () {
+            if (this.props.sendOnEnter) {
+                // don't compare previous value, if user has pressed <enter> they want it submitted
+                this.send()
+            }
         }
     }
 }

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -64,9 +64,9 @@ export default {
     methods: {
         send: function () {
             this.$socket.emit('widget-change', this.id, this.value)
-            this.lastSent = this.value
         },
         onChange: function () {
+            this.lastSent = this.value
             if (this.props.sendOnDelay) {
                 // is send on delay enabled, if so, set a timeout to send the message
                 if (this.delayTimer) {


### PR DESCRIPTION
## Description

- Adds `sendOnEnter`, `sendOnDelay` and `sendOnBlur` controls to the Text Input
- Reintroduces the `delay` property too, from Dashboard 1.0
- Updates documentation for `ui-text-input` and the migration tables

## Related Issue(s)

Closes #349 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)

