### PR TITLE
More robust handling of scoped .socket message emissions

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -285,7 +285,7 @@ module.exports = function (RED) {
          */
         function emit (event, msg, wNode) {
             Object.values(uiShared.connections).forEach(conn => {
-                const nodeAllowsConstraints = n.acceptsClientConfig?.includes(wNode.type)
+                const nodeAllowsConstraints = wNode ? n.acceptsClientConfig?.includes(wNode.type) : true
                 if ((nodeAllowsConstraints && isValidConnection(conn, msg)) || !nodeAllowsConstraints) {
                     conn.emit(event, msg)
                 }
@@ -314,7 +314,7 @@ module.exports = function (RED) {
                 checks.push(msg._client?.socketId === conn.id)
             }
             // if ANY check says this is valid - we send the msg
-            return checks.includes(true)
+            return !checks.length || checks.includes(true)
         }
 
         /**

--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -19,7 +19,7 @@ module.exports = function (RED) {
         }
 
         function emit (payload) {
-            ui.emit('ui-control:' + node.id, payload)
+            ui.emit('ui-control:' + node.id, payload, node)
         }
 
         const evts = {


### PR DESCRIPTION
## Description

- Had a very tight constraints introduced in `0.11.0` which required `msg._client.socketid` _or_ a plugin, however, default state includes neither for a `ui-control`, and so should be by-passable if none exist.

## Related Issue(s)

Closes #462 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)