### PR TITLE
UI Template: Ensure "widget-send" events are cleared on socket connection loss

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -386,6 +386,9 @@ module.exports = function (RED) {
                 socket.removeAllListeners('widget-load')
             } catch (_error) { /* do nothing */ }
             try {
+                socket.removeAllListeners('widget-send')
+            } catch (_error) { /* do nothing */ }
+            try {
                 socket.removeAllListeners('disconnect')
             } catch (_error) { /* do nothing */ }
 


### PR DESCRIPTION
## Description

Forgot to ensure that _all_ event listeners for `widget-send` were removed when a socket connection was lost, this meant that when NR was restarted, or a new connection was established (browser refresh) then existing listeners were still fired.

## Related Issue(s)

Closes #524 