### PR TITLE
Add icon prop to UI gauge used as label supplement

### DIFF
--- a/docs/nodes/widgets/ui-gauge.md
+++ b/docs/nodes/widgets/ui-gauge.md
@@ -11,6 +11,7 @@ props:
     Prefix: Text to be added _before_ the value in the middle of the gauge.
     Suffix: Text to be shown _after_ the value in the middle of the gauge.
     Units: Small text to be shown below the value in the middle of the gauge.
+    Icon: Icon to be shown below the value in the middle of the gauge. Uses <a href="https://pictogrammers.com/library/mdi/">Material Designs Icon</a>, no need to include the <code>mdi-</code> prefix.
     Sizes (Gauge): (px) How thick the arc and backdrop of the gauge are rendered.
     Sizes (Gap): (px) How big the gap/padding is between the Gauge and the "Segments"
     Sizes (Segments): (px) How thick the segments are rendered.

--- a/docs/user/migration/ui_gauge.json
+++ b/docs/user/migration/ui_gauge.json
@@ -78,6 +78,11 @@
         {
             "property": "segments",
             "notes": "Array of objects that define the segments of the gauge"
-        }
+        },
+        {
+            "property": "icon",
+            "notes": "Icon displayed beneath the gauge (from MDI)"
+        },
+        
     ]
 }

--- a/nodes/widgets/locales/en-US/ui_gauge.json
+++ b/nodes/widgets/locales/en-US/ui_gauge.json
@@ -23,7 +23,9 @@
             "gauge": "Gauge",
             "gap": "Gap",
             "styling": "Styling",
-            "class": "Class"
+            "class": "Class",
+            "units": "Units",
+            "icon": "Icon"
         },
         "errors": {
             "unique": "All 'from' values must be unique."

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -32,6 +32,7 @@
             gstyle: { value: 'needle' },
             title: { value: 'gauge' },
             units: { value: 'units' },
+            icon: { value: '' },
             prefix: { value: '' },
             suffix: { value: '' },
             segments: {
@@ -216,6 +217,10 @@
         <div class="form-row" id="ui-gauge-units">
             <label for="node-input-units"><i class="fa fa-calculator"></i> <span data-i18n="ui-gauge.label.units"></span></label>
             <input type="text" id="node-input-units" placeholder="segmental sub-label">
+        </div>
+        <div class="form-row" id="ui-gauge-icon">
+            <label for="node-input-icon"><i class="fa fa-home"></i> <span data-i18n="ui-gauge.label.icon"></span></label>
+            <input type="text" id="node-input-icon" placeholder="segmental sub-label icon name (from MDI)">
         </div>
     </div>
     <div class="form-row">

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -216,11 +216,11 @@
         </div>
         <div class="form-row" id="ui-gauge-units">
             <label for="node-input-units"><i class="fa fa-calculator"></i> <span data-i18n="ui-gauge.label.units"></span></label>
-            <input type="text" id="node-input-units" placeholder="segmental sub-label">
+            <input type="text" id="node-input-units" placeholder="Unit">
         </div>
         <div class="form-row" id="ui-gauge-icon">
             <label for="node-input-icon"><i class="fa fa-home"></i> <span data-i18n="ui-gauge.label.icon"></span></label>
-            <input type="text" id="node-input-icon" placeholder="segmental sub-label icon name (from MDI)">
+            <input type="text" id="node-input-icon" placeholder="Icon from mdi library, e.g. 'home'">
         </div>
     </div>
     <div class="form-row">

--- a/ui/src/widgets/ui-gauge/UIGauge.vue
+++ b/ui/src/widgets/ui-gauge/UIGauge.vue
@@ -42,7 +42,7 @@
         </svg>
         <div ref="value" class="nrdb-ui-gauge-value" :class="'nrdb-ui-' + props.gtype">
             <span>{{ props.prefix }}{{ value || props.min }}{{ props.suffix }}</span>
-            <label>{{ props.units }}</label>
+            <label v-if="props.icon || props.units"><v-icon v-if="props.icon" :icon="`mdi-${props.icon}`" />{{ props.units }}</label>
         </div>
     </div>
 </template>


### PR DESCRIPTION
## Description

<img width="471" alt="Screenshot 2024-02-13 at 15 09 13" src="https://github.com/FlowFuse/node-red-dashboard/assets/507155/5653a5fd-e719-4a0d-9a73-b2d98b95b312">
<img width="525" alt="Screenshot 2024-02-13 at 15 11 03" src="https://github.com/FlowFuse/node-red-dashboard/assets/507155/0e1e6648-4e32-42ce-a45b-2428e1edb976">
<img width="512" alt="Screenshot 2024-02-13 at 15 09 26" src="https://github.com/FlowFuse/node-red-dashboard/assets/507155/b29e8801-a5ad-48e7-bdb3-1bfb5a416bc1">


## Related Issue(s)

Fixes #567 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

