### PR TITLE
Widget: UI Control

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -81,6 +81,7 @@ export default ({ mode }) => {
               collapsed: false,
               items: [
                 { text: 'ui-button', link: '/nodes/widgets/ui-button' },
+                { text: 'ui-control', link: '/nodes/widgets/ui-control' },
                 { text: 'ui-chart', link: '/nodes/widgets/ui-chart' },
                 { text: 'ui-dropdown', link: '/nodes/widgets/ui-dropdown' },
                 { text: 'ui-event', link: '/nodes/widgets/ui-event' },

--- a/docs/components/AddedIn.vue
+++ b/docs/components/AddedIn.vue
@@ -1,0 +1,37 @@
+<template>
+    <a class="added-in" :href="'https://github.com/FlowFuse/node-red-dashboard/releases/tag/v' + version" target="_blank">Added In: v{{ version }}</a>
+</template>
+
+<script>
+export default {
+    name: 'AddedIn',
+    props: {
+        version: {
+            type: String,
+            required: true
+        }
+    }
+}
+</script>
+
+<style scoped>
+.added-in {
+    display: inline-flex;
+    font-size: 14px;
+    line-height: 20px;
+    padding: 3px 9px;
+    color: var(--vp-c-brand-1);
+    margin-left: 0.5em;
+    border-radius: 2rem;
+    background-color: var(--vp-c-brand-soft);
+    border: 1px solid var(--vp-c-brand-1);
+    text-decoration: none;
+    transition: none;
+    vertical-align: middle;
+}
+
+.added-in:hover {
+    background-color: var(--vp-c-brand-1);
+    color: #fff;
+}
+</style>

--- a/docs/contributing/widgets/third-party.md
+++ b/docs/contributing/widgets/third-party.md
@@ -1,4 +1,8 @@
-# Building Third Party Widgets
+<script setup>
+    import AddedIn from '../../components/AddedIn.vue'
+</script>
+
+# Building Third Party Widgets <AddedIn version="0.8.0" />
 
 If you have an idea for a widget that you'd like to build in Dashboard 2.0 we are open to Pull Requests and ideas for additions to the [core collection](../../nodes/widgets.md) of Widgets.
 

--- a/docs/layouts/notebook.md
+++ b/docs/layouts/notebook.md
@@ -1,4 +1,8 @@
-# Layout: Notebook
+<script setup>
+    import AddedIn from '../components/AddedIn.vue'
+</script>
+
+# Layout: Notebook <AddedIn version="0.4.0" />
 
 This layout mimics a traditional Jupyter Notebook, where the layout will stretch to 100% width, up to a maximum width of 1024px, and will centrally align.
 

--- a/docs/nodes/widgets/ui-control.md
+++ b/docs/nodes/widgets/ui-control.md
@@ -112,3 +112,45 @@ _Note:_ `pages` can be subbed with `tabs` as per Dashboard 1.0 and `groups` can 
 ## Events List
 
 In addition to `ui-control` taking input to _control_ the UI, we have also maintained support for all events emitted by `ui-control` from Dashboard 1.0 here too.
+
+### Connection Status
+
+We follow the Dashboard 1.0 convention for emitting socket-based events from the `ui-control` node.
+
+#### .on('connection')
+
+When a new Dashboard client connects to Node-RED, the `ui-control` node will emit:
+
+```js
+msg = {
+    payload: 'connect',
+    socketid: '<socketid>',
+    socketip: '<socketip>'
+}
+```
+
+#### .on('disconnect')
+
+When a Dashboard client disconnects from Node-RED, the `ui-control` node will emit:
+
+```js
+msg = {
+    payload: 'lost',
+    socketid: '<socketid>',
+    socketip: '<socketip>'
+}
+```
+
+### Change Tab/Page
+
+When a user changes the active tab or page, the `ui-control` node will emit:
+
+```js
+msg = {
+    payload: 'change',
+    socketid: '<socketid>',
+    socketip: '<socketip>',
+    tab: '<Page Index>',
+    name: '<Page Name>'
+}
+```

--- a/docs/nodes/widgets/ui-control.md
+++ b/docs/nodes/widgets/ui-control.md
@@ -17,9 +17,10 @@
 
 <script setup>
     import EventsList from '../../components/EventsList.vue'
+    import AddedIn from '../../components/AddedIn.vue'
 </script>
 
-# Control `ui-control`
+# Control `ui-control` <AddedIn version="0.9.0" />
 
 This widget doesn't render any content into your Dashboard. Instead, it provides an interface for you to control the behaviour of your Dashboard from within the Node-RED Editor.
 

--- a/docs/nodes/widgets/ui-control.md
+++ b/docs/nodes/widgets/ui-control.md
@@ -1,0 +1,34 @@
+---
+{
+    "events": [
+        {
+            "event": "$pageview",
+            "payload": "{ page }",
+            "description": "Sent whenever a user <i>views</i> a given page on the Dashboard"
+        },
+        {
+            "event": "$pageleave",
+            "payload": "{ page }",
+            "description": "Sent whenever a user <i>leaves</i> a given page on the Dashboard"
+        }
+    ]
+}
+---
+
+<script setup>
+    import EventsList from '../../components/EventsList.vue'
+</script>
+
+# Control `ui-control`
+
+This widget doesn't render any content into your Dashboard. Instead, it provides an interface for you to control the behaviour of your Dashboard from within the Node-RED Editor.
+
+Functionality is generally divided into two main features:
+
+- **Navigation**: Force the user to move to a new page
+- **Display**: Show/Hide groups and pages
+- **Disability**: Enable/Disable groups and pages, this still shows them, but prevents interaction
+
+## Controls List
+
+Currently, we support the following controls:

--- a/docs/nodes/widgets/ui-control.md
+++ b/docs/nodes/widgets/ui-control.md
@@ -32,3 +32,32 @@ Functionality is generally divided into two main features:
 ## Controls List
 
 Currently, we support the following controls:
+
+### Navigation
+
+You can programmaticaly force navigation with the following payload into `ui-control`:
+
+```js
+msg.payload = {
+    page: '<Page Name>',
+}
+```
+
+_Note:_ `page` can also be subbed with `tab` as per Dashboard 1.0
+
+### Show/Hide
+
+You can programmaticaly show/hide groups and pages with the following payload into `ui-control`:
+
+```js
+msg.payload = {
+    pages: {
+        show: ['<Page Name>', '<Page Name>']
+    }
+    groups: {
+        hide: ['<Group Name>', '<Group Name>']
+    }
+}
+```
+
+_Note:_ `pages` can be subbed with `tabs` as per Dashboard 1.0 and `groups` can also be subbed with `group` as per Dashboard 1.0.

--- a/docs/nodes/widgets/ui-control.md
+++ b/docs/nodes/widgets/ui-control.md
@@ -35,15 +35,41 @@ Currently, we support the following controls:
 
 ### Navigation
 
-You can programmaticaly force navigation with the following payload into `ui-control`:
+You can programmaticaly force navigation with the following payloads with `ui-control`:
+
+#### Change Page
+
+Explicitely choose the page you want to navigate to:
 
 ```js
+// String
+msg.payload = '<Page Name>'
+
+// Object
 msg.payload = {
     page: '<Page Name>',
 }
 ```
 
-_Note:_ `page` can also be subbed with `tab` as per Dashboard 1.0
+#### Next/Previous
+
+Navigate to the next or previous page in the list:
+
+```js
+// Next Page
+msg.payload = "+1"
+
+// Previous Page
+msg.payload = "-1"
+```
+
+#### Refresh
+
+You can force a refresh of the current view by sending a blank string payload:
+
+```js
+msg.payload = ""
+```
 
 ### Show/Hide
 
@@ -82,3 +108,7 @@ msg.payload = {
 ```
 
 _Note:_ `pages` can be subbed with `tabs` as per Dashboard 1.0 and `groups` can also be subbed with `group` as per Dashboard 1.0.
+
+## Events List
+
+In addition to `ui-control` taking input to _control_ the UI, we have also maintained support for all events emitted by `ui-control` from Dashboard 1.0 here too.

--- a/docs/nodes/widgets/ui-control.md
+++ b/docs/nodes/widgets/ui-control.md
@@ -52,10 +52,31 @@ You can programmaticaly show/hide groups and pages with the following payload in
 ```js
 msg.payload = {
     pages: {
-        show: ['<Page Name>', '<Page Name>']
+        show: ['<Page Name>', '<Page Name>'],
+        hide: ['<Page Name>']
     }
     groups: {
-        hide: ['<Group Name>', '<Group Name>']
+        show: ['<Group Name>', '<Group Name>'],
+        hide: ['<Group Name>']
+    }
+}
+```
+
+_Note:_ `pages` can be subbed with `tabs` as per Dashboard 1.0 and `groups` can also be subbed with `group` as per Dashboard 1.0.
+
+### Enable/Disable
+
+You can programmaticaly disable/enable groups and pages with the following payload into `ui-control`:
+
+```js
+msg.payload = {
+    pages: {
+        enable: ['<Page Name>', '<Page Name>'],
+        disable: ['<Page Name>']
+    }
+    groups: {
+        enable: ['<Group Name>', '<Group Name>'],
+        disable: ['<Group Name>']
     }
 }
 ```

--- a/docs/nodes/widgets/ui-event.md
+++ b/docs/nodes/widgets/ui-event.md
@@ -36,6 +36,8 @@ Each time a user views a page, the `ui-event` node will emit:
 ```js
 msg = {
     topic: '$pageview',
+    socketid: '1234',
+    socketip: '127.0.0.1'
     payload: {
         page: {
             name: 'Page Name',

--- a/docs/nodes/widgets/ui-event.md
+++ b/docs/nodes/widgets/ui-event.md
@@ -17,9 +17,10 @@
 
 <script setup>
     import EventsList from '../../components/EventsList.vue'
+    import AddedIn from '../../components/AddedIn.vue'
 </script>
 
-# Event `ui-event`
+# Event `ui-event` <AddedIn version="0.9.0" />
 
 This widget doesn't render any content into your Dashboard. Instead, it listens for user-driven behaviour and events in your Dashboard and emits accordingly into the Node-RED Editor when those events have taken place.
 

--- a/docs/nodes/widgets/ui-markdown.md
+++ b/docs/nodes/widgets/ui-markdown.md
@@ -5,6 +5,7 @@ props:
 ---
 
 <script setup>
+    import AddedIn from '../../components/AddedIn.vue'
 </script>
 
 # Markdown Viewer `ui-markdown`
@@ -70,7 +71,7 @@ function () {
 | `msg.payload` | {{ msg.payload || 'Placeholder' }} |
 ````
 
-## Mermaid Charts
+## Mermaid Charts <AddedIn version="0.5.0" />
 
 The `ui-markdown` widget also supports the injection of [Mermaid](https://mermaid.js.org/intro/). To do so, you can include a mermaid chart definition inside a Markdown fenced code block, defined with the `mermaid` type:
 

--- a/docs/nodes/widgets/ui-notification.md
+++ b/docs/nodes/widgets/ui-notification.md
@@ -10,7 +10,11 @@ props:
     Class: Appends CSS classes to the widget
 ---
 
-# Notification `ui-notification`
+<script setup>
+    import AddedIn from '../../components/AddedIn.vue'
+</script>
+
+# Notification `ui-notification` <AddedIn version="0.5.0" />
 
 Known in Dashboard 1.0 as a "Toast", this widget displays text/HTML in a small window that will appear on the screen for a defined duration of time (`timeout`) and at a defined location on the screen (`position`).
 

--- a/docs/nodes/widgets/ui-table.md
+++ b/docs/nodes/widgets/ui-table.md
@@ -9,9 +9,10 @@ props:
 ---
 
 <script setup>
+    import AddedIn from '../../components/AddedIn.vue'
 </script>
 
-# Data Table `ui-table`
+# Data Table `ui-table` <AddedIn version="0.4.0" />
 
 Renders a set of data in a tabular format. Expects an input (`msg.payload`) in the format of:
 

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -277,6 +277,15 @@ module.exports = function (RED) {
                 }
             }
 
+            // loop over pages - check statestore if we've had any dynamic properties set
+            for (const [id, group] of node.ui.groups) {
+                const state = statestore.getAll(id)
+                if (state) {
+                    // merge the statestore with our props to account for dynamically set properties:
+                    node.ui.groups.set(id, { ...group, ...state })
+                }
+            }
+
             // pass the connected UI the UI config
             socket.emit('ui-config', node.id, {
                 dashboards: Object.fromEntries(node.ui.dashboards),

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -99,12 +99,12 @@ module.exports = function (RED) {
             uiShared.app.use(config.path, uiShared.httpMiddleware, express.static(path.join(__dirname, '../../dist')))
 
             // debugging endpoints
-            uiShared.app.get(config.path + '/_debug/datastore/:widgetid', uiShared.httpMiddleware, (req, res) => {
-                return res.json(datastore.get(req.params.widgetid))
+            uiShared.app.get(config.path + '/_debug/datastore/:itemid', uiShared.httpMiddleware, (req, res) => {
+                return res.json(datastore.get(req.params.itemid))
             })
 
-            uiShared.app.get(config.path + '/_debug/statestore/:widgetid', uiShared.httpMiddleware, (req, res) => {
-                return res.json(statestore.getAll(req.params.widgetid))
+            uiShared.app.get(config.path + '/_debug/statestore/:itemid', uiShared.httpMiddleware, (req, res) => {
+                return res.json(statestore.getAll(req.params.itemid))
             })
 
             // serve dashboard
@@ -259,13 +259,21 @@ module.exports = function (RED) {
          * @param {Socket} socket - socket.io socket connecting to the server
          */
         function emitConfig (socket) {
-            const widgets = node.ui.widgets
             // loop over widgets - check statestore if we've had any dynamic properties set
-            for (const [id, widget] of widgets) {
+            for (const [id, widget] of node.ui.widgets) {
                 const state = statestore.getAll(id)
                 if (state) {
                     // merge the statestore with our props to account for dynamically set properties:
                     widget.props = { ...widget.props, ...state }
+                }
+            }
+
+            // loop over pages - check statestore if we've had any dynamic properties set
+            for (const [id, page] of node.ui.pages) {
+                const state = statestore.getAll(id)
+                if (state) {
+                    // merge the statestore with our props to account for dynamically set properties:
+                    node.ui.pages.set(id, { ...page, ...state })
                 }
             }
 

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -535,6 +535,11 @@ module.exports = function (RED) {
         }
 
         /**
+         * Allow for any child node to emit to all connected UIs
+         */
+        node.emit = emit
+
+        /**
          * Register allows for pages, widgets, groups, etc. to register themselves with the Base UI Node
          * @param {*} page
          * @param {*} widget

--- a/nodes/config/ui_group.html
+++ b/nodes/config/ui_group.html
@@ -10,7 +10,7 @@
             width: { value: 6 },
             height: { value: 1 },
             order: { value: -1 },
-            disp: { value: true }, // show title on group card
+            showTitle: { value: true }, // show title on group card
             className: { value: '' }
         },
         label: function () {
@@ -18,6 +18,12 @@
             return `${this.name} [${page}]` || 'UI Group'
         },
         oneditprepare: function () {
+            console.log('this.showTitle')
+            console.log(this.showTitle)
+            if (this.disp) {
+                console.log(this.disp)
+                this.showTitle = this.disp
+            }
             $('#node-config-input-size').elementSizer({
                 width: '#node-config-input-width',
                 height: '#node-config-input-height',
@@ -43,7 +49,8 @@
         <button class="editor-button" id="node-config-input-size"></button>
     </div>
     <div class="form-row">
-        <input style="margin:8px 0 10px 102px; width:20px;" type="checkbox" checked id="node-config-input-disp"> <label style="width:auto" for="node-config-input-disp"><span data-i18n="ui-group.display-name"></span></label>
+        <input style="margin:8px 0 10px 102px; width:20px;" type="checkbox" checked id="node-config-input-showTitle">
+        <label style="width:auto" for="node-config-input-showTitle"><span data-i18n="ui-group.display-name"></span></label>
     </div>
     <div class="form-row" id="text-row-class">
         <label for="node-config-input-className"><i class="fa fa-code"></i> Class</label>

--- a/nodes/config/ui_group.js
+++ b/nodes/config/ui_group.js
@@ -7,6 +7,12 @@ module.exports = function (RED) {
         RED.nodes.createNode(this, config)
         const node = this
 
+        if (!('showTitle' in config)) {
+            // migration backwards compatibility
+            // we now use showTitle, not disp, but older flows still may have disp
+            config.showTitle = config.disp || true
+        }
+
         node.on('close', function (removed, done) {
             node.deregister() // deregister self
             done()

--- a/nodes/widgets/locales/en-US/ui_control.html
+++ b/nodes/widgets/locales/en-US/ui_control.html
@@ -1,0 +1,59 @@
+
+<script type="text/html" data-help-name="ui-control">
+    <p>Allows dynamic control of the Dashboard.</p>
+    <h3>Controls List</h3>
+    <h4>Navigation</h4>
+    <p>Control which page is shown to a user, by programmatically changing the page.</p>
+    <p><b>Change Page:</b> The default function is to change the currently displayed page. The following optins are supported for the <code>msg.payload</code></p>
+    <ul>
+        <li><code>"Page Name"</code> - String</li>
+        <li><code>{"page":"Page Name"}</code> - Object</li>
+        <li><code>2</code> - The numerical index (from 0) of the page to be displayed</li>
+    </ul>
+    <p><b>Next/Previous:</b> You can also send string in the format:</p>
+    <ul>
+        <li><code>"+1"</code> - Next Page</li>
+        <li><code>"-1"</code> - Previous Page</li>
+    </ul>
+    <p><b>Refresh:</b> Sending a blank tab name <code>""</code> will refresh the current page.</p>
+    <ul>
+        <li><code>""</code></li>
+        <li><code>{"page":""}</code></li>
+    </ul>
+    <h4>Show/Hide Pages & Groups</h4>
+    <p>Dashboard pages & groups can be shown and hidden by sending a <code>msg.payload</code> object with the format
+    <pre>msg.payload = {
+    pages: {
+        show: ['&lt;Page Name&gt;', '&lt;Page Name&gt;'],
+        hide: ['&lt;Page Name&gt;']
+    }
+    groups: {
+        show: ['&lt;Group Name&gt;', '&lt;Group Name&gt;'],
+        hide: ['&lt;Group Name&gt;']
+    }
+}</pre>
+    <h4>Enable/Disable Pages & Groups</h4>
+    <p>Dashboard pages & groups can be disabled & re-enabled by sending a <code>msg.payload</code> object with the format
+    <pre>msg.payload = {
+    pages: {
+        enable: ['&lt;Page Name&gt;', '&lt;Page Name&gt;'],
+        disable: ['&lt;Page Name&gt;']
+    }
+    groups: {
+        enable: ['&lt;Group Name&gt;', '&lt;Group Name&gt;'],
+        disable: ['&lt;Group Name&gt;']
+    }
+}</pre>
+    <h3>Events List</h3>
+    <p>When any browser client connects or loses connection, changes tab, or expands or collapses a group this node will emit a <code>msg</code> containing:</p>
+    <ul>
+    <li><code>payload</code> - <i>connect</i>, <i>lost</i>, <i>change</i>, or <i>group</i>.
+    <li><code>socketid</code> - the ID of the socket (this will change every time the browser reloads the page).
+    <li><code>socketip</code> - the ip address from where the connection originated.
+    <li><code>tab</code> - the number of the tab. (only for 'change' event).
+    <li><code>name</code> - the name of the tab. (only for 'change' event).
+    <li><code>group</code> - the name of the group. (only for 'group' event).
+    <li><code>open</code> - the state of the group. (only for 'group' event).
+    </ul>
+    <p>Optional - report only connect events - useful to use to trigger a resend of data to a new client without needing to filter out other events.</p>
+</script>

--- a/nodes/widgets/locales/en-US/ui_control.html
+++ b/nodes/widgets/locales/en-US/ui_control.html
@@ -28,7 +28,7 @@
         hide: ['&lt;Page Name&gt;']
     }
     groups: {
-        show: ['&lt;Group Name&gt;', '&lt;Group Name&gt;'],
+        show: ['&lt;Page Name&gt;:&lt;Group Name&gt;', '&lt;Group Name&gt;'],
         hide: ['&lt;Group Name&gt;']
     }
 }</pre>
@@ -52,8 +52,6 @@
     <li><code>socketip</code> - the ip address from where the connection originated.
     <li><code>tab</code> - the number of the tab. (only for 'change' event).
     <li><code>name</code> - the name of the tab. (only for 'change' event).
-    <li><code>group</code> - the name of the group. (only for 'group' event).
-    <li><code>open</code> - the state of the group. (only for 'group' event).
     </ul>
     <p>Optional - report only connect events - useful to use to trigger a resend of data to a new client without needing to filter out other events.</p>
 </script>

--- a/nodes/widgets/locales/en-US/ui_control.json
+++ b/nodes/widgets/locales/en-US/ui_control.json
@@ -1,0 +1,13 @@
+{
+    "ui-control": {
+        "label": {
+            "name": "Name",
+            "output": "Output"
+        },
+        "events": {
+            "all": "All Events",
+            "change": "Page/Tab Change Events Only",
+            "connect": "Connection Events Only"
+        }
+    }
+  }

--- a/nodes/widgets/locales/en-US/ui_event.html
+++ b/nodes/widgets/locales/en-US/ui_event.html
@@ -17,4 +17,20 @@
             <b>$pageleave</b> - Emits whenever a user leaves a page.
         </li>
     </ul>
+    <p>An example output <code>msg</code> is as follows:</p>
+        <pre>msg = {
+    topic: '$pageview',
+    socketid: '1234',
+    socketip: '127.0.0.1'
+    payload: {
+        page: {
+            name: 'Page Name',
+            path: '/page/path'
+            id: '1234',
+            theme: 'dark',
+            layout: 'default',
+            _groups: []
+        }
+    }
+}</pre>
 </script>

--- a/nodes/widgets/ui_control.html
+++ b/nodes/widgets/ui_control.html
@@ -2,7 +2,7 @@
     (function () {
         // convert to i18 text
         function c_ (x) {
-            return RED._('node-red-dashboard/ui_ui_control:ui_ui_control.' + x)
+            return RED._('@flowfuse/node-red-dashboard/ui-control:ui-control.' + x)
         }
     
         RED.nodes.registerType('ui-control', {

--- a/nodes/widgets/ui_control.html
+++ b/nodes/widgets/ui_control.html
@@ -7,7 +7,7 @@
     
         RED.nodes.registerType('ui-control', {
             category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
-            color: '@flowfuse/node-red-dashboard/ui-base:ui-base.colors.darkest',
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.darkest'),
             defaults: {
                 name: { value: '' },
                 ui: { type: 'ui-base', value: '', required: true },
@@ -16,7 +16,7 @@
             inputs: 1,
             outputs: 1,
             align: 'right',
-            icon: 'ui_link.png',
+            icon: 'font-awesome/fa-arrow-circle-right',
             paletteLabel: 'ui control',
             label: function () { return this.name || 'ui control' },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },

--- a/nodes/widgets/ui_control.html
+++ b/nodes/widgets/ui_control.html
@@ -1,0 +1,51 @@
+<script type="text/javascript">
+    (function () {
+        // convert to i18 text
+        function c_ (x) {
+            return RED._('node-red-dashboard/ui_ui_control:ui_ui_control.' + x)
+        }
+    
+        RED.nodes.registerType('ui-control', {
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: '@flowfuse/node-red-dashboard/ui-base:ui-base.colors.darkest',
+            defaults: {
+                name: { value: '' },
+                ui: { type: 'ui-base', value: '', required: true },
+                events: { value: 'all' }
+            },
+            inputs: 1,
+            outputs: 1,
+            align: 'right',
+            icon: 'ui_link.png',
+            paletteLabel: 'ui control',
+            label: function () { return this.name || 'ui control' },
+            labelStyle: function () { return this.name ? 'node_label_italic' : '' },
+            outputLabels: function () { return this.events },
+            oneditprepare: function () {
+                const node = this
+                const sel = $('#node-input-events')
+                for (const name of ['all', 'change', 'connect']) {
+                    const text = c_('events.' + name)
+                    $('<option/>').val(name).text(text).appendTo(sel)
+                }
+                $(sel).val(node.events)
+            }
+        })
+    })()
+</script>
+
+<script type="text/html" data-template-name="ui-control">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="ui-control.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]ui-control.placeholder.name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-ui"><i class="fa fa-bookmark"></i> UI</label>
+        <input type="text" id="node-input-ui">
+    </div>
+    <div class="form-row">
+        <label for="node-input-events"><i class="fa fa-sign-out"></i> <span data-i18n="ui-control.label.output"></span></label>
+        <select id="node-input-events" style="width:70%;">
+        </select>
+    </div>
+</script>

--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -38,10 +38,8 @@ module.exports = function (RED) {
                             const p = allPages[page]
                             // update the state store for each page
                             statestore.set(p.id, 'visible', false)
-                            console.log('hide', p.id)
                         })
                     }
-                    console.log(pages)
                     // send to front end in order to action there too
                     ui.emit('ui-control', {
                         pages
@@ -56,7 +54,7 @@ module.exports = function (RED) {
                         if (n.type === 'ui-page') {
                             if (n.name === page) {
                                 // send a message to the ui to switch to this tab
-                                ui.emit('ui-control', { page, socketid: msg.socketid })
+                                ui.emit('ui-control', { page })
                                 pageFound = true
                             }
                         }
@@ -67,14 +65,31 @@ module.exports = function (RED) {
                 }
                 // show or hide ui groups
                 if ('groups' in msg.payload || 'group' in msg.payload) {
-                    if ('hide' in msg.payload.group) {
-                        // loop over the groups in this array
-
-                        const groups = RED.nodes.filterNodes({ type: 'ui-group' })
-                        console.log(groups)
-                        // statestore.set(node.id, 'group', msg.payload.group.hide)
+                    const groups = msg.payload.groups || msg.payload.group
+                    // get a map of group name to group object
+                    const allGroups = {}
+                    RED.nodes.eachNode((n) => {
+                        if (n.type === 'ui-group') {
+                            allGroups[n.name] = n
+                        }
+                    })
+                    if ('show' in groups) {
+                        // we are setting visibility: true
+                        groups.show.forEach(function (group) {
+                            const g = allGroups[group]
+                            // update the state store for each page
+                            statestore.set(g.id, 'visible', true)
+                        })
                     }
-                    ui.emit('ui-control', { group: msg.payload.group, socketid: msg.socketid })
+                    if ('hide' in groups) {
+                        // we are setting visibility: true
+                        groups.hide.forEach(function (group) {
+                            const g = allGroups[group]
+                            // update the state store for each page
+                            statestore.set(g.id, 'visible', false)
+                        })
+                    }
+                    ui.emit('ui-control', { groups })
                 }
 
                 // send specific visible/hidden commands via SocketIO here,

--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -1,0 +1,109 @@
+const statestore = require('../store/state.js')
+
+module.exports = function (RED) {
+    function UiControlNode (config) {
+        const node = this
+        RED.nodes.createNode(this, config)
+
+        // which ui does this widget belong to
+        const ui = RED.nodes.getNode(config.ui)
+
+        const evts = {
+            onInput: function (msg, send, done) {
+                console.log(msg)
+                // handle the logic here of what to do when input is received
+
+                if (typeof msg.payload !== 'object') { msg.payload = { tab: msg.payload } }
+                // show/hide or enable/disable tabs
+                if ('tabs' in msg.payload) {
+                    ui.emit('ui-control', { tabs: msg.payload.tabs, socketid: msg.socketid })
+                }
+                // switch to tab name (or number)
+                if ('tab' in msg.payload || 'page' in msg.payload) {
+                    const page = msg.payload.page || msg.payload.tab
+                    let pageFound = false
+                    // check we have a valid tab/page name
+                    RED.nodes.eachNode(function (n) {
+                        if (n.type === 'ui-page') {
+                            if (n.name === page) {
+                                // send a message to the ui to switch to this tab
+                                ui.emit('ui-control', { tab: page, socketid: msg.socketid })
+                                pageFound = true
+                            }
+                        }
+                    })
+                    if (!pageFound) {
+                        node.error("No page with the name '" + page + "' found")
+                    }
+                }
+                // show or hide ui groups
+                if ('group' in msg.payload) {
+                    if ('hide' in msg.payload.group) {
+                        // loop over the groups in this array
+
+                        const groups = RED.nodes.filterNodes({ type: 'ui-group' })
+                        console.log(groups)
+                        // statestore.set(node.id, 'group', msg.payload.group.hide)
+                    }
+                    ui.emit('ui-control', { group: msg.payload.group, socketid: msg.socketid })
+                }
+
+                // send specific visible/hidden commands via SocketIO here,
+                // so all logic stays server-side
+
+                node.send({ payload: 'input' })
+            }
+        }
+
+        // inform the dashboard UI that we are adding this node
+        ui.register(null, null, node, config, evts)
+
+        // this.events = config.events || 'all'
+
+        // this.on('input', function (msg) {
+        // })
+
+        // const sendconnect = function (id, ip) {
+        //     node.send({ payload: 'connect', socketid: id, socketip: ip })
+        // }
+
+        // const sendlost = function (id, ip) {
+        //     node.send({ payload: 'lost', socketid: id, socketip: ip })
+        // }
+
+        // const sendchange = function (index, name, id, ip, p) {
+        //     node.send({ payload: 'change', tab: index, name, socketid: id, socketip: ip, params: p })
+        // }
+
+        // const sendcollapse = function (group, state, id, ip) {
+        //     node.send({ payload: 'group', group, open: state, socketid: id, socketip: ip })
+        // }
+
+        // if (node.events === 'connect') {
+        //     ui.ev.on('newsocket', sendconnect)
+        // } else if (node.events === 'change') {
+        //     ui.ev.on('changetab', sendchange)
+        //     ui.ev.on('collapse', sendcollapse)
+        // } else {
+        //     ui.ev.on('newsocket', sendconnect)
+        //     ui.ev.on('changetab', sendchange)
+        //     ui.ev.on('collapse', sendcollapse)
+        //     ui.ev.on('endsocket', sendlost)
+        // }
+
+        // this.on('close', function () {
+        //     if (node.events === 'connect') {
+        //         ui.ev.removeListener('newsocket', sendconnect)
+        //     } else if (node.events === 'change') {
+        //         ui.ev.removeListener('changetab', sendchange)
+        //         ui.ev.removeListener('collapse', sendcollapse)
+        //     } else {
+        //         ui.ev.removeListener('newsocket', sendconnect)
+        //         ui.ev.removeListener('changetab', sendchange)
+        //         ui.ev.removeListener('collapse', sendcollapse)
+        //         ui.ev.removeListener('endsocket', sendlost)
+        //     }
+        // })
+    }
+    RED.nodes.registerType('ui-control', UiControlNode)
+}

--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -115,6 +115,37 @@ module.exports = function (RED) {
                 // so all logic stays server-side
 
                 node.send({ payload: 'input' })
+            },
+            onSocket: {
+                connection: function (conn) {
+                    node.send({
+                        payload: 'connect',
+                        socketid: conn.id,
+                        socketip: conn.client.conn.remoteAddress
+                    })
+                },
+                disconnect: function (conn, id, msg) {
+                    node.send({
+                        payload: 'lost',
+                        socketid: conn.id,
+                        socketip: conn.client.conn.remoteAddress
+                    })
+                },
+                'ui-control': function (conn, id, evt, payload) {
+                    console.log('ui-control', node.id, id, evt, payload)
+                    if (id === node.id) {
+                        // this message was sent by this particular node
+                        if (evt === 'change') {
+                            node.send({
+                                payload: 'change',
+                                tab: payload.page, // index of tab
+                                name: payload.name, // page name
+                                socketid: conn.id,
+                                socketip: conn.client.conn.remoteAddress
+                            })
+                        }
+                    }
+                }
             }
         }
 

--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -40,6 +40,23 @@ module.exports = function (RED) {
                             statestore.set(p.id, 'visible', false)
                         })
                     }
+                    // const pMap = RED.nodes.forEach
+                    if ('enable' in pages) {
+                        // we are setting visibility: true
+                        pages.enable.forEach(function (page) {
+                            const p = allPages[page]
+                            // update the state store for each page
+                            statestore.set(p.id, 'disabled', false)
+                        })
+                    }
+                    if ('disable' in pages) {
+                        // we are setting visibility: true
+                        pages.disable.forEach(function (page) {
+                            const p = allPages[page]
+                            // update the state store for each page
+                            statestore.set(p.id, 'disabled', true)
+                        })
+                    }
                     // send to front end in order to action there too
                     ui.emit('ui-control', {
                         pages

--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -22,6 +22,7 @@ module.exports = function (RED) {
 
         const evts = {
             onInput: function (msg, send, done) {
+                const wNode = RED.nodes.getNode(node.id)
                 // handle the logic here of what to do when input is received
 
                 if (typeof msg.payload !== 'object') {
@@ -114,12 +115,13 @@ module.exports = function (RED) {
                 // send specific visible/hidden commands via SocketIO here,
                 // so all logic stays server-side
 
-                node.send({ payload: 'input' })
+                wNode.send({ payload: 'input' })
             },
             onSocket: {
                 connection: function (conn) {
                     if (config.events === 'all' || config.events === 'connect') {
-                        node.send({
+                        const wNode = RED.nodes.getNode(node.id)
+                        wNode.send({
                             payload: 'connect',
                             socketid: conn.id,
                             socketip: conn.client.conn.remoteAddress
@@ -128,7 +130,8 @@ module.exports = function (RED) {
                 },
                 disconnect: function (conn) {
                     if (config.events === 'all' || config.events === 'connect') {
-                        node.send({
+                        const wNode = RED.nodes.getNode(node.id)
+                        wNode.send({
                             payload: 'lost',
                             socketid: conn.id,
                             socketip: conn.client.conn.remoteAddress
@@ -136,10 +139,12 @@ module.exports = function (RED) {
                     }
                 },
                 'ui-control': function (conn, id, evt, payload) {
+                    console.log('ui-control', id, evt, payload, id, node.id)
                     if (id === node.id && (config.events === 'all' || config.events === 'change')) {
                         // this message was sent by this particular node
                         if (evt === 'change') {
-                            node.send({
+                            const wNode = RED.nodes.getNode(node.id)
+                            wNode.send({
                                 payload: 'change',
                                 tab: payload.page, // index of tab
                                 name: payload.name, // page name

--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -118,22 +118,25 @@ module.exports = function (RED) {
             },
             onSocket: {
                 connection: function (conn) {
-                    node.send({
-                        payload: 'connect',
-                        socketid: conn.id,
-                        socketip: conn.client.conn.remoteAddress
-                    })
+                    if (config.events === 'all' || config.events === 'connect') {
+                        node.send({
+                            payload: 'connect',
+                            socketid: conn.id,
+                            socketip: conn.client.conn.remoteAddress
+                        })
+                    }
                 },
-                disconnect: function (conn, id, msg) {
-                    node.send({
-                        payload: 'lost',
-                        socketid: conn.id,
-                        socketip: conn.client.conn.remoteAddress
-                    })
+                disconnect: function (conn) {
+                    if (config.events === 'all' || config.events === 'connect') {
+                        node.send({
+                            payload: 'lost',
+                            socketid: conn.id,
+                            socketip: conn.client.conn.remoteAddress
+                        })
+                    }
                 },
                 'ui-control': function (conn, id, evt, payload) {
-                    console.log('ui-control', node.id, id, evt, payload)
-                    if (id === node.id) {
+                    if (id === node.id && (config.events === 'all' || config.events === 'change')) {
                         // this message was sent by this particular node
                         if (evt === 'change') {
                             node.send({

--- a/nodes/widgets/ui_event.js
+++ b/nodes/widgets/ui_event.js
@@ -10,9 +10,10 @@ module.exports = function (RED) {
         const evts = {
             onSocket: {
                 'ui-event': function (conn, id, evt, payload) {
+                    const wNode = RED.nodes.getNode(node.id)
                     if (id === node.id) {
                         // this was sent by this particular node
-                        node.send({
+                        wNode.send({
                             topic: evt,
                             payload,
                             socketid: conn.id,

--- a/nodes/widgets/ui_event.js
+++ b/nodes/widgets/ui_event.js
@@ -9,11 +9,16 @@ module.exports = function (RED) {
 
         const evts = {
             onSocket: {
-                'ui-event': function (conn, evt, payload) {
-                    node.send({
-                        topic: evt,
-                        payload
-                    })
+                'ui-event': function (conn, id, evt, payload) {
+                    if (id === node.id) {
+                        // this was sent by this particular node
+                        node.send({
+                            topic: evt,
+                            payload,
+                            socketid: conn.id,
+                            socketip: conn.client.conn.remoteAddress
+                        })
+                    }
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
             "ui-notification": "nodes/widgets/ui_notification.js",
             "ui-markdown": "nodes/widgets/ui_markdown.js",
             "ui-template": "nodes/widgets/ui_template.js",
-            "ui-event": "nodes/widgets/ui_event.js"
+            "ui-event": "nodes/widgets/ui_event.js",
+            "ui-control": "nodes/widgets/ui_control.js"
         }
     },
     "overrides": {

--- a/ui/src/debug/Debug.vue
+++ b/ui/src/debug/Debug.vue
@@ -33,9 +33,31 @@
                         <v-chip v-for="(filter, $index) in filters.pages" :key="filter.key" closable @click:close="clearFilter('pages', $index)">{{ filter.key }}: {{ filter.value }}</v-chip>
                     </div>
                 </div>
-                <v-data-table :headers="headers.pages" :items="items.pages" :items-per-page="-1">
+                <v-data-table :headers="headers.pages" :items="items.pages" show-expand :items-per-page="-1">
                     <template #item.filter.groups="{ item }">
                         <v-btn variant="outlined" @click="applyFilter('groups', 'page', item.id)">Show Groups</v-btn>
+                    </template>
+                    <template #expanded-row="{ columns, item }">
+                        <tr>
+                            <td :colspan="columns.length" class="nested-table">
+                                <v-tabs
+                                    v-model="view.nested"
+                                >
+                                    <v-tab :value="'properties'">Properties</v-tab>
+                                    <v-tab :value="'statestore'">Dynamic Properties</v-tab>
+                                </v-tabs>
+                                <v-window v-model="view.nested">
+                                    <v-window-item value="properties">
+                                        <v-data-table color="white" :items="Object.entries(item).map(function(e){ return { 'property': e[0], 'value': e[1] }})" :items-per-page="-1">
+                                            <template #bottom />
+                                        </v-data-table>
+                                    </v-window-item>
+                                    <v-window-item value="statestore">
+                                        <debug-data type="page" :item="item.id" store="state" />
+                                    </v-window-item>
+                                </v-window>
+                            </td>
+                        </tr>
                     </template>
                 </v-data-table>
             </v-window-item>
@@ -54,12 +76,34 @@
                     variant="outlined"
                     hide-details
                 />
-                <v-data-table :headers="headers.groups" :items="items.groups" :items-per-page="-1" :search="search.groups">
+                <v-data-table :headers="headers.groups" :items="items.groups" :items-per-page="-1" show-expand :search="search.groups">
                     <template #item.size="{ item }">
                         <span>{{ item.width }}x{{ item.height || 'auto' }}</span>
                     </template>
                     <template #item.filter.widgets="{ item }">
                         <v-btn variant="outlined" @click="applyFilter('widgets', 'props.group', item.id)">Show Widgets</v-btn>
+                    </template>
+                    <template #expanded-row="{ columns, item }">
+                        <tr>
+                            <td :colspan="columns.length" class="nested-table">
+                                <v-tabs
+                                    v-model="view.nested"
+                                >
+                                    <v-tab :value="'properties'">Properties</v-tab>
+                                    <v-tab :value="'statestore'">Dynamic Properties</v-tab>
+                                </v-tabs>
+                                <v-window v-model="view.nested">
+                                    <v-window-item value="properties">
+                                        <v-data-table color="white" :items="Object.entries(item).map(function(e){ return { 'property': e[0], 'value': e[1] }})" :items-per-page="-1">
+                                            <template #bottom />
+                                        </v-data-table>
+                                    </v-window-item>
+                                    <v-window-item value="statestore">
+                                        <debug-data :item="item.id" store="state" />
+                                    </v-window-item>
+                                </v-window>
+                            </td>
+                        </tr>
                     </template>
                 </v-data-table>
             </v-window-item>
@@ -102,7 +146,7 @@
                                         <debug-data :widget="item.id" store="data" />
                                     </v-window-item>
                                     <v-window-item value="statestore">
-                                        <debug-data :widget="item.id" store="state" />
+                                        <debug-data :item="item.id" store="state" />
                                     </v-window-item>
                                 </v-window>
                             </td>

--- a/ui/src/debug/DebugData.vue
+++ b/ui/src/debug/DebugData.vue
@@ -8,7 +8,7 @@
 export default {
     name: 'DebugData',
     props: {
-        widget: { type: String, required: true },
+        item: { type: String, required: true },
         store: { type: String, required: true }
     },
     data () {
@@ -25,7 +25,7 @@ export default {
     methods: {
         getData () {
             const xhr = new XMLHttpRequest()
-            xhr.open('GET', `/dashboard/_debug/${this.store}store/${this.widget}`)
+            xhr.open('GET', `/dashboard/_debug/${this.store}store/${this.item}`)
             xhr.send()
             xhr.responseType = 'json'
             xhr.onload = () => {

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -20,6 +20,7 @@
                 <v-list nav>
                     <v-list-item
                         v-for="page in orderedPages" :key="page.id" active-class="v-list-item--active"
+                        :disabled="page.disabled"
                         prepend-icon="mdi-home" :title="`${page.name} (${page.route.path})`"
                         :to="{name: page.route.name}" link
                     />
@@ -113,10 +114,15 @@ export default {
     watch: {
         theme: function () {
             this.updateTheme()
+        },
+        pages: {
+            handler: function () {
+                console.log('pages changed')
+            },
+            deep: true
         }
     },
     mounted () {
-        console.log('BaselineLayout mounted. siteTemplates:', this.siteTemplates(this.$route.meta.dashboard), 'pageTemplates:', this.pageTemplates(this.$route.meta.id))
         this.updateTheme()
     },
     methods: {

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -27,7 +27,7 @@
             </v-navigation-drawer>
             <slot class="nrdb-layout" />
             <div class="nrdb-layout-overlay">
-                <!-- Render any widgets with a 'ui' scope, e.g. ui-notification -->
+                <!-- Render any widgets with a 'ui' scope, e.g. ui-notification, ui-event, ui-control -->
                 <component
                     :is="widget.component"
                     v-for="widget in uiWidgets"
@@ -95,7 +95,14 @@ export default {
             return theme
         },
         orderedPages: function () {
-            return Object.values(this.pages).sort((a, b) => a.order - b.order)
+            return Object.values(this.pages)
+                .filter((p) => {
+                    if ('visible' in p && !p.visible) {
+                        return false
+                    }
+                    return true
+                })
+                .sort((a, b) => a.order - b.order)
         },
         uiWidgets: function () {
             // get widgets scoped to the UI, not a group/page

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -114,12 +114,6 @@ export default {
     watch: {
         theme: function () {
             this.updateTheme()
-        },
-        pages: {
-            handler: function () {
-                console.log('pages changed')
-            },
-            deep: true
         }
     },
     mounted () {

--- a/ui/src/layouts/Flex.vue
+++ b/ui/src/layouts/Flex.vue
@@ -54,7 +54,15 @@ export default {
         ...mapState('data', ['properties']),
         ...mapGetters('ui', ['groupsByPage', 'widgetsByGroup']),
         orderedGroups: function () {
+            // get groups on this page
             const groups = this.groupsByPage(this.$route.meta.id)
+                // only show hte groups that haven't had their "visible" property set to false
+                .filter((g) => {
+                    if ('visible' in g) {
+                        return g.visible
+                    }
+                    return true
+                })
             return groups
         },
         page: function () {

--- a/ui/src/layouts/Flex.vue
+++ b/ui/src/layouts/Flex.vue
@@ -6,6 +6,7 @@
                 :id="'nrdb-ui-group-' + g.id"
                 :key="g.id"
                 class="nrdb-ui-group"
+                :disabled="g.disabled"
                 :class="getGroupClass(g)"
                 :style="{'width': ((rowHeight * 2 * g.width) + 'px')}"
             >

--- a/ui/src/layouts/Flex.vue
+++ b/ui/src/layouts/Flex.vue
@@ -10,7 +10,7 @@
                 :style="{'width': ((rowHeight * 2 * g.width) + 'px')}"
             >
                 <v-card variant="outlined" class="bg-group-background" :style="{'min-height': ((rowHeight * g.height) + 'px')}">
-                    <template v-if="g.disp" #title>
+                    <template v-if="g.showTitle" #title>
                         {{ g.name }}
                     </template>
                     <template #text>

--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -2,7 +2,7 @@
     <BaselineLayout :page-title="$route.meta.title">
         <div v-if="gridGroups" :id="'nrdb-page-' + $route.meta.id" class="nrdb-layout--grid nrdb-ui-page" :class="page?.className">
             <div
-                v-for="g in gridGroups"
+                v-for="g in orderedGroups"
                 :id="'nrdb-ui-group-' + g.id"
                 :key="g.id"
                 class="nrdb-ui-group"
@@ -55,8 +55,16 @@ export default {
         ...mapState('ui', ['groups', 'widgets', 'pages']),
         ...mapState('data', ['properties']),
         ...mapGetters('ui', ['groupsByPage', 'widgetsByGroup']),
-        gridGroups: function () {
+        orderedGroups: function () {
+            // get groups on this page
             const groups = this.groupsByPage(this.$route.meta.id)
+                // only show hte groups that haven't had their "visible" property set to false
+                .filter((g) => {
+                    if ('visible' in g) {
+                        return g.visible
+                    }
+                    return true
+                })
             return groups
         },
         page: function () {

--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -1,11 +1,12 @@
 <template>
     <BaselineLayout :page-title="$route.meta.title">
-        <div v-if="gridGroups" :id="'nrdb-page-' + $route.meta.id" class="nrdb-layout--grid nrdb-ui-page" :class="page?.className">
+        <div v-if="orderedGroups" :id="'nrdb-page-' + $route.meta.id" class="nrdb-layout--grid nrdb-ui-page" :class="page?.className">
             <div
                 v-for="g in orderedGroups"
                 :id="'nrdb-ui-group-' + g.id"
                 :key="g.id"
                 class="nrdb-ui-group"
+                :disabled="g.disabled"
                 :class="getGroupClass(g)"
                 :style="`grid-column-end: span ${ g.width }`"
             >

--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -10,7 +10,7 @@
                 :style="`grid-column-end: span ${ g.width }`"
             >
                 <v-card variant="outlined" class="bg-group-background">
-                    <template v-if="g.disp" #title>
+                    <template v-if="g.showTitle" #title>
                         {{ g.name }}
                     </template>
                     <template #text>

--- a/ui/src/layouts/Notebook.vue
+++ b/ui/src/layouts/Notebook.vue
@@ -6,6 +6,7 @@
                 :id="'nrdb-ui-group-' + g.id"
                 :key="g.id"
                 class="nrdb-ui-group"
+                :disabled="g.disabled"
                 :class="getGroupClass(g)"
             >
                 <v-card variant="outlined" class="bg-group-background" :style="{'min-height': ((rowHeight * g.height) + 'px')}">

--- a/ui/src/layouts/Notebook.vue
+++ b/ui/src/layouts/Notebook.vue
@@ -9,7 +9,7 @@
                 :class="getGroupClass(g)"
             >
                 <v-card variant="outlined" class="bg-group-background" :style="{'min-height': ((rowHeight * g.height) + 'px')}">
-                    <template v-if="g.disp" #title>
+                    <template v-if="g.showTitle" #title>
                         {{ g.name }}
                     </template>
                     <template #text>

--- a/ui/src/layouts/Notebook.vue
+++ b/ui/src/layouts/Notebook.vue
@@ -53,7 +53,15 @@ export default {
         ...mapState('data', ['properties']),
         ...mapGetters('ui', ['groupsByPage', 'widgetsByGroup']),
         orderedGroups: function () {
+            // get groups on this page
             const groups = this.groupsByPage(this.$route.meta.id)
+                // only show the groups that haven't had their "visible" property set to false
+                .filter((g) => {
+                    if ('visible' in g) {
+                        return g.visible
+                    }
+                    return true
+                })
             return groups
         },
         page: function () {

--- a/ui/src/store/ui.mjs
+++ b/ui/src/store/ui.mjs
@@ -53,6 +53,18 @@ const getters = {
             })
         }
     },
+    /**
+     *
+     * @param {*} item - 'page' || 'group' || 'widget'
+     * @returns
+     */
+    findBy: (state) => (item, prop, value) => {
+        if (state[item + 's']) {
+            return Object.values(state[item + 's']).find((i) => {
+                return i[prop] === value
+            })
+        }
+    },
     siteTemplates: (state) => (dashboardId) => {
         if (state.widgets) {
             const siteTemplates = Object.values(state.widgets).filter((w) => {
@@ -102,6 +114,15 @@ const mutations = {
         if ('visible' in data) {
             state.widgets[wId].state.visible = data.visible
         }
+    },
+    /**
+     *
+     * @param {*} item - 'page' || 'group' || 'widget'
+     * @returns
+     */
+    setProperty (state, { item, itemId, property, value }) {
+        console.log('setProperty', item, itemId, property, value)
+        state[item + 's'][itemId][property] = value
     }
 }
 

--- a/ui/src/store/ui.mjs
+++ b/ui/src/store/ui.mjs
@@ -121,7 +121,6 @@ const mutations = {
      * @returns
      */
     setProperty (state, { item, itemId, property, value }) {
-        console.log('setProperty', item, itemId, property, value)
         state[item + 's'][itemId][property] = value
     }
 }

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -79,6 +79,15 @@ main {
 }
 
 /**
+* Common Group Styling
+*/
+.nrdb-ui-group[disabled=true] {
+    opacity: 0.5;
+    pointer-events: none;
+    cursor: not-allowed;
+}
+
+/**
 * Common Widget Styling
 */  
 .nrdb-ui-widget {

--- a/ui/src/widgets/index.mjs
+++ b/ui/src/widgets/index.mjs
@@ -1,5 +1,6 @@
 import UIButton from './ui-button/UIButton.vue'
 import UIChart from './ui-chart/UIChart.vue'
+import UIControl from './ui-control/UIControl.vue'
 import UIDropdown from './ui-dropdown/UIDropdown.vue'
 import UIEvent from './ui-event/UIEvent.vue'
 import UIForm from './ui-form/UIForm.vue'
@@ -17,6 +18,7 @@ import UITextInput from './ui-text-input/UITextInput.vue'
 export {
     UIButton,
     UIChart,
+    UIControl,
     UIDropdown,
     UIEvent,
     UIForm,
@@ -38,6 +40,7 @@ export { useDataTracker } from './data-tracker.mjs'
 export default {
     'ui-button': UIButton,
     'ui-chart': UIChart,
+    'ui-control': UIControl,
     'ui-dropdown': UIDropdown,
     'ui-event': UIEvent,
     'ui-form': UIForm,

--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -22,7 +22,6 @@ export default {
     },
     methods: {
         action ($evt) {
-            console.log('button clicked', $evt)
             const evt = {
                 type: $evt.type,
                 clientX: $evt.clientX,

--- a/ui/src/widgets/ui-control/UIControl.vue
+++ b/ui/src/widgets/ui-control/UIControl.vue
@@ -1,5 +1,5 @@
 <script>
-import { mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 
 export default {
     name: 'DBUIControl',
@@ -15,18 +15,46 @@ export default {
     },
     computed: {
         ...mapState('data', ['messages']),
-        ...mapState('ui', ['groups', 'widgets'])
+        ...mapState('ui', ['groups', 'widgets']),
+        ...mapGetters('ui', ['findBy'])
     },
     mounted () {
         // listen for messages
         this.$socket.on('ui-control', (msg) => {
-            if ('tab' in msg || 'page' in msg) {
+            if ('page' in msg) {
                 const page = msg.page || msg.tab
                 // navigate to the tab/page
                 try {
                     this.$router.push({ name: `Page:${page}` })
                 } catch (err) {
+                    console.error(err)
+                }
+            }
 
+            if ('pages' in msg) {
+                if ('show' in msg.pages) {
+                    // we are setting visibility: true
+                    msg.pages.show.forEach((pageName) => {
+                        const p = this.findBy('page', 'name', pageName)
+                        this.$store.commit('ui/setProperty', {
+                            item: 'page',
+                            itemId: p.id,
+                            property: 'visible',
+                            value: true
+                        })
+                    })
+                }
+                if ('hide' in msg.pages) {
+                    // we are setting visibility: false
+                    msg.pages.hide.forEach((pageName) => {
+                        const p = this.findBy('page', 'name', pageName)
+                        this.$store.commit('ui/setProperty', {
+                            item: 'page',
+                            itemId: p.id,
+                            property: 'visible',
+                            value: false
+                        })
+                    })
                 }
             }
         })

--- a/ui/src/widgets/ui-control/UIControl.vue
+++ b/ui/src/widgets/ui-control/UIControl.vue
@@ -19,8 +19,19 @@ export default {
         ...mapGetters('ui', ['findBy'])
     },
     mounted () {
+        const vue = this
         // listen for messages
         this.$socket.on('ui-control', (msg) => {
+            function set (type, name, prop, value) {
+                const item = vue.findBy(type, 'name', name)
+                vue.$store.commit('ui/setProperty', {
+                    item: type,
+                    itemId: item.id,
+                    property: prop,
+                    value
+                })
+            }
+
             if ('page' in msg) {
                 const page = msg.page || msg.tab
                 // navigate to the tab/page
@@ -34,50 +45,26 @@ export default {
             if ('pages' in msg) {
                 if ('show' in msg.pages) {
                     // we are setting visibility: true
-                    msg.pages.show.forEach((pageName) => {
-                        const p = this.findBy('page', 'name', pageName)
-                        this.$store.commit('ui/setProperty', {
-                            item: 'page',
-                            itemId: p.id,
-                            property: 'visible',
-                            value: true
-                        })
+                    msg.pages.show.forEach((name) => {
+                        set('page', name, 'visible', true)
                     })
                 }
                 if ('hide' in msg.pages) {
                     // we are setting visibility: false
                     msg.pages.hide.forEach((pageName) => {
-                        const p = this.findBy('page', 'name', pageName)
-                        this.$store.commit('ui/setProperty', {
-                            item: 'page',
-                            itemId: p.id,
-                            property: 'visible',
-                            value: false
-                        })
+                        set('page', name, 'visible', false)
                     })
                 }
                 if ('disable' in msg.pages) {
                     // we are setting visibility: true
-                    msg.pages.disable.forEach((pageName) => {
-                        const p = this.findBy('page', 'name', pageName)
-                        this.$store.commit('ui/setProperty', {
-                            item: 'page',
-                            itemId: p.id,
-                            property: 'disabled',
-                            value: true
-                        })
+                    msg.pages.disable.forEach((name) => {
+                        set('page', name, 'disabled', true)
                     })
                 }
                 if ('enable' in msg.pages) {
                     // we are setting visibility: false
-                    msg.pages.enable.forEach((pageName) => {
-                        const p = this.findBy('page', 'name', pageName)
-                        this.$store.commit('ui/setProperty', {
-                            item: 'page',
-                            itemId: p.id,
-                            property: 'disabled',
-                            value: false
-                        })
+                    msg.pages.enable.forEach((name) => {
+                        set('page', name, 'disabled', false)
                     })
                 }
             }
@@ -85,26 +72,26 @@ export default {
             if ('groups' in msg) {
                 if ('show' in msg.groups) {
                     // we are setting visibility: true
-                    msg.groups.show.forEach((groupName) => {
-                        const g = this.findBy('group', 'name', groupName)
-                        this.$store.commit('ui/setProperty', {
-                            item: 'group',
-                            itemId: g.id,
-                            property: 'visible',
-                            value: true
-                        })
+                    msg.groups.show.forEach((name) => {
+                        set('group', name, 'visible', true)
                     })
                 }
                 if ('hide' in msg.groups) {
                     // we are setting visibility: false
-                    msg.groups.hide.forEach((groupName) => {
-                        const g = this.findBy('group', 'name', groupName)
-                        this.$store.commit('ui/setProperty', {
-                            item: 'group',
-                            itemId: g.id,
-                            property: 'visible',
-                            value: false
-                        })
+                    msg.groups.hide.forEach((name) => {
+                        set('group', name, 'visible', false)
+                    })
+                }
+                if ('disable' in msg.groups) {
+                    // we are setting visibility: true
+                    msg.groups.disable.forEach((name) => {
+                        set('group', name, 'disabled', true)
+                    })
+                }
+                if ('enable' in msg.groups) {
+                    // we are setting visibility: false
+                    msg.groups.enable.forEach((name) => {
+                        set('group', name, 'disabled', false)
                     })
                 }
             }

--- a/ui/src/widgets/ui-control/UIControl.vue
+++ b/ui/src/widgets/ui-control/UIControl.vue
@@ -1,0 +1,38 @@
+<script>
+import { mapState } from 'vuex'
+
+export default {
+    name: 'DBUIControl',
+    inject: ['$socket'],
+    props: {
+        id: { type: String, required: true },
+        props: { type: Object, default: () => ({}) }
+    },
+    data () {
+        return {
+
+        }
+    },
+    computed: {
+        ...mapState('data', ['messages']),
+        ...mapState('ui', ['groups', 'widgets'])
+    },
+    mounted () {
+        // listen for messages
+        this.$socket.on('ui-control', (msg) => {
+            if ('tab' in msg || 'page' in msg) {
+                const page = msg.page || msg.tab
+                // navigate to the tab/page
+                try {
+                    this.$router.push({ name: `Page:${page}` })
+                } catch (err) {
+
+                }
+            }
+        })
+    },
+    unmounted () {
+        this.$socket.off('ui-control')
+    }
+}
+</script>

--- a/ui/src/widgets/ui-control/UIControl.vue
+++ b/ui/src/widgets/ui-control/UIControl.vue
@@ -57,6 +57,33 @@ export default {
                     })
                 }
             }
+
+            if ('groups' in msg) {
+                if ('show' in msg.groups) {
+                    // we are setting visibility: true
+                    msg.groups.show.forEach((groupName) => {
+                        const g = this.findBy('group', 'name', groupName)
+                        this.$store.commit('ui/setProperty', {
+                            item: 'group',
+                            itemId: g.id,
+                            property: 'visible',
+                            value: true
+                        })
+                    })
+                }
+                if ('hide' in msg.groups) {
+                    // we are setting visibility: false
+                    msg.groups.hide.forEach((groupName) => {
+                        const g = this.findBy('group', 'name', groupName)
+                        this.$store.commit('ui/setProperty', {
+                            item: 'group',
+                            itemId: g.id,
+                            property: 'visible',
+                            value: false
+                        })
+                    })
+                }
+            }
         })
     },
     unmounted () {

--- a/ui/src/widgets/ui-control/UIControl.vue
+++ b/ui/src/widgets/ui-control/UIControl.vue
@@ -56,6 +56,30 @@ export default {
                         })
                     })
                 }
+                if ('disable' in msg.pages) {
+                    // we are setting visibility: true
+                    msg.pages.disable.forEach((pageName) => {
+                        const p = this.findBy('page', 'name', pageName)
+                        this.$store.commit('ui/setProperty', {
+                            item: 'page',
+                            itemId: p.id,
+                            property: 'disabled',
+                            value: true
+                        })
+                    })
+                }
+                if ('enable' in msg.pages) {
+                    // we are setting visibility: false
+                    msg.pages.enable.forEach((pageName) => {
+                        const p = this.findBy('page', 'name', pageName)
+                        this.$store.commit('ui/setProperty', {
+                            item: 'page',
+                            itemId: p.id,
+                            property: 'disabled',
+                            value: false
+                        })
+                    })
+                }
             }
 
             if ('groups' in msg) {

--- a/ui/src/widgets/ui-control/UIControl.vue
+++ b/ui/src/widgets/ui-control/UIControl.vue
@@ -15,13 +15,13 @@ export default {
     },
     computed: {
         ...mapState('data', ['messages']),
-        ...mapState('ui', ['groups', 'widgets']),
+        ...mapState('ui', ['pages', 'groups', 'widgets']),
         ...mapGetters('ui', ['findBy'])
     },
     mounted () {
         const vue = this
         // listen for messages
-        this.$socket.on('ui-control', (msg) => {
+        this.$socket.on('ui-control:' + this.id, (msg) => {
             function set (type, name, prop, value) {
                 const item = vue.findBy(type, 'name', name)
                 vue.$store.commit('ui/setProperty', {
@@ -33,7 +33,66 @@ export default {
             }
 
             if ('page' in msg) {
-                const page = msg.page || msg.tab
+                let page = msg.tab || msg.page
+                const pages = Object.values(this.pages).sort((a, b) => {
+                    return a.order - b.order
+                })
+                if (typeof page === 'number') {
+                    // we have a number, which should link to an index of the page, i.e. 0 = first page, etc.
+                    if (page < 0 || page > pages.length - 1) {
+                        // out of range
+                        console.error('ui-control: page index out of range')
+                        return
+                    } else {
+                        // navigate to the tab/page
+                        try {
+                            this.$router.push({ name: `Page:${pages[page].name}` })
+                        } catch (err) {
+                            console.error(err)
+                        }
+                    }
+                } else if (typeof page === 'string') {
+                    // get current index of existing page
+                    const index = pages.findIndex((p) => {
+                        return p.id === this.$route.meta.id
+                    })
+                    // we have a string, which should link to a page name
+                    if (page === '') {
+                        // refresh the current view
+                        this.$router.go()
+                        return
+                    } else {
+                        if (page === '+1') {
+                            // get next page
+                            if (pages.length === index + 1) {
+                                // we are on the last page, so go to the first page
+                                page = pages[0].name
+                            } else {
+                                // we are not on the last page, so go to the next page
+                                page = pages[index + 1].name
+                            }
+                        } else if (page === '-1') {
+                            // get next page
+                            if (index === 0) {
+                                // we are on the last page, so go to the first page
+                                page = pages[pages.length - 1].name
+                            } else {
+                                // we are not on the last page, so go to the next page
+                                page = pages[index - 1].name
+                            }
+                        }
+                        // navigate to the tab/page
+                        try {
+                            this.$router.push({ name: `Page:${page}` })
+                        } catch (err) {
+                            console.error(err)
+                        }
+                    }
+                } else {
+                    // we don't support any other types
+                    console.error('ui-control: page must be a string or number')
+                    return
+                }
                 // navigate to the tab/page
                 try {
                     this.$router.push({ name: `Page:${page}` })

--- a/ui/src/widgets/ui-event/UIEvent.vue
+++ b/ui/src/widgets/ui-event/UIEvent.vue
@@ -5,12 +5,6 @@ import { useDataTracker } from '../data-tracker.mjs' // eslint-disable-line impo
 export default {
     name: 'DBUIEvent',
     inject: ['$socket'],
-    beforeRouteUpdate (to, from) {
-        this.pageview(to)
-    },
-    beforeRouteLeave (to, from) {
-        this.pageleave(from)
-    },
     props: {
         id: { type: String, required: true },
         props: { type: Object, default: () => ({}) }
@@ -22,6 +16,19 @@ export default {
     },
     computed: {
         ...mapState('ui', ['pages'])
+    },
+    watch: {
+        '$route.meta.id': {
+            handler (val, oldVal) {
+                // this only fire if we switch between two pages of the same layout type,
+                // the full component isn't torn down, so we can watch for changes
+                const oldMsg = this.createPayload(this.pages[oldVal])
+                this.$socket.emit('ui-event', this.id, '$pageleave', oldMsg)
+
+                const newMsg = this.createPayload(this.pages[val])
+                this.$socket.emit('ui-event', this.id, '$peageview', newMsg)
+            }
+        }
     },
     created () {
         // can't do this in setup as we have custom onInput function
@@ -40,15 +47,18 @@ export default {
             this.trigger('$pageleave')
         },
         trigger (evt) {
-            const page = { ...this.page }
+            const msg = this.createPayload(this.page)
+            this.$socket.emit('ui-event', this.id, evt, msg)
+        },
+        createPayload (page) {
+            page = { ...page }
             // re-map _users > _groups for better data readability
             page._groups = page._users
             delete page._users
             // form event data object
-            const msg = {
+            return {
                 page
             }
-            this.$socket.emit('ui-event', evt, msg)
         }
     }
 }

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -81,7 +81,6 @@ export default {
             if (row.required) {
                 // is required
                 return [(v) => {
-                    console.log('v', v)
                     return !!v || row.label + ' is required'
                 }]
             } else {

--- a/ui/src/widgets/ui-table/UITable.vue
+++ b/ui/src/widgets/ui-table/UITable.vue
@@ -132,9 +132,6 @@ export default {
 </script>
 
 <style scoped>
-.nrdb-table {
-
-}
 .nrdb-table-nodata {
     text-align: center;
 }

--- a/ui/src/widgets/ui-table/UITable.vue
+++ b/ui/src/widgets/ui-table/UITable.vue
@@ -115,14 +115,12 @@ export default {
     },
     methods: {
         calculatePaginatedRows () {
-            console.log('calculatePaginatedRows', this.pagination.page, this.props.maxrows)
             if (this.props.maxrows > 0) {
                 this.pagination.pages = Math.ceil(this.rows?.length / this.props.maxrows)
                 this.pagination.rows = this.rows?.slice(
                     (this.pagination.page - 1) * this.props.maxrows,
                     (this.pagination.page) * this.props.maxrows
                 )
-                console.log('updated', this.pagination.pages, this.pagination.rows)
             } else {
                 this.pagination.page = 1
                 this.pagination.pages = 0


### PR DESCRIPTION
## Description

- Backfills Dashboard 1.0's `ui-control` node.
- Allows for:
    - Control of page navigation
    - Hide/show of pages and groups
    - Disable/enable of pages and groups

## Related Issue(s)

Closes #258 

Opened https://github.com/FlowFuse/node-red-dashboard/issues/406 to cover the open/collapse of group events, which currently is supported in 2.0

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

