### PR TITLE
Reference issue re: full msg not sending in this.send() for ui-template

### DIFF
--- a/docs/nodes/widgets/ui-template.md
+++ b/docs/nodes/widgets/ui-template.md
@@ -43,7 +43,7 @@ You have access to a number of built-in variables in your `ui-template` node:
 
 We also offer some helper functions for the Node-RED integration too:
 
-- `this.send` - Send a message to the Node-RED flow.
+- `this.send` - Send a message to the Node-RED flow. Currently limited to sending msg.payload only - [Issue #427](https://github.com/FlowFuse/node-red-dashboard/issues/427)
 - `this.$socket.on('msg-input' + this.id, (msg) = { ... })` - will listen to any messages received by your `ui-template `node and react accordingly.
 
 ### Example (Raw JavaScript)


### PR DESCRIPTION
## Description

- Adds a reference to #427 in the docs to prevent users getting stuck

## Related Issue(s)

https://github.com/FlowFuse/node-red-dashboard/issues/427#issuecomment-1852326331
