### PR TITLE
Set default of ui-text to match the labelling of Vuetify components

### DIFF
--- a/nodes/widgets/ui_text.html
+++ b/nodes/widgets/ui_text.html
@@ -34,6 +34,10 @@
                 name: 'Gill Sans'
             },
             {
+                value: 'Helvetica, sans-serif',
+                name: 'Helvetica'
+            },
+            {
                 value: 'Impact,Impact,Charcoal,sans-serif',
                 name: 'Impact'
             },
@@ -90,9 +94,9 @@
                 format: { value: '{{msg.payload}}' },
                 layout: { value: 'row-spread' },
                 style: { value: false },
-                font: { value: '' },
+                font: { value: 'Helvetica' },
                 fontSize: { value: 16 },
-                color: { value: '#000' },
+                color: { value: '#717171' },
                 className: { value: '' }
             },
             inputs: 1,


### PR DESCRIPTION
## Description

Issue was opened raising the inconsistency between `ui-text` and any other widgets we have that utilise Vuetify. Whilst `ui-text` does allow for customisation to intentionally make this different, we now set the default styling to match.

## Related Issue(s)

Closes #347 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)