### PR TITLE
Add app-bar-actions section to main navigation

### DIFF
--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -13,6 +13,9 @@
                 <v-app-bar-nav-icon @click="drawer = !drawer" />
             </template>
             <v-app-bar-title>{{ pageTitle }}</v-app-bar-title>
+            <template #append>
+                <div id="app-bar-actions" />
+            </template>
         </v-app-bar>
 
         <v-main>


### PR DESCRIPTION
## Description

Adds a section in the `v-app-bar` such that a user can use a Vue Teleport to inject content form a `ui-template`:

```
<Teleport to="#app-bar-actions">
    Test in Action Bar
</Teleport>
```

## Related Issue(s)

This becomes more useful if we implement #440 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)