### PR TITLE
UI Text Input - Disregard concept of "lastValue"

### DIFF
--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -29,7 +29,6 @@ export default {
     },
     data () {
         return {
-            lastSent: null,
             delayTimer: null
         }
     },
@@ -65,7 +64,6 @@ export default {
     methods: {
         send: function () {
             this.$socket.emit('widget-change', this.id, this.value)
-            this.lastSent = this.value
         },
         onChange: function () {
             if (this.props.sendOnDelay) {
@@ -78,7 +76,7 @@ export default {
             }
         },
         onBlur: function () {
-            if (this.props.sendOnBlur && this.lastSent !== this.value && this.value) {
+            if (this.props.sendOnBlur && this.value) {
                 // check if this value has already been sent, as not going to want it sent twice
                 this.send()
             }


### PR DESCRIPTION
## Description

As @thebaldgeek has rightly pointed out, we'd missed out a feature request (arguably a bug) in #442 - that was re-opened, and this fixes it, so messages will _always_ be emitted `onBlur`, even if the value hasn't changed since the last message was sent.

## Related Issue(s)

#442 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)