### PR TITLE
UI Base: Account for upgrade path meaning no defaults set for new properties

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -45,9 +45,19 @@ module.exports = function (RED) {
     function init (node, config) {
         node.uiShared = uiShared // ensure we have a uiShared object on the node (for testing mainly)
 
+        if (!config.acceptsClientConfig) {
+            // for those upgrading, we need this for backwards compatibility
+            config.acceptsClientConfig = ['ui-control', 'ui-notification']
+        }
+
+        if (!('includeClientData' in config)) {
+            // for those upgrading, we need this for backwards compatibility
+            config.includeClientData = true
+        }
+
         // expose these properties at runtime
-        node.acceptsClientConfig = config.acceptsClientConfig || [] // which node types can be scoped to a specific client
-        node.includeClientData = config.includeClientData || false // whether to include client data in msg payloads
+        node.acceptsClientConfig = config.acceptsClientConfig // which node types can be scoped to a specific client
+        node.includeClientData = config.includeClientData // whether to include client data in msg payloads
 
         // eventually check if we have routes used, so we can support multiple base UIs
         if (!uiShared.app) {
@@ -275,7 +285,7 @@ module.exports = function (RED) {
          */
         function emit (event, msg, wNode) {
             Object.values(uiShared.connections).forEach(conn => {
-                const nodeAllowsConstraints = n.acceptsClientConfig.includes(wNode.type)
+                const nodeAllowsConstraints = n.acceptsClientConfig?.includes(wNode.type)
                 if ((nodeAllowsConstraints && isValidConnection(conn, msg)) || !nodeAllowsConstraints) {
                     conn.emit(event, msg)
                 }


### PR DESCRIPTION
## Description

Under the covers with the [Plugin work](https://github.com/FlowFuse/node-red-dashboard/pull/438) we introduced two new properties to `ui-base`, but nether of them have editable configuration at the NR Editor level - as such, when upgrading versions of Dashboard 2.0, these properties do not get set, and are then undefined when running Dashboard.

This PR sets defaults for those properties _if_ they do not exist at the point of deploy/restart of Node-RED. This path will only occur for those upgrading from < 0.11.0 to 0.11.0, and using an already created `ui-base`.

First noticed/raised here: https://discourse.nodered.org/t/dashboard-2-beta-development/83550/122?u=joepavitt

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)