### PR TITLE
UI Template - Ensure passthru is set at runtime, if not configured in Editor

### DIFF
--- a/nodes/widgets/ui_template.js
+++ b/nodes/widgets/ui_template.js
@@ -20,6 +20,11 @@ module.exports = function (RED) {
             config.group = ''
         }
 
+        // ensure we have a value for passthru (default to true)
+        if (typeof config.passthru === 'undefined') {
+            config.passthru = true
+        }
+
         // which group are we rendering this widget
         if (config.group) {
             const group = RED.nodes.getNode(config.group)


### PR DESCRIPTION
## Description

Seeing issues around warnings and deployment problems with `ui-template`:

- https://discourse.nodered.org/t/dashboard-2-ui-template-config-error/84785
- https://github.com/FlowFuse/node-red-dashboard/pull/497#issuecomment-1902859908

Can't see any reason why they're occurring, they're not marked as `required` fields, and there is an explicit check to see if the `passthru` field exists before any logic using it is considered.

The only option I can possibly think of is the `undefined` nature of `passthru`, so I've added a catch here at runtime.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)