### PR TITLE
Debug View: Fix display of message history, and truncate Arrays

### DIFF
--- a/cypress/tests/widgets/switch.spec.js
+++ b/cypress/tests/widgets/switch.spec.js
@@ -36,9 +36,9 @@ describe('Node-RED Dashboard 2.0 - Switches', () => {
 
     it('maintains state on page refresh', () => {
         // set to on
-        cy.get('#nrdb-ui-widget-dashboard-ui-button-bool-on').click()
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-bool-on'))
         // click the switch directly
-        cy.get('#nrdb-ui-widget-dashboard-ui-switch-bool').find('input').click()
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-switch-bool').find('input'))
         // should now be off
         cy.checkOutput('msg.payload', 'off')
 

--- a/ui/src/debug/Debug.vue
+++ b/ui/src/debug/Debug.vue
@@ -143,7 +143,7 @@
                                         </v-data-table>
                                     </v-window-item>
                                     <v-window-item value="datastore">
-                                        <debug-data :widget="item.id" store="data" />
+                                        <debug-data :item="item.id" store="data" />
                                     </v-window-item>
                                     <v-window-item value="statestore">
                                         <debug-data :item="item.id" store="state" />

--- a/ui/src/debug/DebugData.vue
+++ b/ui/src/debug/DebugData.vue
@@ -1,5 +1,10 @@
 <template>
-    <pre v-if="data" style="padding: 12px; opacity: 0.5;">{{ data }}</pre>
+    <pre v-if="data && Array.isArray(data) && data.length > 10" style="padding: 12px; opacity: 0.5;">Array&lt;{{ data.length }}&gt;
+
+{{ data.slice(0, 10) }}
+... [+ {{ data.length - 10 }} more]
+    </pre>
+    <pre v-else-if="data" style="padding: 12px; opacity: 0.5;">{{ data }}</pre>
     <p v-else style="padding: 12px; opacity: 0.5;">No Data Found</p>
     <v-btn style="margin: 12px;" variant="outlined" prepend-icon="mdi-refresh" @click="getData()">Refresh</v-btn>
 </template>


### PR DESCRIPTION
## Description

- Noticed a bug in the Debug View when fixing #498, this fixes that (so now historical data correctly shows in the debug view.
- Also added a truncation of array data, making it easier to view `ui-chart` message history for example. Shows when data has a length greater than 10 items.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)