### PR TITLE
UI Page & UI Group - Default Interaction & Visibility States

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -73,6 +73,7 @@ export default ({ mode }) => {
               items: [
                 { text: 'ui-base', link: '/nodes/config/ui-base' },
                 { text: 'ui-page', link: '/nodes/config/ui-page' },
+                { text: 'ui-group', link: '/nodes/config/ui-group' },
                 { text: 'ui-theme', link: '/nodes/config/ui-theme' }
               ]
             },

--- a/docs/nodes/config/ui-group.md
+++ b/docs/nodes/config/ui-group.md
@@ -1,0 +1,19 @@
+---
+props:
+    Name: Descrptive name for this group, will show in the Node-RED Editor and as a label in the Dashboard.
+    Page: The Page (<code>ui-page</code>) that this group will render on. 
+    Size: The width and height of the group. Height will always be reinforced by this value, the height is generally a <i>minimum</i> height, and will extend to dfit it's content.
+    Class: Any custom CSS classes you wish to add to the Group.
+    Default State: <ul><li><b>Visibility</b> - Defines the default visibility of this group.</li><li><b>Interactivity</b> - Controls whether the group and it's contents are disabled/enabledwhen the page is loaded.</li></ul><p>Both of these can be overridden by the user at runtime using a <code>ui-control</code> node.</p>
+---
+
+<script setup>
+</script>
+
+# Config: UI Group `ui-group`
+
+Each group is rendered within a `ui-page` as part of a [Layout](../../contributing/guides/layouts). Each layout will differ in how those groups are rendered, but fundamentally, a group is a collection of widgets, and generally has a label to categorise the contents of a single group.
+
+## Properties
+
+<PropsTable/>

--- a/docs/nodes/config/ui-page.md
+++ b/docs/nodes/config/ui-page.md
@@ -5,6 +5,7 @@ props:
     Icon: Which <a href="https://pictogrammers.com/library/mdi/">Material Designs Icon</a> to use for the page. No need to include the <code>mdi-</code> prefix.
     Theme: Which Dashboard 2.0 theme to use for this page. You can customise your own too.
     Layout: Which Layout Manager to render the widgets with
+    Default State: <ul><li><b>Visibility</b> - Defines the default visibility of this page in hte side navigation menu.</li><li><b>Interactivity</b> - Controls whether the item is disabled/enabled in the side navigation menu.</li></ul><p>Both of these can be overridden by the user at runtime using a <code>ui-control</code> node.</p>
 ---
 
 <script setup>

--- a/nodes/config/locales/en-US/ui_group.json
+++ b/nodes/config/locales/en-US/ui_group.json
@@ -8,7 +8,11 @@
             "group" : "Group",
             "unassigned" : "unassigned",
             "className": "Class",
-            "classNamePlaceholder": "Optional CSS class name(s) for widget"
+            "classNamePlaceholder": "Optional CSS class name(s) for widget",
+            "visible": "Visible",
+            "hidden": "Hidden",
+            "active": "Active",
+            "disabled": "Disabled"
         },
         "display-name" : "Display group name",
         "collapse-name" : "Allow group to be collapsed"

--- a/nodes/config/locales/en-US/ui_page.json
+++ b/nodes/config/locales/en-US/ui_page.json
@@ -1,0 +1,10 @@
+{
+    "ui-page" : {
+        "label": {
+            "visible": "Visible",
+            "hidden": "Hidden",
+            "active": "Active",
+            "disabled": "Disabled"
+        }
+    }
+}

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -97,8 +97,21 @@
         overflow: hidden;
         white-space: nowrap;
     }
