### PR TITLE
UI Switch - Handle on/off values that are Objects

### DIFF
--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -46,13 +46,25 @@ module.exports = function (RED) {
                 // retrieve the assigned on/off value
                 const on = RED.util.evaluateNodeProperty(config.onvalue, config.onvalueType, wNode)
                 const off = RED.util.evaluateNodeProperty(config.offvalue, config.offvalueType, wNode)
-                if (msg.payload === true || msg.payload === on) {
-                    msg.payload = on
-                } else if (msg.payload === false || msg.payload === off) {
-                    msg.payload = off
+
+                if (typeof msg.payload === 'object') {
+                    if (JSON.stringify(msg.payload) === JSON.stringify(on)) {
+                        msg.payload = on
+                    } else if (JSON.stringify(msg.payload) === JSON.stringify(off)) {
+                        msg.payload = off
+                    } else {
+                        // throw Node-RED error
+                        error = 'Invalid payload value'
+                    }
                 } else {
-                    // throw Node-RED error
-                    error = 'Invalid payload value'
+                    if (msg.payload === true || msg.payload === on) {
+                        msg.payload = on
+                    } else if (msg.payload === false || msg.payload === off) {
+                        msg.payload = off
+                    } else {
+                        // throw Node-RED error
+                        error = 'Invalid payload value'
+                    }
                 }
                 if (!error) {
                     // store the latest msg passed to node

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -44,6 +44,13 @@ export default {
                 const val = this.value
                 if (typeof (val) === 'boolean') {
                     return val
+                } else if (typeof (val) === 'object') {
+                    // don't make a decision either way, unless it matches, exactly, the defined on/off values
+                    if (JSON.stringify(val) === JSON.stringify(this.props.evaluated.on)) {
+                        return true
+                    } else if (JSON.stringify(val) === JSON.stringify(this.props.evaluated.off)) {
+                        return false
+                    }
                 } else if (this.props.evaluated) {
                     return val === this.props.evaluated.on
                 }


### PR DESCRIPTION
## Description

- We were just doing straight comparisons of the values from `msg.payload` and the `on`/`off` values set in the configuration. 
- Instead, I've now introduced, if the value is an object, then `JSON.stringify` both and compare their results.
- This does fall over if an object contains multiple properties that are not ordered the same, but for setting an on/off value, I wouldn't expect a rich object to be used for on/off values

## Related Issue(s)

Closes #458

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
