### PR TITLE
UI Template - Improved Page/UI Scope Definitions

### DIFF
--- a/docs/nodes/widgets/ui-template.md
+++ b/docs/nodes/widgets/ui-template.md
@@ -1,7 +1,7 @@
 ---
 props:
     Group: Defines which group of the UI Dashboard this widget will render in.
-    Scope: "Template nodes can be used  for 3 purposes/scopes: <ul><li><b>Widget:</b>A standard HTML/Vue widget rendered in a group in the Dashboard.</li><li><b>CSS (All Pages):</b>Define custom CSS classes/styling that applies to the entire Dashboard.</li><li><b>CSS (Single Page):</b>Define custom CSS classes/styling that applies just a single page of your Dashboard.</li></ul>"
+    Scope: "Template nodes can be used  for 3 purposes/scopes: <ul><li><b>Widget (Group-Scoped):</b>A standard HTML/Vue widget rendered in a group in the Dashboard.</li><li><b>Widget (Page-Scoped):</b>A HTML/Vue widget that will render on a page, outside of any existing groups. Note that these widgets will render after any Groups. An example use case for this would be if you wanted to have a fixed footer on a given page.</li><li><b>Widget (UI-Scoped):</b>A HTML/Vue widget rendered on every page of the Dashboard. Most commonly used in conjuction with <a href=\"#teleports\">Teleports</a></li><li><b>CSS (All Pages):</b>Define custom CSS classes/styling that applies to the entire Dashboard.</li><li><b>CSS (Single Page):</b>Define custom CSS classes/styling that applies just a single page of your Dashboard.</li></ul>"
     Class: Appends CSS classes to the widget
     Template: The content of the widget or CSS &lt;style&gt;. If using this for CSS, you do not need to include any &lt;style&gt; tags, as these will be automatically added.
 ---

--- a/nodes/widgets/ui_template.js
+++ b/nodes/widgets/ui_template.js
@@ -9,6 +9,17 @@ module.exports = function (RED) {
             onAction: true // TODO: think we need an onSend event for template nodes that matches up with a `widget-send` message
         }
 
+        if (config.templateScope === 'local') {
+            config.page = ''
+            config.ui = ''
+        } else if (config.templateScope === 'widget:page') {
+            config.ui = ''
+            config.group = ''
+        } else if (config.templateScope === 'widget:ui') {
+            config.page = ''
+            config.group = ''
+        }
+
         // which group are we rendering this widget
         if (config.group) {
             const group = RED.nodes.getNode(config.group)

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -111,7 +111,9 @@ export default {
         },
         uiWidgets: function () {
             // get widgets scoped to the UI, not a group/page
-            const widgets = Object.values(this.widgets).filter(w => Object.hasOwn(w.props, 'ui') && !!w.props.ui)
+            const widgets = Object.values(this.widgets).filter(w => {
+                return Object.hasOwn(w.props, 'ui') && !!w.props.ui && !w.props.group && !w.props.page
+            })
             return widgets
         }
     },

--- a/ui/src/store/ui.mjs
+++ b/ui/src/store/ui.mjs
@@ -42,7 +42,7 @@ const getters = {
         if (state.widgets) {
             const widgetsOnPage = Object.values(state.widgets).filter((w) => {
                 // return all widgets that belong to the specified group (so long as it is not a non-local scoped ui-template)
-                return w.props.page && w.props.page === pageId
+                return !w.props.group && w.props.page && w.props.page === pageId
             })
             return widgetsOnPage
         }


### PR DESCRIPTION
## Description

In https://github.com/FlowFuse/node-red-dashboard/pull/472 we introduced page-scoped and UI-scoped options for a `ui-template` node. This allowed for widgets to render at the UI-Level, or Page-Level, instead of being nested inside a Group.

This PR ensures that at runtime, we clear any `ui`, `page` or `group` data that is no longer required in older `ui-templates`. We had an issue whereby if a `ui-template` at some point was deployed as a Single Page CSS, or UI-wide CSS type, then it was given a `page` or `ui` value under the covers. This was then never cleared when changing between types, so, when adding in our new page/ui-scoped widgets, some older `ui-template` nodes still have `ui`/`page`/`group` attributes, even though they're no longer scoped accordingly.

I've also added in documentation for the different options, as that was missed in the #472 PR.

## Related Issue(s)

Fix #477

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