-    .nrdb2-sb-list-header-button-group {
+    .nrdb2-sb-list-header-actions {
         position: absolute;
+        gap: 4px; 
+        right: 1rem;
+        display: flex;
+        gap: 4px;
+    }
+    .nrdb2-sb-list-header-actions a {
+        cursor: pointer;
+    }
+    .nrdb2-sb-list-header-state-options {
+        display: flex;
+        gap: 4px;
+    }
+    .nrdb2-sb-list-header-button-group {
         right: 1rem;
         display: flex;
         gap: 4px;
@@ -305,12 +318,12 @@
 
     /**
      * Add group of actions to the right-side of a row in the sidebar editable list.
-     * @param {Object} row - jQuery object to add this button group as a child element to
-     * @param {Object} row - The page/group/widget that these actions are bound to
+     * @param {Object} parent - jQuery object to add this button group as a child element to
+     * @param {Object} item - The page/group/widget that these actions are bound to
      */
-    function addRowActions (row, item) {
+    function addRowActions (parent, item) {
         const configNodes = ['ui-base', 'ui-page', 'ui-group']
-        const btnGroup = $('<div>', { class: 'nrdb2-sb-list-header-button-group', id: item.id }).appendTo(row)
+        const btnGroup = $('<div>', { class: 'nrdb2-sb-list-header-button-group', id: item.id }).appendTo(parent)
         if (!configNodes.includes(item.type)) {
             const focusButton = $('<a href="#" class="nr-db-sb-tab-focus-button editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-bullseye"></i> ' + c_('layout.focus') + '</a>').appendTo(btnGroup)
             focusButton.on('click', function (evt) {
@@ -331,6 +344,98 @@
         })
     }
 
+    /**
+     * Add group of actions to the right-side of a row in the sidebar editable list.
+     * @param {Object} parent - jQuery object to add this button group as a child element to
+     * @param {Object} item - The page/group/widget that these actions are bound to
+     */
+    function addRowStateOptions (parent, item) {
+        const nodes = ['ui-page', 'ui-group']
+
+        const btnGroup = $('<div>', { class: 'nrdb2-sb-list-header-state-options', id: item.id }).appendTo(parent)
+
+        if (nodes.includes(item.type)) {
+            const visibleIcon = (item.visible === 'false' || item.visible === false) ? 'fa-eye-slash' : 'fa-eye'
+            const visibleBtn = $('<a href="#" title="Hide" class="nr-db-sb-tab-visible-button editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa ' + visibleIcon + '"></i></a>').appendTo(btnGroup)
+            visibleBtn.on('click', function (evt) {
+                const events = []
+
+                evt.stopPropagation()
+                evt.preventDefault()
+
+                if (item.visible === 'true' || item.visible === true || item.visible === undefined) {
+                    // toggle to hidden
+                    item.visible = false
+                    $(this).prop('title', 'Show')
+                    $(this).find('i').addClass('fa-eye-slash').removeClass('fa-eye')
+                    events.push({
+                        t: 'edit',
+                        node: item,
+                        changes: {
+                            visible: true
+                        },
+                        dirty: item.dirty,
+                        changed: item.changed
+                    })
+                } else {
+                    // toggle to shown
+                    item.visible = true
+                    $(this).prop('title', 'Hide')
+                    $(this).find('i').addClass('fa-eye').removeClass('fa-eye-slash')
+                    events.push({
+                        t: 'edit',
+                        node: item,
+                        changes: {
+                            visible: false
+                        },
+                        dirty: item.dirty,
+                        changed: item.changed
+                    })
+                }
+                recordEvents(events)
+            })
+            const disabledIcon = (item.disabled === 'true' || item.disabled === true) ? 'fa-lock' : 'fa-unlock'
+            const disabledBtn = $('<a href="#" class="nr-db-sb-tab-visible-button editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa ' + disabledIcon + '"></i></a>').appendTo(btnGroup)
+            disabledBtn.on('click', function (evt) {
+                const events = []
+
+                evt.stopPropagation()
+                evt.preventDefault()
+
+                if (item.disabled === 'true' || item.disabled === true) {
+                    // toggle to hidden
+                    item.disabled = false
+                    $(this).prop('title', 'Disable')
+                    $(this).find('i').addClass('fa-unlock').removeClass('fa-lock')
+                    events.push({
+                        t: 'edit',
+                        node: item,
+                        changes: {
+                            disabled: true
+                        },
+                        dirty: item.dirty,
+                        changed: item.changed
+                    })
+                } else {
+                    // toggle to shown
+                    item.disabled = true
+                    $(this).prop('title', 'Enable')
+                    $(this).find('i').addClass('fa-lock').removeClass('fa-unlock')
+                    events.push({
+                        t: 'edit',
+                        node: item,
+                        changes: {
+                            disabled: false
+                        },
+                        dirty: item.dirty,
+                        changed: item.changed
+                    })
+                }
+                recordEvents(events)
+            })
+        }
+    }
+
     // Adds child list of groups for a given page
     function addGroupOrderingList (pageId, container, groups, widgetsByGroup) {
         // ordered list of groupss to live within a container (e.g. page list item)
@@ -347,7 +452,9 @@
                 $('<i>', { class: 'nrdb2-sb-icon nrdb2-sb-group-icon fa ' + groupicon }).appendTo(titleRow)
                 $('<span>', { class: 'nrdb2-sb-title' }).text(group.name || group.id).appendTo(titleRow)
 
-                addRowActions(titleRow, group)
+                const actions = $('<div>', { class: 'nrdb2-sb-list-header-actions' }).appendTo(titleRow)
+                addRowActions(actions, group)
+                addRowStateOptions(actions, group)
 
                 // adds widgets within this group
                 const widgets = widgetsByGroup[group.id] || []
@@ -412,7 +519,8 @@
                 $('<i>', { class: 'nrdb2-sb-icon nrdb2-sb-widget-icon fa ' + widgeticon }).appendTo(titleRow)
                 $('<span>', { class: 'nrdb2-sb-title' }).text(widget.name || widget.label || widget.type || widget.id).appendTo(titleRow)
 
-                addRowActions(titleRow, widget)
+                const actions = $('<div>', { class: 'nrdb2-sb-list-header-actions' }).appendTo(titleRow)
+                addRowActions(actions, widget)
             },
             sortItems: function (items) {
                 // track any changes
@@ -567,7 +675,9 @@
                 $('<span>', { class: 'nrdb2-sb-title' }).text(page.name || page.id).appendTo(titleRow)
 
                 // page - actions
-                addRowActions(titleRow, page)
+                const actions = $('<div>', { class: 'nrdb2-sb-list-header-actions' }).appendTo(titleRow)
+                addRowActions(actions, page)
+                addRowStateOptions(actions, page)
 
                 // adds groups within this page
                 const groups = groupsByPage[page.id] || []

--- a/nodes/config/ui_group.html
+++ b/nodes/config/ui_group.html
@@ -11,7 +11,9 @@
             height: { value: 1 },
             order: { value: -1 },
             showTitle: { value: true }, // show title on group card
-            className: { value: '' }
+            className: { value: '' },
+            visible: { value: true },
+            disabled: { value: false }
         },
         label: function () {
             const page = RED.nodes.node(this.page)?.name || ''
@@ -26,8 +28,42 @@
                 height: '#node-config-input-height',
                 auto: false
             })
+    
+            // backwards compatibility
+            if (this.visible === undefined || this.visible === true) {
+                this.visible = true
+                $('#node-config-input-visible').val('true')
+            } else if (this.visible === false) {
+                this.visible = false
+                $('#node-config-input-visible').val('false')
+            }
+            // backwards compatibility
+            if (this.disabled === undefined || this.disabled === false) {
+                this.disabled = false
+                $('#node-config-input-disabled').val('false')
+            } else if (this.disabled === true) {
+                this.disabled = true
+                $('#node-config-input-disabled').val('true')
+            }
+        },
+        oneditsave: function () {
+            // convert string to boolean
+            const visible = $('#node-config-input-visible').val()
+            if (visible === 'true') {
+                this.visible = true
+            } else {
+                this.visible = false
+            }
+    
+            // convert string to boolean
+            const disabled = $('#node-config-input-disabled').val()
+            if (disabled === 'true') {
+                this.disabled = true
+            } else {
+                this.disabled = false
+            }
         }
-    })
+})
 </script>
 
 <script type="text/html" data-template-name="ui-group">
