### PR TITLE
UI Template - Fix Editor warning when using "Single Page CSS" type

### DIFF
--- a/nodes/widgets/ui_template.html
+++ b/nodes/widgets/ui_template.html
@@ -178,7 +178,7 @@
                         break
                     case 'page:style':
                         $('#template-row-page').show()
-                        that._def.defaults.ui.required = true
+                        that._def.defaults.page.required = true
                         that.editor.getSession().setMode('ace/mode/css')
                         break
                     case 'site:script':


### PR DESCRIPTION
## Description

When working on some examples for the docs, found that a NR warning kept showing when choosing the "Single Page (CSS)" type for a UI Template.

Upon inspection, found we'd set the wrong field to be `required` when this option was chosen.