### PR TITLE
UI Path - Fix default path visibility & path value

### DIFF
--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -12,7 +12,7 @@
                 required: true
             },
             path: {
-                value: '/',
+                value: -1,
                 required: false
             },
             icon: {
@@ -32,10 +32,21 @@
                 value: -1
             },
             className: { value: '' },
-            visible: { value: true },
-            disabled: { value: false }
+            visible: { value: 'true' },
+            disabled: { value: 'false' }
         },
         oneditprepare: function () {
+            if (this.path === -1) {
+                // we have no path set yet
+                let pageCount = 0
+                RED.nodes.eachConfig((cNode) => {
+                    pageCount += cNode.type === 'ui-page' ? 1 : 0
+                })
+                this.path = '/page' + (pageCount + 1)
+                $('#node-config-input-path').val(this.path)
+                console.log('setting path to', this.path)
+            }
+
             $('#node-config-input-layout').typedInput({
                 type: 'layout',
                 types: [{


### PR DESCRIPTION
## Description

- Uses default option as a string as expected for the `<select />` elements on the `visibility` 
- Also put in an improvements for the default `path`, whereby it counts existing pages, and sets path to `/pageN`, where `N` is the number of pages + 1

## Related Issue(s)

Fix #494 
Deliver iteration for #348 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)