### PR TITLE
Use Node-RED CSS vars

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -69,8 +69,8 @@
         cursor: pointer;
     }
     .nrdb2-sb-list-header.nrdb2-sb-pages-list-header {
-        border-top: 1px solid var(--ff-grey-200);
-        border-bottom: 1px solid var(--ff-grey-200);
+        border-top: 1px solid var(--red-ui-primary-border-color, --ff-grey-200);
+        border-bottom: 1px solid var(--red-ui-primary-border-color, --ff-grey-200);
     }
     .nrdb2-sb-list-header .nrdb2-sb-title {
         text-overflow: ellipsis;
@@ -89,7 +89,7 @@
         transition: 0.15s opacity;
     }
     .nrdb2-sb-list-header:hover {
-        background-color: var(--ff-grey-100);
+        background-color: var(--red-ui-secondary-background-hover, --ff-grey-100);
     }
     .nrdb2-sb-list-header:hover .nrdb2-sb-list-handle, 
     .nrdb2-sb-list-header:hover .nrdb2-sb-list-header-button-group {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Replicating the changes made in https://github.com/node-red/node-red-dashboard/pull/763, this PR changes `ui_base.html` to use Node-RED's CSS vars with a fallback to their current values.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

