### PR TITLE
Set mdi- prefix for all custom icons to be optional

### DIFF
--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -24,7 +24,7 @@
                     <v-list-item
                         v-for="page in orderedPages" :key="page.id" active-class="v-list-item--active"
                         :disabled="page.disabled || undefined"
-                        :prepend-icon="`mdi-${page.icon || 'home'}`"
+                        :prepend-icon="`mdi-${page.icon.replace(/^mdi-/, '') || 'home'}`"
                         :title="getPageLabel(page)"
                         :to="{name: page.route.name}" link
                         :data-nav="page.id"

--- a/ui/src/widgets/ui-gauge/UIGauge.vue
+++ b/ui/src/widgets/ui-gauge/UIGauge.vue
@@ -410,6 +410,8 @@ export default {
 .nrdb-ui-gauge-value label {
     font-size: 0.75rem;
     line-height: 0.825rem;
+    display: flex;
+    align-items: center;
 }
 
 .nrdb-ui-gauge #backdrop path {

--- a/ui/src/widgets/ui-gauge/UIGauge.vue
+++ b/ui/src/widgets/ui-gauge/UIGauge.vue
@@ -42,7 +42,7 @@
         </svg>
         <div ref="value" class="nrdb-ui-gauge-value" :class="'nrdb-ui-' + props.gtype">
             <span>{{ props.prefix }}{{ value || props.min }}{{ props.suffix }}</span>
-            <label v-if="props.icon || props.units"><v-icon v-if="props.icon" :icon="`mdi-${props.icon}`" />{{ props.units }}</label>
+            <label v-if="props.icon || props.units"><v-icon v-if="props.icon" :icon="`mdi-${icon}`" />{{ props.units }}</label>
         </div>
     </div>
 </template>
@@ -89,6 +89,9 @@ export default {
         },
         gaugeHeight: function () {
             return this.props.gtype === 'gauge-half' ? '150px' : '300px'
+        },
+        icon () {
+            return this.props.icon.replace(/^mdi-/, '')
         }
     },
     watch: {

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -26,7 +26,7 @@ export default {
         icon: function () {
             if (this.props.onicon && this.props.officon) {
                 const icon = this.status ? this.props.onicon : this.props.officon
-                return 'mdi-' + icon
+                return 'mdi-' + icon.replace(/^mdi-/, '')
             } else {
                 return null
             }


### PR DESCRIPTION
## Description

Currently if `mdi-` prefix is added, icons fail to render for pages, switches and gauges. This PR strips `mdi-` if is is prefixed meaning both with and without work (though the docs still suggest without).

## Related Issue(s)

#567 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

