### PR TITLE
UI Slider: Control added over when a msg is emitted, can be continuous, or on release-only

### DIFF
--- a/docs/nodes/widgets/ui-slider.md
+++ b/docs/nodes/widgets/ui-slider.md
@@ -5,6 +5,7 @@ props:
     Label: The text shown to the left of the slider.
     Thumb Label: If true, will so a label on hte slider's thumb when moved/focussed.
     Range: min - the minimum valu the slider can be changed to; max - the maximum value the slider can be changed to; step - the increment/decrement value when the slider is moved.
+    Output: Defines when a msg is emitted, either as the slider is moved, or as the slider is released.
 ---
 
 <script setup>

--- a/docs/user/migration/ui_slider.json
+++ b/docs/user/migration/ui_slider.json
@@ -39,8 +39,8 @@
         },
         {
             "property": "output",
-            "changes": -1,
-            "notes": "Dashboard 2.0's (current) default behaviour is to output 'continuously while sliding', which was one of two options in Dashboard 1.0"
+            "changes": null,
+            "notes": null
         },
         {
             "property": "passthru",

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -126,13 +126,13 @@
                 </div>
             </div>
         </div>
-        <!-- <div class="form-row">
+        <div class="form-row">
             <label for="node-input-outs"><i class="fa fa-sign-out"></i> Output</label>
             <select id="node-input-outs" style="width:204px">
                 <option value="all">continuously while sliding</option>
                 <option value="end">only on release</option>
             </select>
-        </div>-->
+        </div>
         <div class="form-row">
             <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
             <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">

--- a/ui/src/widgets/ui-slider/UISlider.vue
+++ b/ui/src/widgets/ui-slider/UISlider.vue
@@ -1,9 +1,11 @@
+<!-- Error in plugin, @end is supported from Vuetify 3.2.0 -->
+<!-- eslint-disable vuetify/no-deprecated-events -->
 <template>
     <v-slider
         v-model="value" :label="props.label" hide-details="auto"
-        :class="className"
-        :thumb-label="props.thumbLabel || false"
-        :min="props.min" :max="props.max" :step="props.step || 1"
+        :class="className" :thumb-label="props.thumbLabel || false"
+        :min="props.min"
+        :max="props.max" :step="props.step || 1" @update:model-value="onChange" @end="onBlur"
     />
 </template>
 
@@ -38,16 +40,21 @@ export default {
                 return // no change
             }
             this.value = val
-        },
-        value: function (val, oldVal) {
-            if (this.storeValue === val) {
-                return // no change
-            }
-            this.onChange()
         }
     },
     methods: {
         onChange () {
+            if (!this.props.outs || this.props.outs === 'all') {
+                this.send()
+            }
+        },
+        onBlur () {
+            if (this.props.outs === 'end') {
+                this.send()
+            }
+        },
+        send () {
+            this.value = Number(this.value)
             const msg = this.messages[this.id] || {}
             msg.payload = this.value
             this.$store.commit('data/bind', msg)


### PR DESCRIPTION
## Description

- Adds the same dropdown option from Dashboard 1.0
- Documentation for `ui-slider` updated
- Migration documentation updated

## Related Issue(s)

Closes #312
Closes #357

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)