### PR TITLE
Improve deregistration lifecycle for ui-event and ui-control

### DIFF
--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -161,49 +161,13 @@ module.exports = function (RED) {
         // inform the dashboard UI that we are adding this node
         ui.register(null, null, node, config, evts)
 
-        // this.events = config.events || 'all'
-
-        // const sendconnect = function (id, ip) {
-        //     node.send({ payload: 'connect', socketid: id, socketip: ip })
-        // }
-
-        // const sendlost = function (id, ip) {
-        //     node.send({ payload: 'lost', socketid: id, socketip: ip })
-        // }
-
-        // const sendchange = function (index, name, id, ip, p) {
-        //     node.send({ payload: 'change', tab: index, name, socketid: id, socketip: ip, params: p })
-        // }
-
-        // const sendcollapse = function (group, state, id, ip) {
-        //     node.send({ payload: 'group', group, open: state, socketid: id, socketip: ip })
-        // }
-
-        // if (node.events === 'connect') {
-        //     ui.ev.on('newsocket', sendconnect)
-        // } else if (node.events === 'change') {
-        //     ui.ev.on('changetab', sendchange)
-        //     ui.ev.on('collapse', sendcollapse)
-        // } else {
-        //     ui.ev.on('newsocket', sendconnect)
-        //     ui.ev.on('changetab', sendchange)
-        //     ui.ev.on('collapse', sendcollapse)
-        //     ui.ev.on('endsocket', sendlost)
-        // }
-
-        // this.on('close', function () {
-        //     if (node.events === 'connect') {
-        //         ui.ev.removeListener('newsocket', sendconnect)
-        //     } else if (node.events === 'change') {
-        //         ui.ev.removeListener('changetab', sendchange)
-        //         ui.ev.removeListener('collapse', sendcollapse)
-        //     } else {
-        //         ui.ev.removeListener('newsocket', sendconnect)
-        //         ui.ev.removeListener('changetab', sendchange)
-        //         ui.ev.removeListener('collapse', sendcollapse)
-        //         ui.ev.removeListener('endsocket', sendlost)
-        //     }
-        // })
+        node.on('close', function (removed, done) {
+            if (removed) {
+                // handle node being removed
+                ui?.deregister(null, null, node)
+            }
+            done()
+        })
     }
     RED.nodes.registerType('ui-control', UiControlNode)
 }

--- a/nodes/widgets/ui_event.js
+++ b/nodes/widgets/ui_event.js
@@ -13,7 +13,11 @@ module.exports = function (RED) {
             onSocket: {
                 'ui-event': function (conn, id, evt, payload) {
                     const wNode = RED.nodes.getNode(node.id)
-                    if (id === node.id) {
+                    if (!wNode) {
+                        console.log('ui-event node not found', id)
+                    }
+                    if (wNode && id === node.id) {
+                        console.log('running ui-event handler', id)
                         // this was sent by this particular node
                         let msg = {
                             topic: evt,
@@ -27,7 +31,15 @@ module.exports = function (RED) {
         }
 
         // inform the dashboard UI that we are adding this node
-        ui.register(null, null, node, config, evts)
+        ui?.register(null, null, node, config, evts)
+
+        node.on('close', function (removed, done) {
+            if (removed) {
+                // handle node being removed
+                ui?.deregister(null, null, node)
+            }
+            done()
+        })
     }
     RED.nodes.registerType('ui-event', EventNode)
 }


### PR DESCRIPTION
## Description

- Improves the tear down lifecycle of the `ui-event` and `ui-control` by ensuring they're "deregistered" correctly when removed from the Editor.
- Adds logic into the `deregister` function that checks if there are any hooks that SocketIO can remove from it's listeners, given the widget/node being deregistered.

## Related Issue(s)

Fixes #463 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)