### PR TITLE
UI Template - Modify send() to permit definition of full msg object, not just a payload

### DIFF
--- a/cypress/fixtures/flows/dashboard-templates.json
+++ b/cypress/fixtures/flows/dashboard-templates.json
@@ -182,5 +182,57 @@
                 "test-helper"
             ]
         ]
+    },
+    {
+        "id": "dashboard-ui-template-payload-only",
+        "type": "ui-template",
+        "z": "node-red-tab-templates",
+        "group": "dashboard-ui-group",
+        "page": "",
+        "ui": "",
+        "name": "Payload Only",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "head": "",
+        "format": "<template>\n    <v-btn data-action=\"ui-button-payload-only\" @click=\"onClick\">Payload Only</v-btn>\n</template>\n\n<script>\n    export default {\n        methods: {\n            onClick: function () {\n                this.send(30)\n            }\n        }\n    }\n</script>",
+        "storeOutMessages": true,
+        "passthru": false,
+        "resendOnRefresh": true,
+        "templateScope": "local",
+        "className": "",
+        "x": 310,
+        "y": 140,
+        "wires": [
+            [
+                "test-helper"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-template-full-msg",
+        "type": "ui-template",
+        "z": "node-red-tab-templates",
+        "group": "dashboard-ui-group",
+        "page": "",
+        "ui": "",
+        "name": "Full Message",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "head": "",
+        "format": "<template>\n    <v-btn data-action=\"ui-button-full-msg\" @click=\"onClick\">Full Msg</v-btn>\n</template>\n\n<script>\n    export default {\n        methods: {\n            onClick: function () {\n                this.send({payload: 20, topic: 'full-msg'})\n            }\n        }\n    }\n</script>",
+        "storeOutMessages": true,
+        "passthru": false,
+        "resendOnRefresh": true,
+        "templateScope": "local",
+        "className": "",
+        "x": 310,
+        "y": 180,
+        "wires": [
+            [
+                "test-helper"
+            ]
+        ]
     }
 ]

--- a/cypress/tests/widgets/template.spec.js
+++ b/cypress/tests/widgets/template.spec.js
@@ -13,4 +13,15 @@ describe('Node-RED Dashboard 2.0 - Templates', () => {
         cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-to-disabled'))
         cy.checkOutput('msg.payload', 'payload 1')
     })
+
+    it('permits the sending of a full msg object', () => {
+        cy.clickAndWait(cy.get('[data-action="ui-button-full-msg"]'))
+        cy.checkOutput('msg.payload', 20)
+        cy.checkOutput('msg.topic', 'full-msg')
+    })
+
+    it('permits the sending a payload value and will auto-wrap into a msg structure', () => {
+        cy.clickAndWait(cy.get('[data-action="ui-button-payload-only"]'))
+        cy.checkOutput('msg.payload', 30)
+    })
 })

--- a/docs/contributing/guides/events.md
+++ b/docs/contributing/guides/events.md
@@ -29,13 +29,68 @@ Sent from UI to NR when the UI/widget is first loaded. Gives a chance for NR to 
 - ID: `<node-id>`
 - Payload: `<value>` - typically the payload data to be sent in the msg
 
-Sent from UI to NR when the value of a widget is changed from the UI, e.g. text input, slider
+Sent from UI to NR when the value of a widget is changed from the UI, e.g. text input, slider. Assumes the value emitted is the `msg.payload`.
+
+This takes hte previously received msg, and merges it with the newly received value, for example if the msg was:
+
+```json
+{
+    "payload": 30,
+    "topic": "on-change"
+}
+```
+
+and the `widget-change` received a new value of `40`, then the newly emitted message would be:
+
+```json
+{
+    "payload": 40,
+    "topic": "on-change"
+}
+```
+
+Any value received here will also be stored against the widget in the datastore.
 
 ### `widget-action`
 - ID: `<node-id>`
 - Payload: `<msg>`
 
-Sent from UI to NR when a widget is actioned, e.g. click of a button or upload of a file
+Sent from UI to NR when a widget is actioned, e.g. click of a button or upload of a file.
+
+### `widget-send`
+- ID: `<node-id>`
+- Payload: `<msg>`
+
+Generally used by `ui-template`. This event is wrapped by the Template's `send(msg)` function which allows users to define their own full `msg` objects to be emitted by a `ui-template` node. If a non-Object value is sent, then Dashboard will automatically wrap that into a `msg.payload` object, e.g:
+
+```js
+send(10)
+```
+
+will result in a `msg` object of:
+
+```json
+{
+    "payload": 10 
+}
+```
+
+Similiarly, is instead an object is specified:
+
+```js
+send({ myVar: 10, topic: "my-topic" })
+```
+
+then the `msg` object will be:
+
+```json
+{
+    "myVar": 10,
+    "topic": "my-topic"
+}
+```
+
+Any `msg` emitted using this fucntion is also stored in the datastore associated with the widget.
 
 ## Event Payloads
 

--- a/docs/nodes/widgets/ui-template.md
+++ b/docs/nodes/widgets/ui-template.md
@@ -43,7 +43,7 @@ You have access to a number of built-in variables in your `ui-template` node:
 
 We also offer some helper functions for the Node-RED integration too:
 
-- `this.send` - Send a message to the Node-RED flow. Currently limited to sending msg.payload only - [Issue #427](https://github.com/FlowFuse/node-red-dashboard/issues/427)
+- `this.send` - Send a message to the Node-RED flow. If a non-Object value is sent, then Dashboard will automatically wrap that into a `msg.payload` object.
 - `this.$socket.on('msg-input' + this.id, (msg) = { ... })` - will listen to any messages received by your `ui-template `node and react accordingly.
 
 ### Example (Raw JavaScript)

--- a/ui/src/widgets/ui-template/UITemplate.vue
+++ b/ui/src/widgets/ui-template/UITemplate.vue
@@ -211,7 +211,7 @@ export default {
             msg._dashboard = msg._dashboard || {}
             msg._dashboard.sourceId = component.id
             msg._dashboard.templateId = this.id
-            this.$socket.emit('widget-change', this.id, msg) // widget-change will store msg state server-side
+            this.$socket.emit('widget-send', this.id, msg) // widget-change will store msg state server-side
         },
         submit (component, $evt) {
             // extract the form names and values from $evt.target & generate a msg


### PR DESCRIPTION
## Description

- Add new `widget-send` and use this in our `send()` function, rather than using the existing `widget-change` event.
- The latter had limitations in that it expected (and rightly so) just a `payload` value, and then compared to previous values, etc.
- Now, we have a dedicated `send` event which allows users to have full control
- Also updated documentation for `Events Architecture` to detail this, and the `ui-template` docs to remove the reference to this open issue

Todo:

- Update E2E Tests to cover this function
- Events diagram

## Related Issue(s)

Closes #427 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated