### PR TITLE
Handle missing props.icon for older gauges & pages

### DIFF
--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -24,7 +24,7 @@
                     <v-list-item
                         v-for="page in orderedPages" :key="page.id" active-class="v-list-item--active"
                         :disabled="page.disabled || undefined"
-                        :prepend-icon="`mdi-${page.icon.replace(/^mdi-/, '') || 'home'}`"
+                        :prepend-icon="`mdi-${page.icon?.replace(/^mdi-/, '') || 'home'}`"
                         :title="getPageLabel(page)"
                         :to="{name: page.route.name}" link
                         :data-nav="page.id"

--- a/ui/src/widgets/ui-gauge/UIGauge.vue
+++ b/ui/src/widgets/ui-gauge/UIGauge.vue
@@ -91,7 +91,7 @@ export default {
             return this.props.gtype === 'gauge-half' ? '150px' : '300px'
         },
         icon () {
-            return this.props.icon.replace(/^mdi-/, '')
+            return this.props.icon?.replace(/^mdi-/, '')
         }
     },
     watch: {


### PR DESCRIPTION
## Description

In #574 we handle the use case where a user wants to include `mdi-` icons, however, this wasn't tested for _existing_ gauges, which were already successfully deployed _without_ an `.icon` property.

This adds a catch in to make sure that's handled.