### PR TITLE
UI Switch - Check msg.payload against on/off values, not just isTruthy()

### DIFF
--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -59,9 +59,9 @@ module.exports = function (RED) {
                     datastore.save(node.id, msg)
 
                     node.status({
-                        fill: msg.payload === on ? 'green' : 'red',
+                        fill: (msg.payload === true || msg.payload === on) ? 'green' : 'red',
                         shape: 'ring',
-                        text: msg.payload === on ? states[1] : states[0]
+                        text: (msg.payload === true || msg.payload === on) ? states[1] : states[0]
                     })
 
                     if (config.passthru) {

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -59,9 +59,9 @@ module.exports = function (RED) {
                     datastore.save(node.id, msg)
 
                     node.status({
-                        fill: msg.payload ? 'green' : 'red',
+                        fill: msg.payload === on ? 'green' : 'red',
                         shape: 'ring',
-                        text: msg.payload ? states[1] : states[0]
+                        text: msg.payload === on ? states[1] : states[0]
                     })
 
                     if (config.passthru) {


### PR DESCRIPTION
## Description

When `ui-switch` received an input, we checked the `msg.payload`, and if `true`, shows the "on" status, if `false`, shows the "off" status, this was fine if the user explicitly sent `true`/`false` values (which is supported, however, we also claim that you can send the defined on/off value, where this then breaks, as the `msg.payload ? "on" : "off"` check _always_ results in a truthy value, as it's always equal to _something_.

This PR fixes that check to account for the two scenarios:

 - User has sent a `msg.payload` of `true`/`false`
 - User has sent a payload that matches the values defined in the `ui-switch` configuration.

## Related Issue(s)

Closes #311 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)