### PR TITLE
UI Text Input - Fix onBlur

### DIFF
--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -26,7 +26,12 @@
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
                 topicType: { value: 'msg' },
                 mode: { value: 'text', required: true },
-                delay: { value: 300, validate: function (v) { return $('#node-input-sendOnDelay').is(':checked') ? RED.validators.number()(v) : true } },
+                delay: {
+                    value: 300,
+                    validate: function (v) {
+                        return $('#node-input-sendOnDelay').is(':checked') ? RED.validators.number()(v) : true
+                    }
+                },
                 passthru: { value: true },
                 sendOnDelay: { value: false },
                 sendOnBlur: { value: true },
@@ -66,21 +71,6 @@
                         $('#node-input-container-sendOnEnter').hide()
                     } else {
                         $('#node-input-container-sendOnEnter').show()
-                    }
-                })
-
-                $('#node-input-delay').on('change', (evt) => {
-                    const delay = $('#node-input-delay').val()
-                    if (delay === '' || delay === '0') {
-                        this.sendOnDelay = false
-                        if ($('#node-input-sendOnDelay').is(':checked')) {
-                            $('#node-input-sendOnDelay').click()
-                        }
-                    } else {
-                        this.sendOnDelay = true
-                        if (!$('#node-input-sendOnDelay').is(':checked')) {
-                            $('#node-input-sendOnDelay').click()
-                        }
                     }
                 })
             },

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -64,6 +64,7 @@ export default {
     methods: {
         send: function () {
             this.$socket.emit('widget-change', this.id, this.value)
+            this.lastSent = this.value
         },
         onChange: function () {
             if (this.props.sendOnDelay) {
@@ -76,11 +77,9 @@ export default {
             }
         },
         onBlur: function () {
-            console.log('onBlur', this.lastSent, this.value)
-            if (this.props.sendOnBlur && this.lastSent !== this.value) {
+            if (this.props.sendOnBlur && this.lastSent !== this.value && this.value) {
                 // check if this value has already been sent, as not going to want it sent twice
                 this.send()
-                this.lastSent = this.value
             }
         },
         onEnter: function () {

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -66,7 +66,6 @@ export default {
             this.$socket.emit('widget-change', this.id, this.value)
         },
         onChange: function () {
-            this.lastSent = this.value
             if (this.props.sendOnDelay) {
                 // is send on delay enabled, if so, set a timeout to send the message
                 if (this.delayTimer) {
@@ -77,9 +76,11 @@ export default {
             }
         },
         onBlur: function () {
+            console.log('onBlur', this.lastSent, this.value)
             if (this.props.sendOnBlur && this.lastSent !== this.value) {
                 // check if this value has already been sent, as not going to want it sent twice
                 this.send()
+                this.lastSent = this.value
             }
         },
         onEnter: function () {


### PR DESCRIPTION
## Description

- Remove "smart" logic to try and workout if user accidentally left onDelay ticked/unticked
- Fix the onBlur logic so that the `lastSent` value only updates _on send_

## Related Issue(s)

Closes #442 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