@@ -52,6 +88,27 @@
     <div class="form-row" id="text-row-class">
         <label for="node-config-input-className"><i class="fa fa-code"></i> Class</label>
         <input type="text" id="node-config-input-className" placeholder="Optional CSS class name(s) for group"/>
+    </div>
+    <div class="form-row" style="font-weight: 600;">
+        <i class="w-16 fa fa-eye"></i> Default State
+    </div>
+    <div class="form-row">
+        <div style="display: flex; align-items: center; gap: 2px;">
+            <label for="node-config-input-visible" style="margin-bottom: 0">Visibility</label>
+            <select id="node-config-input-visible" style="width: 150px;">
+                <option value="true" data-i18n="ui-group.label.visible"></option>
+                <option value="false" data-i18n="ui-group.label.hidden"></option>
+            </select>
+        </div>
+    </div>
+    <div class="form-row">
+        <div style="display: flex; align-items: center; gap: 2px;">
+            <label for="node-config-input-disabled" style="margin-bottom: 0">Interactivity</label>
+            <select id="node-config-input-disabled" style="width: 150px;">
+                <option value="false" data-i18n="ui-group.label.active"></option>
+                <option value="true" data-i18n="ui-group.label.disabled"></option>
+            </select>
+        </div>
     </div>
     <div class="form-row">
         <button onclick="RED.sidebar.show('dashboard-2.0')" class="editor-button editor-button-small">Open Dashboard 2.0 Sidebar</button>

--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -31,7 +31,9 @@
             order: {
                 value: -1
             },
