### PR TITLE
Bump vue dependency to 3.4.5 to get rid of internal vue errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@flowfuse/node-red-dashboard",
-    "version": "0.10.2",
+    "version": "0.11.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@flowfuse/node-red-dashboard",
-            "version": "0.10.2",
+            "version": "0.11.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "acorn": "^8.11.2",
@@ -15,7 +15,7 @@
                 "escodegen": "^2.1.0",
                 "express": "^4.18.2",
                 "socket.io": "^4.7.1",
-                "vue": "^3.3.4"
+                "vue": "^3.4.5"
             },
             "devDependencies": {
                 "@mdi/font": "~6.9.96",
@@ -277,9 +277,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
-            "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+            "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1893,49 +1893,60 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.8.tgz",
-            "integrity": "sha512-hN/NNBUECw8SusQvDSqqcVv6gWq8L6iAktUR0UF3vGu2OhzRqcOiAno0FmBJWwxhYEXRlQJT5XnoKsVq1WZx4g==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.5.tgz",
+            "integrity": "sha512-Daka7P1z2AgKjzuueWXhwzIsKu0NkLB6vGbNVEV2iJ8GJTrzraZo/Sk4GWCMRtd/qVi3zwnk+Owbd/xSZbwHtQ==",
             "dependencies": {
-                "@babel/parser": "^7.23.0",
-                "@vue/shared": "3.3.8",
+                "@babel/parser": "^7.23.6",
+                "@vue/shared": "3.4.5",
+                "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.0.2"
             }
         },
