### PR TITLE
Remove assumption that "dependencies" exists in Node-RED package.json

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -69,8 +69,8 @@ module.exports = function (RED) {
                 node.log('Cannot import third party widgets. No access to Node-RED package.json')
             }
 
-            if (packageJson) {
-                Object.entries(packageJson.dependencies).filter(([packageName, _packageVersion]) => {
+            if (packageJson && packageJson.dependencies) {
+                Object.entries(packageJson.dependencies)?.filter(([packageName, _packageVersion]) => {
                     return packageName.includes('node-red-dashboard-2-')
                 }).map(([packageName, _packageVersion]) => {
                     const modulePath = path.join(RED.settings.userDir, 'node_modules', packageName)


### PR DESCRIPTION
## Description

- Dashboard crashes if Node-RED in a completely clean install of NR
- I had assumed `dependencies` would always be there, given that Dashboard itself is a dependency, but it appears I was wrong in that assumption

## Related Issue

I _believe_ this is the fix for https://github.com/FlowFuse/node-red-dashboard/issues/373 too

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)