### PR TITLE
UI Switch - More reliable onChange handler & accompanying E2E Test

### DIFF
--- a/cypress/tests/widgets/switch.spec.js
+++ b/cypress/tests/widgets/switch.spec.js
@@ -33,6 +33,21 @@ describe('Node-RED Dashboard 2.0 - Switches', () => {
         // should now be off
         cy.checkOutput('msg.payload', 'off')
     })
+
+    it('maintains state on page refresh', () => {
+        // set to on
+        cy.get('#nrdb-ui-widget-dashboard-ui-button-bool-on').click()
+        // click the switch directly
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-bool').find('input').click()
+        // should now be off
+        cy.checkOutput('msg.payload', 'off')
+
+        // refresh page
+        cy.reload()
+        // should still be off
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-bool').find('.v-input.v-input--horizontal').should('have.class', 'v-switch')
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-bool').find('.v-input.v-input--horizontal').should('not.have.class', 'active')
+    })
 })
 
 describe('Node-RED Dashboard 2.0 - Switches with Icons', () => {

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="nrdb-switch" :class="{'nrdb-nolabel': !props.label, [className]: !!className}">
         <label v-if="props.label" class="v-label">{{ props.label }}</label>
-        <v-switch v-if="!icon" v-model="state" :class="{'active': state}" hide-details="auto" color="primary" @click="onChange" />
+        <v-switch v-if="!icon" v-model="state" :class="{'active': state}" hide-details="auto" color="primary" @update:model-value="onChange" />
         <v-btn v-else variant="text" :icon="icon" :color="color" @click="toggle" />
     </div>
 </template>
@@ -64,10 +64,10 @@ export default {
         }
     },
     methods: {
-        onChange () {
+        onChange (val) {
             // only runs when clicked/changed in UI.
             // inverted as the store doesn't quite update quick enough, but this is reliable method
-            this.$socket.emit('widget-change', this.id, !this.value)
+            this.$socket.emit('widget-change', this.id, val)
         },
         toggle () {
             this.state = !this.state


### PR DESCRIPTION
## Description

- We previously had an `@click` event handler which watched the click event, then invertted the current value and emitted it. It would appear, for some reason that the `@click` handler _sometimes_ ran after the underlying Vue tick had computed, and sometimes before.
- I've changed this to a watch on the attached `value` to the switch, which guarantees we see an accurate value in the event handler, even on reload.

## Related Issue(s)

Closes #457 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->