### PR TITLE
UI Button - Ensure payload is set when type is flow/global

### DIFF
--- a/cypress/fixtures/flows/context-api.json
+++ b/cypress/fixtures/flows/context-api.json
@@ -29,7 +29,7 @@
         "type": "function",
         "z": "node-red-tab-helper-api",
         "name": "function 1",
-        "func": "msg.payload = {\n    msg: global.get('msg')\n}\nreturn msg;",
+        "func": "msg.payload = {} \n\nconst key = msg.req.query?.key || 'msg'\n\nconst body = {}\nbody[key] = global.get(key)\n\nmsg.payload = body\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -101,6 +101,54 @@
         "headers": {},
         "x": 430,
         "y": 100,
+        "wires": []
+    },
+    {
+        "id": "http-in-store-global",
+        "type": "http in",
+        "z": "node-red-tab-helper-api",
+        "name": "",
+        "url": "/context/global",
+        "method": "post",
+        "upload": false,
+        "swaggerDoc": "",
+        "x": 140,
+        "y": 160,
+        "wires": [
+            [
+                "fcn-store-global"
+            ]
+        ]
+    },
+    {
+        "id": "fcn-store-global",
+        "type": "function",
+        "z": "node-red-tab-helper-api",
+        "name": "Set Global Var",
+        "func": "function createNestedObject(keys, value) {\n    const keyParts = keys.split('.');\n    const result = {};\n    let current = result;\n\n    for (let i = 0; i < keyParts.length; i++) {\n        const key = keyParts[i];\n        if (i === keyParts.length - 1) {\n            current[key] = value;\n        } else {\n            current[key] = {};\n            current = current[key];\n        }\n    }\n\n    return result;\n}\n\nconst keys = msg.payload.key.split('.')\n\nif (keys.length > 1) {\n    const nested = createNestedObject(msg.payload.key, msg.payload.value)\n    global.set(keys[0], nested[keys[0]])\n} else {\n    global.set(msg.payload.key, msg.payload.value)\n}\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 340,
+        "y": 160,
+        "wires": [
+            [
+                "http-out-store-global"
+            ]
+        ]
+    },
+    {
+        "id": "http-out-store-global",
+        "type": "http response",
+        "z": "node-red-tab-helper-api",
+        "name": "",
+        "statusCode": "",
+        "headers": {},
+        "x": 490,
+        "y": 160,
         "wires": []
     }
 ]

--- a/cypress/fixtures/flows/dashboard-buttons.json
+++ b/cypress/fixtures/flows/dashboard-buttons.json
@@ -128,5 +128,33 @@
                 "test-helper"
             ]
         ]
+    },
+    {
+        "id": "dashboard-ui-button-global",
+        "type": "ui-button",
+        "z": "node-red-tab-buttons",
+        "group": "dashboard-ui-group",
+        "name": "",
+        "label": "Button 2 (global)",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "test",
+        "payloadType": "global",
+        "topic": "button-global-topic",
+        "topicType": "str",
+        "x": 120,
+        "y": 180,
+        "wires": [
+            [
+                "test-helper"
+            ]
+        ]
     }
 ]

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -78,6 +78,18 @@ Cypress.Commands.add('resetContext', (field, value) => {
     cy.request('POST', '/context/reset')
 })
 
-Cypress.Commands.add('checkOutput', (msg, value) => {
-    cy.request('GET', '/context/flow').its(`body.${msg}`).should('eq', value)
+Cypress.Commands.add('checkOutput', (key, value) => {
+    const parentKey = key.split('.')[0]
+    cy.request('GET', '/context/flow?key=' + parentKey).its(`body.${key}`).should('eq', value)
+})
+
+Cypress.Commands.add('setGlobalVar', (key, value) => {
+    const body = { key, value }
+    cy.request('POST', '/context/global', body)
+})
+
+Cypress.Commands.add('clickAndWait', (element, wait) => {
+    wait = wait || 100
+    element.click()
+    cy.wait(wait)
 })

--- a/cypress/tests/widgets/button.spec.js
+++ b/cypress/tests/widgets/button.spec.js
@@ -15,4 +15,14 @@ describe('Node-RED Dashboard 2.0 - Buttons', () => {
         cy.checkOutput('msg.payload.hello', 'world')
         cy.checkOutput('msg.topic', 'button-json-topic')
     })
+
+    it('can retrieve global variables when clicked', () => {
+        // set global. var via helper API
+        cy.setGlobalVar('test', 'global-var')
+        cy.checkOutput('test', 'global-var')
+
+        // Emitting global var
+        cy.clickAndWait(cy.get('button').contains('Button 2 (global)'))
+        cy.checkOutput('msg.payload', 'global-var')
+    })
 })

--- a/cypress/tests/widgets/switch.spec.js
+++ b/cypress/tests/widgets/switch.spec.js
@@ -67,7 +67,7 @@ describe('Node-RED Dashboard 2.0 - Switches with Icons', () => {
 
     it('does send a msg if the switch in Dashboard is clicked', () => {
         // set to on
-        cy.get('#nrdb-ui-widget-dashboard-ui-button-str-on').click()
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-str-on'))
         // click the switch directly
         cy.get('#nrdb-ui-widget-dashboard-ui-switch-str').find('button').click()
         // should now be off

--- a/nodes/widgets/ui_button.js
+++ b/nodes/widgets/ui_button.js
@@ -22,6 +22,7 @@ module.exports = function (RED) {
                         if (parts.length === 0) {
                             throw new Error()
                         }
+                        payload = RED.util.evaluateNodeProperty(payload, payloadType, node)
                     } catch (err) {
                         node.warn('Invalid payload property expression - defaulting to node id')
                         payload = node.id


### PR DESCRIPTION
## Description

- Adds a missing line that sets the `payload` to the result of `evaluateNodeProperty` which was missing in the conditional branch for `flow` and `global`
- Adds E2E Tests to cover this pathway
- Adds a new `clickAndWait` function to check for stability improvements of E2E Tests/Websockets in CI Ppeline

## Related Issue(s)

Fix #353

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)