+        "node_modules/@vue/compiler-core/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.8.tgz",
-            "integrity": "sha512-+PPtv+p/nWDd0AvJu3w8HS0RIm/C6VGBIRe24b9hSyNWOAPEUosFZ5diwawwP8ip5sJ8n0Pe87TNNNHnvjs0FQ==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.5.tgz",
+            "integrity": "sha512-J8YlxknJVd90SXFJ4HwGANSAXsx5I0lK30sO/zvYV7s5gXf7gZR7r/1BmZ2ju7RGH1lnc6bpBc6nL61yW+PsAQ==",
             "dependencies": {
-                "@vue/compiler-core": "3.3.8",
-                "@vue/shared": "3.3.8"
+                "@vue/compiler-core": "3.4.5",
+                "@vue/shared": "3.4.5"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.8.tgz",
-            "integrity": "sha512-WMzbUrlTjfYF8joyT84HfwwXo+8WPALuPxhy+BZ6R4Aafls+jDBnSz8PDz60uFhuqFbl3HxRfxvDzrUf3THwpA==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.5.tgz",
+            "integrity": "sha512-jauvkDuSSUbP0ebhfNqljhShA90YEfX/0wZ+w40oZF43IjGyWYjqYaJbvMJwGOd+9+vODW6eSvnk28f0SGV7OQ==",
             "dependencies": {
-                "@babel/parser": "^7.23.0",
-                "@vue/compiler-core": "3.3.8",
-                "@vue/compiler-dom": "3.3.8",
-                "@vue/compiler-ssr": "3.3.8",
-                "@vue/reactivity-transform": "3.3.8",
-                "@vue/shared": "3.3.8",
+                "@babel/parser": "^7.23.6",
+                "@vue/compiler-core": "3.4.5",
+                "@vue/compiler-dom": "3.4.5",
+                "@vue/compiler-ssr": "3.4.5",
+                "@vue/shared": "3.4.5",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.5",
-                "postcss": "^8.4.31",
+                "postcss": "^8.4.32",
                 "source-map-js": "^1.0.2"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.8.tgz",
-            "integrity": "sha512-hXCqQL/15kMVDBuoBYpUnSYT8doDNwsjvm3jTefnXr+ytn294ySnT8NlsFHmTgKNjwpuFy7XVV8yTeLtNl/P6w==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.5.tgz",
+            "integrity": "sha512-DDdEcDzj2lWTMfUMMtEpLDhURai9LhM0zSZ219jCt7b2Vyl0/jy3keFgCPMitG0V1S1YG4Cmws3lWHWdxHQOpg==",
             "dependencies": {
-                "@vue/compiler-dom": "3.3.8",
-                "@vue/shared": "3.3.8"
+                "@vue/compiler-dom": "3.4.5",
+                "@vue/shared": "3.4.5"
             }
         },
         "node_modules/@vue/devtools-api": {
@@ -1945,60 +1956,48 @@
             "dev": true
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.8.tgz",
-            "integrity": "sha512-ctLWitmFBu6mtddPyOKpHg8+5ahouoTCRtmAHZAXmolDtuZXfjL2T3OJ6DL6ezBPQB1SmMnpzjiWjCiMYmpIuw==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.5.tgz",
+            "integrity": "sha512-BcWkKvjdvqJwb7BhhFkXPLDCecX4d4a6GATvCduJQDLv21PkPowAE5GKuIE5p6RC07/Lp9FMkkq4AYCTVF5KlQ==",
             "dependencies": {
-                "@vue/shared": "3.3.8"
-            }
-        },
-        "node_modules/@vue/reactivity-transform": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.8.tgz",
-            "integrity": "sha512-49CvBzmZNtcHua0XJ7GdGifM8GOXoUMOX4dD40Y5DxI3R8OUhMlvf2nvgUAcPxaXiV5MQQ1Nwy09ADpnLQUqRw==",
-            "dependencies": {
-                "@babel/parser": "^7.23.0",
-                "@vue/compiler-core": "3.3.8",
-                "@vue/shared": "3.3.8",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.5"
+                "@vue/shared": "3.4.5"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.8.tgz",
-            "integrity": "sha512-qurzOlb6q26KWQ/8IShHkMDOuJkQnQcTIp1sdP4I9MbCf9FJeGVRXJFr2mF+6bXh/3Zjr9TDgURXrsCr9bfjUw==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.5.tgz",
+            "integrity": "sha512-wh9ELIOQKeWT9SaUPdLrsxRkZv14jp+SJm9aiQGWio+/MWNM3Lib0wE6CoKEqQ9+SCYyGjDBhTOTtO47kCgbkg==",
             "dependencies": {
-                "@vue/reactivity": "3.3.8",
-                "@vue/shared": "3.3.8"
+                "@vue/reactivity": "3.4.5",
+                "@vue/shared": "3.4.5"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.8.tgz",
-            "integrity": "sha512-Noy5yM5UIf9UeFoowBVgghyGGPIDPy1Qlqt0yVsUdAVbqI8eeMSsTqBtauaEoT2UFXUk5S64aWVNJN4MJ2vRdA==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.5.tgz",
+            "integrity": "sha512-n5ewvOjyG3IEpqGBahdPXODFSpVlSz3H4LF76Sx0XAqpIOqyJ5bIb2PrdYuH2ogBMAQPh+o5tnoH4nJpBr8U0Q==",
             "dependencies": {
-                "@vue/runtime-core": "3.3.8",
-                "@vue/shared": "3.3.8",
-                "csstype": "^3.1.2"
+                "@vue/runtime-core": "3.4.5",
+                "@vue/shared": "3.4.5",
+                "csstype": "^3.1.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.8.tgz",
-            "integrity": "sha512-zVCUw7RFskvPuNlPn/8xISbrf0zTWsTSdYTsUTN1ERGGZGVnRxM2QZ3x1OR32+vwkkCm0IW6HmJ49IsPm7ilLg==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.5.tgz",
+            "integrity": "sha512-jOFc/VE87yvifQpNju12VcqimH8pBLxdcT+t3xMeiED1K6DfH9SORyhFEoZlW5TG2Vwfn3Ul5KE+1aC99xnSBg==",
             "dependencies": {
-                "@vue/compiler-ssr": "3.3.8",
-                "@vue/shared": "3.3.8"
+                "@vue/compiler-ssr": "3.4.5",
+                "@vue/shared": "3.4.5"
             },
             "peerDependencies": {
-                "vue": "3.3.8"
+                "vue": "3.4.5"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.8.tgz",
-            "integrity": "sha512-8PGwybFwM4x8pcfgqEQFy70NaQxASvOC5DJwLQfpArw1UDfUXrJkdxD3BhVTMS+0Lef/TU7YO0Jvr0jJY8T+mw=="
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.5.tgz",
+            "integrity": "sha512-6XptuzlMvN4l4cDnDw36pdGEV+9njYkQ1ZE0Q6iZLwrKefKaOJyiFmcP3/KBDHbt72cJZGtllAc1GaHe6XGAyg=="
         },
         "node_modules/@vueuse/core": {
             "version": "10.6.1",
@@ -3280,9 +3279,9 @@
             }
         },
         "node_modules/csstype": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/cytoscape": {
             "version": "3.26.0",
@@ -10798,15 +10797,15 @@
             "dev": true
         },
         "node_modules/vue": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.8.tgz",
-            "integrity": "sha512-5VSX/3DabBikOXMsxzlW8JyfeLKlG9mzqnWgLQLty88vdZL7ZJgrdgBOmrArwxiLtmS+lNNpPcBYqrhE6TQW5w==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.5.tgz",
+            "integrity": "sha512-VH6nHFhLPjgu2oh5vEBXoNZxsGHuZNr3qf4PHClwJWw6IDqw6B3x+4J+ABdoZ0aJuT8Zi0zf3GpGlLQCrGWHrw==",
             "dependencies": {
-                "@vue/compiler-dom": "3.3.8",
-                "@vue/compiler-sfc": "3.3.8",
-                "@vue/runtime-dom": "3.3.8",
-                "@vue/server-renderer": "3.3.8",
-                "@vue/shared": "3.3.8"
+                "@vue/compiler-dom": "3.4.5",
+                "@vue/compiler-sfc": "3.4.5",
+                "@vue/runtime-dom": "3.4.5",
+                "@vue/server-renderer": "3.4.5",
+                "@vue/shared": "3.4.5"
             },
             "peerDependencies": {
                 "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "escodegen": "^2.1.0",
         "express": "^4.18.2",
         "socket.io": "^4.7.1",
-        "vue": "^3.3.4"
+        "vue": "^3.4.5"
     },
     "devDependencies": {
         "@mdi/font": "~6.9.96",

--- a/ui/src/widgets/ui-template/UITemplate.vue
+++ b/ui/src/widgets/ui-template/UITemplate.vue
@@ -128,19 +128,6 @@ export default {
                         }
                     ]
                 }
-                // future?
-                // if (_props.format && (_props.templateScope === 'page:script' || _props.templateScope === 'site:script')) {
-                //     setup.script = [{ textContent: _props.format, id: `${_props.name || _props.templateScope}-${_props.id}` }]
-                // }
-                // if (hasProperty(_props, 'script')) {
-                //     setup.script = [_props.head.script]
-                // }
-                // if (hasProperty(_props, 'meta')) {
-                //     setup.meta = [_props.head.meta]
-                // }
-                // if (hasProperty(_props, 'link')) {
-                //     setup.link = [_props.head.link]
-                // }
                 return setup
             },
             template: props.props.templateScope !== 'local' ? undefined : template,


### PR DESCRIPTION
## Description

Was hitting an error inside `ui-template` linked to a `<Teleport />` element, upgrading to VueJS `3.4.x` fixes the issue.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)