-            className: { value: '' }
+            className: { value: '' },
+            visible: { value: true },
+            disabled: { value: false }
         },
         oneditprepare: function () {
             $('#node-config-input-layout').typedInput({
@@ -46,6 +48,34 @@
                 }],
                 typeField: '#node-input-layoutType'
             })
+
+            // backwards compatibility
+            if (this.visible === undefined) {
+                this.visible = true
+                $('#node-config-input-visible').val('true')
+            }
+            // backwards compatibility
+            if (this.disabled === undefined) {
+                this.disabled = false
+                $('#node-config-input-disabled').val('false')
+            }
+        },
+        oneditsave: function () {
+            // convert string to boolean
+            const visible = $('#node-config-input-visible').val()
+            if (visible === 'true') {
+                this.visible = true
+            } else {
+                this.visible = false
+            }
+    
+            // convert string to boolean
+            const disabled = $('#node-config-input-disabled').val()
+            if (disabled === 'true') {
+                this.disabled = true
+            } else {
+                this.disabled = false
+            }
         },
         label: function () {
             const baseNode = RED.nodes.node(this.ui)
@@ -85,6 +115,27 @@
     <div class="form-row" id="text-row-class">
         <label for="node-config-input-className"><i class="w-16 fa fa-code"></i> Class</label>
         <input type="text" id="node-config-input-className" placeholder="Optional CSS class name(s) for page"/>
+    </div>
+    <div class="form-row" style="font-weight: 600;">
+        <i class="w-16 fa fa-eye"></i> Default State
+    </div>
+    <div class="form-row">
+        <div style="display: flex; align-items: center; gap: 2px;">
+            <label for="node-config-input-visible" style="margin-bottom: 0">Visibility</label>
+            <select id="node-config-input-visible" style="width: 150px;">
+                <option value="true" data-i18n="ui-page.label.visible"></option>
+                <option value="false" data-i18n="ui-page.label.hidden"></option>
+            </select>
+        </div>
+    </div>
+    <div class="form-row">
+        <div style="display: flex; align-items: center; gap: 2px;">
+            <label for="node-config-input-disabled" style="margin-bottom: 0">Interactivity</label>
+            <select id="node-config-input-disabled" style="width: 150px;">
+                <option value="false" data-i18n="ui-page.label.active"></option>
+                <option value="true" data-i18n="ui-page.label.disabled"></option>
+            </select>
+        </div>
     </div>
     <div class="form-row">
         <button onclick="RED.sidebar.show('dashboard-2.0')" class="editor-button editor-button-small">Open Dashboard 2.0 Sidebar</button>

--- a/nodes/config/ui_page.js
+++ b/nodes/config/ui_page.js
@@ -12,6 +12,22 @@ module.exports = function (RED) {
             done()
         })
 
+        // backward compatibility
+        if (!('disabled' in config)) {
+            // ensure we have a value
+            config.disabled = false
+        } else {
+            // ensure we have a boolean
+            config.disabled = (config.disabled === 'true' || config.disabled === true)
+        }
+        if (!('visible' in config)) {
+            // ensure we have a value
+            config.visible = true
+        } else {
+            // ensure we have a boolean
+            config.visible = (config.visible === 'true' || config.visible === true)
+        }
+
         /**
          * Function for widgets to register themselves with this page
          * Calls the parent UI Base "register" function and registers this page,

--- a/ui/src/debug/Debug.vue
+++ b/ui/src/debug/Debug.vue
@@ -48,7 +48,7 @@
                                 </v-tabs>
                                 <v-window v-model="view.nested">
                                     <v-window-item value="properties">
-                                        <v-data-table color="white" :items="Object.entries(item).map(function(e){ return { 'property': e[0], 'value': e[1] }})" :items-per-page="-1">
+                                        <v-data-table color="white" :items="Object.entries(item).map(function(e){ return { 'property': e[0], 'value': e[1], 'type': typeof(e[1]) }})" :items-per-page="-1">
                                             <template #bottom />
                                         </v-data-table>
                                     </v-window-item>


### PR DESCRIPTION
## Description

1. Add the "Default State" options to the `ui-group` and `ui-page` elements:

<img width="662" alt="Screenshot 2024-01-10 at 15 29 05" src="https://github.com/FlowFuse/node-red-dashboard/assets/99246719/32804050-e5ae-48f2-a25c-3e3fbffbb1b0">

3. Add options to the side menu to control the default states:

<img width="573" alt="Screenshot 2024-01-10 at 15 25 08" src="https://github.com/FlowFuse/node-red-dashboard/assets/99246719/7c7086e9-4093-4085-b559-0c73d07024f6">

## Related Issue(s)

Closes #481 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)