### PR TITLE
Heatmap widget

### DIFF
--- a/docs/nodes/widgets.md
+++ b/docs/nodes/widgets.md
@@ -9,6 +9,11 @@
         image: '/images/node-examples/ui-button.png',
         description: 'Adds a clickable button to your dashboard.'
     }, {
+        name: 'Heatmap',
+        widget: 'ui-heatmap',
+        image: '/images/node-examples/ui-heatmap.png',
+        description: 'Renders a heatmap.'
+    }, {
         name: 'Markdown',
         widget: 'ui-markdown',
         image: '/images/node-examples/ui-markdown.png',

--- a/docs/nodes/widgets/ui-heatmap.md
+++ b/docs/nodes/widgets/ui-heatmap.md
@@ -1,0 +1,28 @@
+---
+props:
+    Group: Defines which group of the UI Dashboard this widget will render in.
+    Size: Controls the width of the button with respect to the parent group. Maximum value is the width of the group.
+    Label: The text shown within the button.
+    Mode: The type of HTML input to display. Options - text | password | email | number | tel | color | date | time | week | month | datetime-local
+    Passthrough: If this node receives a msg in Node-RED, should it be passed through to the output as if a new value was inserted to the input?
+    Send On "Delay": If true, then a msg will be emitted will be sent after the delay specified in "Delay (ms)".
+    Delay: If "Send on Delay" is true, then the value in the text input will be send after this (ms) delay.
+    Send On "Focus Leave": Sends a msg when the text input loses focus. Will only send if the value has changed from the last msg sent
+    Send On "Press Enter": Sends a msg when the user presses the enter key. Will always send, even if the value has not changed.
+---
+
+<script setup>
+</script>
+
+# Text Input `ui-text-input`
+
+Adds a single text input row to your dashboard, with a configurable "type" (text, password, etc).
+
+## Properties
+
+<PropsTable/>
+
+## Example
+
+![Example of a Button](/images/node-examples/ui-text-input.png "Example of a Button"){data-zoomable}
+*Example of a rendered button in a Dashboard.*

--- a/docs/nodes/widgets/ui-heatmap.md
+++ b/docs/nodes/widgets/ui-heatmap.md
@@ -2,27 +2,217 @@
 props:
     Group: Defines which group of the UI Dashboard this widget will render in.
     Size: Controls the width of the button with respect to the parent group. Maximum value is the width of the group.
-    Label: The text shown within the button.
-    Mode: The type of HTML input to display. Options - text | password | email | number | tel | color | date | time | week | month | datetime-local
-    Passthrough: If this node receives a msg in Node-RED, should it be passed through to the output as if a new value was inserted to the input?
-    Send On "Delay": If true, then a msg will be emitted will be sent after the delay specified in "Delay (ms)".
-    Delay: If "Send on Delay" is true, then the value in the text input will be send after this (ms) delay.
-    Send On "Focus Leave": Sends a msg when the text input loses focus. Will only send if the value has changed from the last msg sent
-    Send On "Press Enter": Sends a msg when the user presses the enter key. Will always send, even if the value has not changed.
+    Class: The text shown within the button.
+    Grid size: <code>Rows</code> | <code>Columns</code>
+        Choose the dimensions of the grid, by specifying the number of rows and columns.
+    
+    Radius: Defines the radius of a data point, in times the size of a grid cell.
+
+    Min value: Define the minimum data value, i.e. the data value that will correspond to offset 0.0 in the color gradient.  If not specified, the minimum data value is automatically adjusted to the minimum value in the input data.  The minimum value needs to be set in case relative gradient calculations are required.  The minimum value corresponds to the first color in the gradient.
+    Max value: Define the maximum data value, i.e. the data value that will correspond to offset 1.0 in the color gradient.  If not specified, the maximum data value is automatically adjusted to the maximum value in the input data.  The maximum value needs to be set in case relative gradient calculations are required.  The maximum value corresponds to the last color in the gradient.
+    Opacity: Define the opacity factor that will be applied to the entire heatmap.
+    Angle: Define the rotation angle of the entire heatmap.
+    X: Define the translation distance of the entire heatmap into the X direction.
+    Y: Define the translation distance of the entire heatmap into the Y direction.
+    Zoom: Define the zoom factor of the entire heatmap.
+    Background: Define the url of the background image that needs to be drawn behind the heatmap.  A base64 encoded url will contain the image data.
+    Color gradient:
+        <b>Offset:</b> The position at which a particular color starts in the gradient.</br>
+        <b>Color:</b> The visible hue, which represents a value or category (e.g. red is hot and blue is cold).</br>
+        <b>Opacity:</b> How transparent the color is.
+dynamic:
+    Class:
+        payload: msg.class
+        structure: ["String"]
 ---
 
 <script setup>
+    import AddedIn from '../../components/AddedIn.vue';
 </script>
 
-# Text Input `ui-text-input`
+# Chart `ui-chart`
 
-Adds a single text input row to your dashboard, with a configurable "type" (text, password, etc).
+Provides configuration options to create the following chart types:
+
+- [Line Chart](#line-chart)
+- [Scatter Plot](#scatter-plot)
+- [Bar Chart](#bar-graph)
 
 ## Properties
 
 <PropsTable/>
 
-## Example
+## Dynamic Properties
 
-![Example of a Button](/images/node-examples/ui-text-input.png "Example of a Button"){data-zoomable}
-*Example of a rendered button in a Dashboard.*
+<DynamicPropsTable/>
+
+## Controls
+
+### "Set" data
+
+You can set data for a heatmap by sending a `msg.topic` of `setData` to the node.  Any existing data will first be removed, then new data will be added.
+
+The input data can be injected in the `msg.payload` in two different formats:
+
+1. As an array of numbers:
+   ```js
+   msg = {
+      "topic": "setData",
+      "payload": [87, 23, 3, ... ]
+   }
+   ```
+   These numbers will be used as values in the grid cells, from left to right and top to bottom.
+
+2. As an array of objects:
+   ```js
+   msg = {
+      "topic": "setData",
+      "payload": [{ row: 1, column: 1, value: 87}, { row: 5, column: 7, value: 47}, ... ]
+   }
+   ```
+   These numbers will be used as values in the grid cells at the specified location.
+
+### "Add" data
+
+You can add data for a heatmap by sending a `msg.topic` of `addData` to the node.  Any new data provided will be added to the existing data on the heatmap.
+
+The input data can only be injected in the `msg.payload` as an array of objects:
+```js
+msg = {
+    "topic": "addData",
+    "payload": [
+        {
+            "row": 1,
+            "column": 1,
+            "value": 87
+        },
+        {
+            "row": 5,
+            "column": 7,
+            "value": 47
+        },
+        ...
+    ]
+}
+```
+These numbers will be used as values in the grid cells at the specified location.  When there is no value yet in the specified grid cell, then the new value will be added there.  Otherwise the existing data in the cell will be overwritten by the new data.
+
+### Clear All Data
+
+You can remove all data from a heatmap at any time by sending a `msg.topic` of `clear` to the node. 
+
+### Set opacity
+
+You can set the opacity of the heatmap by sending a `msg.topic` of `setOpacity` to the node.  This allows you to configure the transparency of the heatmap, for example to show the background image partially through the heatmap.  The opacity is a value between 0.0 and 1.0.
+
+```js
+msg = {
+    "topic": "setOpacity",
+    "payload": 0.8
+}
+```
+
+### Set rotation angle
+
+You can set the rotation angle of the heatmap by sending a `msg.topic` of `setRotationAngle` to the node.  This allows you to rotate the entire heatmap.
+
+```js
+msg = {
+    "topic": "setRotationAngle",
+    "payload": 45
+}
+```
+
+### Set zoom factor
+
+You can set the zoom factor of the heatmap by sending a `msg.topic` of `setZoom` to the node.  This allows you to zoom in or out the entire heatmap.  A zoom factor of 1.0 means no zooming.
+
+```js
+msg = {
+    "topic": "setZoom",
+    "payload": 45
+}
+```
+
+### Set min value
+
+You can set the minimum data value of the heatmap by sending a `msg.topic` of `setMin` to the node.  When no minimum value has been set explicit (via an input msg or via the node config screen), then the minimum value of all injected values will be used.  
+
+```js
+msg = {
+    "topic": "setMin",
+    "payload": 9
+}
+```
+
+### Set max value
+
+You can set the maximum data value of the heatmap by sending a `msg.topic` of `setMax` to the node.  When no maximum value has been set explicit (via an input msg or via the node config screen), then the maximum value of all injected values will be used.  
+
+```js
+msg = {
+    "topic": "setMax",
+    "payload": 98
+}
+```
+
+### Set translation
+
+You can set the translation value of the heatmap by sending a `msg.topic` of `setTranslate` to the node.  This allows you to move the entire heatmap in the X and/or Y direction.  The translation is specified as an array, with first the X translation and secondly the Y translation.
+
+```js
+msg = {
+    "topic": "setTranslate",
+    "payload": [20, 10]
+}
+```
+
+### Set background image
+
+You can set a new background image by sending a `msg.topic` of `setBackgroundImageUrl` to the node.  That url refers to a public available static image resource.  
+
+Remark: to avoid CORS issues in your browser (when the url refers to another hostname), you might consider to convert the image once to a base64 encoded image.  Then you simple need to inject that base64 encoded image embedded in the url, i.e. push it to your dashboard without having to make the image url public available:
+
+```js
+msg = {
+    "topic": "setGradient",
+    "payload": "data:image/jpeg;base64,..."
+}
+```
+
+### Set color gradient
+
+You can set a new color gradient dynamically by sending a `msg.topic` of `setGradient` to the node.
+
+```js
+msg = {
+    "topic": "setGradient",
+    "payload": [
+        {
+            "color": "#000000",
+            "opacity": 0,
+            "offset": 0
+        },
+        {
+            "color": "#00FF00",
+            "opacity": 0.2,
+            "offset": 0.2
+        },
+        {
+            "color": "#FF0000",
+            "opacity": 0.5,
+            "offset": 0.45
+        },
+        {
+            "color": "#00FFFF",
+            "opacity": 1,
+            "offset": 0.85
+        },
+        {
+            "color": "#0000FF",
+            "opacity": 1,
+            "offset": 1
+        }
+    ]
+}
+```

--- a/docs/nodes/widgets/ui-heatmap.md
+++ b/docs/nodes/widgets/ui-heatmap.md
@@ -30,13 +30,8 @@ dynamic:
     import AddedIn from '../../components/AddedIn.vue';
 </script>
 
-# Chart `ui-chart`
+# Heatmap `ui-heatmap`
 
-Provides configuration options to create the following chart types:
-
-- [Line Chart](#line-chart)
-- [Scatter Plot](#scatter-plot)
-- [Bar Chart](#bar-graph)
 
 ## Properties
 
@@ -158,7 +153,7 @@ msg = {
 
 ### Set translation
 
-You can set the translation value of the heatmap by sending a `msg.topic` of `setTranslate` to the node.  This allows you to move the entire heatmap in the X and/or Y direction.  The translation is specified as an array, with first the X translation and secondly the Y translation.
+You can set the translation value of the heatmap by sending a `msg.topic` of `setTranslate` to the node.  This allows you to move the entire heatmap in the X and/or Y direction.  The translation is specified as an array, with first the X translation and secondly the Y translation.  Both values are specified in grid cell units.
 
 ```js
 msg = {

--- a/docs/nodes/widgets/ui-heatmap.md
+++ b/docs/nodes/widgets/ui-heatmap.md
@@ -1,4 +1,5 @@
 ---
+description: Use color gradients to represent the density or magnitude of data points across a two-dimensional area to identify patterns with Node-RED Dashboard 2.0
 props:
     Group: Defines which group of the UI Dashboard this widget will render in.
     Size: Controls the width of the button with respect to the parent group. Maximum value is the width of the group.

--- a/nodes/widgets/locales/en-US/ui_heatmap.html
+++ b/nodes/widgets/locales/en-US/ui_heatmap.html
@@ -1,0 +1,41 @@
+
+<script type="text/html" data-help-name="ui-heatmap">
+    <h3>Properties</h3>
+    <dl class="message-properties">
+        <dt>Label <span class="property-type">str</span></dt>
+        <dd>Text shown above the rendered chart in the Dashboard.</dd>
+        <dt>Type <span class="property-type">line | bar | scatter</span></dt>
+        <dd>Choose the type of graph that you wish to render data with. Note
+            that different data structures are accepted for different chart types.</dd>
+        <dt>Show Legend <span class="property-type">bool</span></dt>
+        <dd>Defines whether or not a legend is shown between the title and the chart. Each label is driven by <code>msg.topic</code>.</dd>
+        <dt>X-Axis Type <span class="property-type">linear | categorical | time</span></dt>
+        <dd>
+            For charts with an x-axis, this option allows customisation
+            of the type of axis to render.
+        </dd>
+        <dt>Properties <span class="property-type">string</span></dt>
+        <dd>
+            <p><b>Series:</b> Controls how you want to set the Series of data stream into this widget. The default is <code>msg.topic</code>, where separate topics will render to a new line/bar in their respective plots. You can also provide a JSON array, which will plot multiple data points from a single msg object.</p>
+            <p><b>X:</b> Only available for Line & Scatter Charts. This defines the key (which can be nested) of the value that should be plotted onto the x-axis. If left blank, the x-value will be calculated as the current timestamp.</p>
+            <p><b>Y:</b> Defines the key (which can be nested, e.g. <code>'nested.value'</code>) of the value that should be plotted onto the x-axis. This value is ignored if injecting single numerical values into the chart.</p>
+        </dd>
+    </dl>
+    <h3>Input</h3>
+    <p>Data can be passed into the Chart node in a variety of formats,
+    depending on the "X-Axis Type" (e.g. linear, categorical, time).</p>
+    <dl class="message-properties">
+        <dt>Numerical <span class="property-type">linear | categorical | time</span></dt>
+        <dd><pre>msg.payload = 5</pre> A single value, that will be plotted
+            in the y-axis, and the current time of injection as the x-value.</dd>
+        <dt>Series <span class="property-type">linear | categorical | time</span></dt>
+        <dd><pre>msg.topic = 'Series 1'</pre> Multiple series can
+            be shown on the same chart by using a different msg.topic value on each
+            input message.</dd>
+        <dt>Object <span class="property-type">linear</span></dt>
+        <dd><pre>msg.payload = {x: 10, y: 15}</pre>This type of data is only
+            supported on linear plots, e.g. "Line" or "Scatter" charts.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p></p>
+</script>

--- a/nodes/widgets/locales/en-US/ui_heatmap.html
+++ b/nodes/widgets/locales/en-US/ui_heatmap.html
@@ -1,41 +1,72 @@
-
 <script type="text/html" data-help-name="ui-heatmap">
     <h3>Properties</h3>
     <dl class="message-properties">
-        <dt>Label <span class="property-type">str</span></dt>
-        <dd>Text shown above the rendered chart in the Dashboard.</dd>
-        <dt>Type <span class="property-type">line | bar | scatter</span></dt>
-        <dd>Choose the type of graph that you wish to render data with. Note
-            that different data structures are accepted for different chart types.</dd>
-        <dt>Show Legend <span class="property-type">bool</span></dt>
-        <dd>Defines whether or not a legend is shown between the title and the chart. Each label is driven by <code>msg.topic</code>.</dd>
-        <dt>X-Axis Type <span class="property-type">linear | categorical | time</span></dt>
+        <dt>Grid size <span class="property-type">rows | columns</span></dt>
+        <dd>Choose the dimensions of the grid, by specifying the number of rows and columns.</dd>
+        <dt>Radius <span class="property-type">number</span></dt>
+        <dd>Defines the radius of a data point, in times the size of a grid cell.</dd>
+        <dt>Min value <span class="property-type">number</span></dt>
         <dd>
-            For charts with an x-axis, this option allows customisation
-            of the type of axis to render.
+            Define the minimum data value, i.e. the data value that will correspond
+            to offset 0.0 in the color gradient.  If not specified, the minimum data
+            value is automatically adjusted to the minimum value in the input data.
         </dd>
-        <dt>Properties <span class="property-type">string</span></dt>
+        <dt>Max value <span class="property-type">number</span></dt>
         <dd>
-            <p><b>Series:</b> Controls how you want to set the Series of data stream into this widget. The default is <code>msg.topic</code>, where separate topics will render to a new line/bar in their respective plots. You can also provide a JSON array, which will plot multiple data points from a single msg object.</p>
-            <p><b>X:</b> Only available for Line & Scatter Charts. This defines the key (which can be nested) of the value that should be plotted onto the x-axis. If left blank, the x-value will be calculated as the current timestamp.</p>
-            <p><b>Y:</b> Defines the key (which can be nested, e.g. <code>'nested.value'</code>) of the value that should be plotted onto the x-axis. This value is ignored if injecting single numerical values into the chart.</p>
+            Define the maximum data value, i.e. the data value that will correspond
+            to offset 1.0 in the color gradient.  If not specified, the maximum data
+            value is automatically adjusted to the maximum value in the input data.
+        </dd>
+        <dt>Opacity <span class="property-type">number</span></dt>
+        <dd>
+            Define the opacity factor that will be applied to the entire heatmap.
+        </dd>
+        <dt>Angle <span class="property-type">number</span></dt>
+        <dd>
+            Define the rotation angle of the entire heatmap.
+        </dd>
+        <dt>X <span class="property-type">number</span></dt>
+        <dd>
+            Define the translation distance of the entire heatmap into the X direction.
+        </dd>
+        <dt>Y <span class="property-type">number</span></dt>
+        <dd>
+            Define the translation distance of the entire heatmap into the Y direction.
+        </dd>
+        <dt>Zoom <span class="property-type">number</span></dt>
+        <dd>
+            Define the zoom factor of the entire heatmap.
+        </dd>
+        <dt>Background <span class="property-type">number</span></dt>
+        <dd>
+            Define the url of the background image that needs to be drawn behind the
+            heatmap.  A base64 encoded url will contain the image data.
+        </dd>
+        <dt>Color gradient <span class="property-type">table</span></dt>
+        <dd>
+            <p><b>Offset:</b> The position at which a particular color starts in the gradient.</p>
+            <p><b>Color:</b> The visible hue, which represents a value or category (e.g. red
+            is hot and blue is cold).</p>
+            <p><b>Opacity:</b> How transparent the color is.</p>
         </dd>
     </dl>
     <h3>Input</h3>
-    <p>Data can be passed into the Chart node in a variety of formats,
-    depending on the "X-Axis Type" (e.g. linear, categorical, time).</p>
+    <p>Data can be passed into the Heatmap node in a variety of formats,
+    depending on the topic ("setData" or "addData").</p>
     <dl class="message-properties">
-        <dt>Numerical <span class="property-type">linear | categorical | time</span></dt>
-        <dd><pre>msg.payload = 5</pre> A single value, that will be plotted
-            in the y-axis, and the current time of injection as the x-value.</dd>
-        <dt>Series <span class="property-type">linear | categorical | time</span></dt>
-        <dd><pre>msg.topic = 'Series 1'</pre> Multiple series can
-            be shown on the same chart by using a different msg.topic value on each
-            input message.</dd>
-        <dt>Object <span class="property-type">linear</span></dt>
-        <dd><pre>msg.payload = {x: 10, y: 15}</pre>This type of data is only
-            supported on linear plots, e.g. "Line" or "Scatter" charts.</dd>
+        <dt>Numerical array <span class="property-type">numbers</span></dt>
+        <dd><pre>msg.payload = [1, 2, 3, 4, 5 ...]</pre> An array of numeric values which
+            will be drawn from left to right, and top to bottom.  This type of data is
+            only supported for topic "setData".</dd>
+        <dt>Object array <span class="property-type">objects</span></dt>
+        <dd><pre>msg.payload = [{row: 10, column: 15, value: 5}, ...]</pre>An array of 
+            numeric values which will be drawn at the specified grid cell.  This type 
+            of data is supported for both topics "addData" and "setData".</dd>
     </dl>
-    <h3>Details</h3>
-    <p></p>
+    <h3>Dynamic Properties</h3>
+    <dt>msg.topic <span class="property-type">append | replace</span></dt>
+    <dd>
+        Can be used to override the default settings in the config screen, by the new value
+        in the msg.payload.
+    </dd>
 </script>

--- a/nodes/widgets/locales/en-US/ui_heatmap.html
+++ b/nodes/widgets/locales/en-US/ui_heatmap.html
@@ -27,11 +27,11 @@
         </dd>
         <dt>X <span class="property-type">number</span></dt>
         <dd>
-            Define the translation distance of the entire heatmap into the X direction.
+            Define the translation distance of the entire heatmap into the X direction (in grid cell units).
         </dd>
         <dt>Y <span class="property-type">number</span></dt>
         <dd>
-            Define the translation distance of the entire heatmap into the Y direction.
+            Define the translation distance of the entire heatmap into the Y direction (in grid cell units).
         </dd>
         <dt>Zoom <span class="property-type">number</span></dt>
         <dd>

--- a/nodes/widgets/ui_heatmap.html
+++ b/nodes/widgets/ui_heatmap.html
@@ -139,7 +139,6 @@
                         offset: 1.0
                     }],
                     validate: function (v) {
-                        debugger
                         return validateColorGradient(v)
                     }
                 },
@@ -164,7 +163,7 @@
                     id: "node-heatmap-tabsheets",
                     onchange: function(tab) {
                         node.currentTabId = tab.id
-debugger
+
                         // Show only the content (i.e. the children) of the selected tabsheet, and hide the others
                         $("#node-heatmap-tabsheets-content").children().hide()
                         $("#" + tab.id).show()
@@ -388,7 +387,7 @@ debugger
                 <ol id="node-input-colorgradient-container"></ol>
             </div>
             <div class="form-row" style="margin-bottom:0;">
-                <div id="node-colorgradient-error" class="form-tips" style="max-width: none;font-weight: bold;"></div>
+                <div id="node-colorgradient-error" class="form-tips" style="max-width: none;font-weight: bold;color: red;"></div>
             </div>
         </div>
 </script>

--- a/nodes/widgets/ui_heatmap.html
+++ b/nodes/widgets/ui_heatmap.html
@@ -3,6 +3,83 @@
         function hasProperty (obj, prop) {
             return Object.prototype.hasOwnProperty.call(obj, prop)
         }
+
+        function isSortedAscending(arr) {
+            for (let i = 0; i < arr.length - 1; i++) {
+                if (arr[i + 1].offset - arr[i].offset < 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        function hasDuplicates(arr) {
+            let uniqueObjects = new Set();
+            for (const obj of arr) {
+               let identifier = `${obj.opacity}-${obj.offset}-${obj.color}`;
+               if (uniqueObjects.has(identifier)) {
+                   return true; // Found a duplicate
+               }
+               uniqueObjects.add(identifier);
+            }
+            return false; // No duplicates found
+        }
+
+        // Validate the options to (choose and) show configuration error if any.
+        // Any changes for options (adds new or changes any value), calls validation.
+        function validateColorGradient(colorGradient){
+            // When no input parameter, copy all the options from the editableList to this a temporary object
+            if(!colorGradient) {
+                colorGradient = []
+
+                let colorGradientList = $("#node-input-colorgradient-container").editableList('items')
+                colorGradientList.each(function(i) {
+                    let colorGradientItem = $(this)
+                    let offset = colorGradientItem.find(".node-input-colorgradient-offset").val()
+                    let color = colorGradientItem.find(".node-input-colorgradient-color").val()
+                    let opacity = colorGradientItem.find(".node-input-colorgradient-opacity").val()
+                    colorGradient.push({offset:offset, color:color, opacity: opacity})
+                })
+            }
+
+            if (hasDuplicates(colorGradient)) {
+                $("#node-colorgradient-error").text("No duplicate rows allowed")
+                $("#node-colorgradient-error").show();
+                return false
+            }
+            else if(colorGradient.length < 2){
+                $("#node-colorgradient-error").text("Configure at least two lines")
+                $("#node-colorgradient-error").show();
+                return false
+            }
+            else if(!isSortedAscending(colorGradient)) {
+                $("#node-colorgradient-error").text("The offset values should be ascending")
+                $("#node-colorgradient-error").show();
+                return false
+            }
+            else if(colorGradient[0].offset != 0){
+                $("#node-colorgradient-error").text("The first offset should be 0")
+                $("#node-colorgradient-error").show();
+                return false
+            }
+            // A float is 1.0 when the remainder of a division by 1 is 0
+            else if(colorGradient[colorGradient.length - 1].offset % 1 !== 0){
+                $("#configError").text("The last offset should be 1.0")
+                $("#node-colorgradient-error").show();
+                return false
+            }
+            else if(!colorGradient.every(obj => { return obj.opacity >= 0.0 && obj.opacity <= 1.0 })) {
+                $("#node-colorgradient-error").text("All opacity values should be between 0.0 and 1.0")
+                $("#node-colorgradient-error").show();
+                return false
+            }
+            else {
+                // Valid color gradient
+                $("#node-colorgradient-error").hide();
+                return true
+            }
+        }
+
         RED.nodes.registerType('ui-heatmap', {
             category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
             color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
@@ -37,21 +114,34 @@
                 translateY: { value: 0 },
                 zoomFactor: { value: 1.0 },
                 colorGradient: { value: [{
-                        color: [0, 0, 0, 0.00],
+                        color: '#000000', // Black
+                        opacity: 0.00,
                         offset: 0
-                    }, {
-                        color: [0, 0, 255, 0.2],
+                    },
+                    {
+                        color: '#0000FF', // Blue
+                        opacity: 0.2,
                         offset: 0.2
-                    }, {
-                        color: [0, 255, 0, 0.5],
+                    },
+                    {
+                        color: '#00FF00', // Green
+                        opacity: 0.5,
                         offset: 0.45
-                    }, {
-                        color: [255, 255, 0, 1.0],
+                    },
+                    {
+                        color: '#FFFF00', // Yellow
+                        opacity: 1.0,
                         offset: 0.85
-                    }, {
-                        color: [255, 0, 0, 1.0],
+                    },
+                    {
+                        color: '#FF0000', // Red
+                        opacity: 1.0,
                         offset: 1.0
-                    }]
+                    }],
+                    validate: function (v) {
+                        debugger
+                        return validateColorGradient(v)
+                    }
                 },
                 backgroundImageUrl: { value: "" }
             },
@@ -61,10 +151,32 @@
             icon: 'font-awesome/fa-i-cursor',
             paletteLabel: 'heatmap',
             oneditprepare: function () {
+                let node = this
+
                 $('#node-input-size').elementSizer({
                     width: '#node-input-width',
                     height: '#node-input-height',
                     group: '#node-input-group'
+                })
+
+                // Show tabsheets
+                node.tabs = RED.tabs.create({
+                    id: "node-heatmap-tabsheets",
+                    onchange: function(tab) {
+                        node.currentTabId = tab.id
+debugger
+                        // Show only the content (i.e. the children) of the selected tabsheet, and hide the others
+                        $("#node-heatmap-tabsheets-content").children().hide()
+                        $("#" + tab.id).show()
+                    }
+                })
+                node.tabs.addTab({
+                    id: "node-heatmap-tabsheet-settings",
+                    label: "Settings"
+                })
+                node.tabs.addTab({
+                    id: "node-heatmap-tabsheet-colorgradient",
+                    label: "Color gradient"
                 })
 
                 $('#node-input-topic').typedInput({
@@ -109,6 +221,70 @@
                             $('#node-input-sendOnDelay').click()
                         }
                     }
+                })
+
+                let colorGradientList = $("#node-input-colorgradient-container").css('min-height','200px').editableList({
+                    header: $("<div>").css('padding-left','32px').append($.parseHTML(
+                       "<div style='width:30%; display: inline-grid'><b>Offset</b></div>" +
+                       "<div style='width:30%; display: inline-grid'><b>Color</b></div>" +
+                       "<div style='width:30%; display: inline-grid'><b>Opacity</b></div>" )),
+                    addItem: function(colorgradientContainer, i, colorGradientItem) {
+                        // Add a new row to the editableList
+                        let row = $('<div/>').appendTo(colorgradientContainer)
+
+                        // Column 1 : Add a numeric input field to the new row, that represents the offset
+                        let offsetField = $('<input/>',{class:"node-input-colorgradient-offset",type:"number",min:"0",max:"1",step:"0.01"}).css({"width":"30%","margin-left":"5px","margin-right":"5px"}).appendTo(row)
+                        offsetField.val(colorGradientItem.offset)
+                        offsetField.on("input", function() {
+                            validateColorGradient()
+                        })
+
+                        // Column 2 : Add a color input field to the new row, that represents the color
+                        let colorField = $('<input/>',{class:"node-input-colorgradient-color",type:"color"}).css({"width":"30%","margin-left":"5px","margin-right":"5px"}).appendTo(row)
+                        colorField.val(colorGradientItem.color)
+                        colorField.on("input", function() {
+                            validateColorGradient()
+                        })
+
+
+                        // Column 3 : Add a numeric input field to the new row, that represents the opacity
+                        let opacityField = $('<input/>',{class:"node-input-colorgradient-opacity",type:"number",min:"0",max:"1",step:"0.1"}).css({"width":"30%","margin-left":"5px"}).appendTo(row)
+                        opacityField.val(colorGradientItem.opacity)
+                        opacityField.on("input", function() {
+                            validateColorGradient()
+                        })
+
+                        validateColorGradient()
+                    },
+                    removeItem: function(data) {
+                        validateColorGradient()
+                    },
+                    sortItems: function(items) {
+                        validateColorGradient()
+                    },
+                    removable: true,
+                    sortable:true
+                })
+
+                // Copy all the color gradient items from this node to the editableList
+                if (node.colorGradient) {
+                    node.colorGradient.forEach(function (colorGradientItem, index) {
+                        colorGradientList.editableList('addItem', colorGradientItem)
+                    })
+                }
+            },
+            oneditsave: function() {
+                let node = this
+
+                // Copy all the color gradient items from the editableList to this node
+                node.colorGradient = []
+                let colorGradientList = $("#node-input-colorgradient-container").editableList('items')
+                colorGradientList.each(function(i) {
+                    let colorGradientItem = $(this)
+                    let offset = colorGradientItem.find(".node-input-colorgradient-offset").val()
+                    let color = colorGradientItem.find(".node-input-colorgradient-color").val()
+                    let opacity = colorGradientItem.find(".node-input-colorgradient-opacity").val()
+                    node.colorGradient.push({offset:offset, color:color, opacity: opacity})
                 })
             },
             label: function () {
@@ -156,46 +332,63 @@
         <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; margin-top: 0; margin-left: 3px;">
     </div>
     <div class="form-row">
-        <label for="node-input-rows"><i class="fa fa-arrows-alt"></i> Grid size</label>
-        <span for="node-input-rows">Rows</span>
-        <input type="text" id="node-input-rows" style="width:80px" min="1">
-        <span for="node-input-columns" style="margin-left:20px;"> Columns</span>
-        <input type="text" id="node-input-columns" style="width:80px" min="1">
+        <!-- Tabsheets -->
+        <ul style="background: #fff; min-width: 600px; margin-bottom: 20px;" id="node-heatmap-tabsheets"></ul>
     </div>
-    <div class="form-row">
-        <label for="node-input-pointRadius"><i class="fa fa-bullseye"></i> Radius</label>
-        <input type="number" id="node-input-pointRadius" min="0.1" step="0.1">
-    </div>
-    <div class="form-row">
-        <label for="node-input-minDataValue"><i class="fa fa-level-up"></i> Min value</label>
-        <input type="number" id="node-input-minDataValue" min="0" step="1">
-    </div>
-    <div class="form-row">
-        <label for="node-input-maxDataValue"><i class="fa fa-level-down"></i> Max value</label>
-        <input type="number" id="node-input-maxDataValue" min="0" step="1">
-    </div>
-    <div class="form-row">
-        <label for="node-input-opacityFactor"><i class="fa fa-low-vision"></i> Opacity</label>
-        <input type="number" id="node-input-opacityFactor" min="0" max="1" step="0.1">
-    </div>
-    <div class="form-row">
-        <label for="node-input-rotationAngle"><i class="fa fa-repeat"></i> Angle</label>
-        <input type="number" id="node-input-rotationAngle" min="0" max="360" step="1">
-    </div>
-    <div class="form-row">
-        <label for="node-input-translateX"><i class="fa fa-arrows-h"></i> X</label>
-        <input type="number" id="node-input-translateX" min="0" step="1">
-    </div>
-    <div class="form-row">
-        <label for="node-input-translateY"><i class="fa fa-arrows-v"></i> Y</label>
-        <input type="number" id="node-input-translateY" min="0" step="1">
-    </div>
-    <div class="form-row">
-        <label for="node-input-zoomFactor"><i class="fa fa-search"></i> Zoom</label>
-        <input type="number" id="node-input-zoomFactor" min="1.0" step="0.1">
-    </div>
-    <div class="form-row">
-        <label for="node-input-backgroundImageUrl"><i class="fa fa-picture-o"></i> Background</label>
-        <input type="text" id="node-input-backgroundImageUrl">
-    </div>
+    <div id="node-heatmap-tabsheets-content" style="min-height: 150px">
+        <!-- Content of all tabsheets -->
+        <div id="node-heatmap-tabsheet-settings" class="node-heatmap-tabsheet-content" style="position: relative; margin-top: 30px;">
+            <div class="form-row">
+                <label for="node-input-rows"><i class="fa fa-arrows-alt"></i> Grid size</label>
+                <span for="node-input-rows">Rows</span>
+                <input type="text" id="node-input-rows" style="width:80px" min="1">
+                <span for="node-input-columns" style="margin-left:20px;"> Columns</span>
+                <input type="text" id="node-input-columns" style="width:80px" min="1">
+            </div>
+            <div class="form-row">
+                <label for="node-input-pointRadius"><i class="fa fa-bullseye"></i> Radius</label>
+                <input type="number" id="node-input-pointRadius" min="0.1" step="0.1">
+            </div>
+            <div class="form-row">
+                <label for="node-input-minDataValue"><i class="fa fa-level-up"></i> Min value</label>
+                <input type="number" id="node-input-minDataValue" min="0" step="1">
+            </div>
+            <div class="form-row">
+                <label for="node-input-maxDataValue"><i class="fa fa-level-down"></i> Max value</label>
+                <input type="number" id="node-input-maxDataValue" min="0" step="1">
+            </div>
+            <div class="form-row">
+                <label for="node-input-opacityFactor"><i class="fa fa-low-vision"></i> Opacity</label>
+                <input type="number" id="node-input-opacityFactor" min="0" max="1" step="0.1">
+            </div>
+            <div class="form-row">
+                <label for="node-input-rotationAngle"><i class="fa fa-repeat"></i> Angle</label>
+                <input type="number" id="node-input-rotationAngle" min="0" max="360" step="1">
+            </div>
+            <div class="form-row">
+                <label for="node-input-translateX"><i class="fa fa-arrows-h"></i> X</label>
+                <input type="number" id="node-input-translateX" min="0" step="1">
+            </div>
+            <div class="form-row">
+                <label for="node-input-translateY"><i class="fa fa-arrows-v"></i> Y</label>
+                <input type="number" id="node-input-translateY" min="0" step="1">
+            </div>
+            <div class="form-row">
+                <label for="node-input-zoomFactor"><i class="fa fa-search"></i> Zoom</label>
+                <input type="number" id="node-input-zoomFactor" min="1.0" step="0.1">
+            </div>
+            <div class="form-row">
+                <label for="node-input-backgroundImageUrl"><i class="fa fa-picture-o"></i> Background</label>
+                <input type="text" id="node-input-backgroundImageUrl">
+            </div>
+        </div>
+        <div id="node-heatmap-tabsheet-colorgradient" class="node-heatmap-tabsheet-content" style="position: relative; margin-top: 30px;">
+            <div class="form-row">
+                <!-- Editable table container for color gradient -->
+                <ol id="node-input-colorgradient-container"></ol>
+            </div>
+            <div class="form-row" style="margin-bottom:0;">
+                <div id="node-colorgradient-error" class="form-tips" style="max-width: none;font-weight: bold;"></div>
+            </div>
+        </div>
 </script>

--- a/nodes/widgets/ui_heatmap.html
+++ b/nodes/widgets/ui_heatmap.html
@@ -28,11 +28,9 @@
                 // Heatmap specific properties
                 rows: { value: 10, required: true},
                 columns: { value: 10, required: true},
-                pointRadius: { value: 20.0 },
-                pointRadius: { value: 20.0 },
+                pointRadius: { value: 2.0 },
                 minDataValue: { value: null },
                 maxDataValue: { value: null },
-                blurFactor: { value: 1.0 },
                 opacityFactor: { value: 1.0 },
                 rotationAngle: { value: 0.0 },
                 translateX: { value: 0 },
@@ -166,7 +164,7 @@
     </div>
     <div class="form-row">
         <label for="node-input-pointRadius"><i class="fa fa-bullseye"></i> Radius</label>
-        <input type="number" id="node-input-pointRadius" min="1" step="1">
+        <input type="number" id="node-input-pointRadius" min="0.1" step="0.1">
     </div>
     <div class="form-row">
         <label for="node-input-minDataValue"><i class="fa fa-level-up"></i> Min value</label>
@@ -175,10 +173,6 @@
     <div class="form-row">
         <label for="node-input-maxDataValue"><i class="fa fa-level-down"></i> Max value</label>
         <input type="number" id="node-input-maxDataValue" min="0" step="1">
-    </div>
-    <div class="form-row">
-        <label for="node-input-blurFactor"><i class="fa fa-soundcloud"></i> Blur</label>
-        <input type="number" id="node-input-blurFactor" min="0" max="1" step="0.1">
     </div>
     <div class="form-row">
         <label for="node-input-opacityFactor"><i class="fa fa-low-vision"></i> Opacity</label>

--- a/nodes/widgets/ui_heatmap.html
+++ b/nodes/widgets/ui_heatmap.html
@@ -1,0 +1,207 @@
+<script type="text/javascript">
+    (function () {
+        function hasProperty (obj, prop) {
+            return Object.prototype.hasOwnProperty.call(obj, prop)
+        }
+        RED.nodes.registerType('ui-heatmap', {
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
+            defaults: {
+                group: { type: 'ui-group', required: true },
+                name: { value: '' },
+                label: { value: 'heatmap' },
+                order: { value: 0 },
+                width: {
+                    value: 0,
+                    validate: function (v) {
+                        const width = v || 0
+                        const currentGroup = $('#node-input-group').val() || this.group
+                        const groupNode = RED.nodes.node(currentGroup)
+                        const valid = !groupNode || +width <= +groupNode.width
+                        $('#node-input-size').toggleClass('input-error', !valid)
+                        return valid
+                    }
+                },
+                height: { value: 0 },
+                passthru: { value: true },
+                className: { value: '' },
+                // Heatmap specific properties
+                rows: { value: 10, required: true},
+                columns: { value: 10, required: true},
+                pointRadius: { value: 20.0 },
+                pointRadius: { value: 20.0 },
+                minDataValue: { value: null },
+                maxDataValue: { value: null },
+                blurFactor: { value: 1.0 },
+                opacityFactor: { value: 1.0 },
+                rotationAngle: { value: 0.0 },
+                translateX: { value: 0 },
+                translateY: { value: 0 },
+                zoomFactor: { value: 1.0 },
+                colorGradient: { value: [{
+                        color: [0, 0, 0, 0.00],
+                        offset: 0
+                    }, {
+                        color: [0, 0, 255, 0.2],
+                        offset: 0.2
+                    }, {
+                        color: [0, 255, 0, 0.5],
+                        offset: 0.45
+                    }, {
+                        color: [255, 255, 0, 1.0],
+                        offset: 0.85
+                    }, {
+                        color: [255, 0, 0, 1.0],
+                        offset: 1.0
+                    }]
+                },
+                backgroundImageUrl: { value: "" }
+            },
+            inputs: 1,
+            outputs: 1,
+            outputLabels: function () { return this.mode },
+            icon: 'font-awesome/fa-i-cursor',
+            paletteLabel: 'heatmap',
+            oneditprepare: function () {
+                $('#node-input-size').elementSizer({
+                    width: '#node-input-width',
+                    height: '#node-input-height',
+                    group: '#node-input-group'
+                })
+
+                $('#node-input-topic').typedInput({
+                    default: 'str',
+                    typeField: $('#node-input-topicType'),
+                    types: ['str', 'msg', 'flow', 'global']
+                })
+
+                $('#node-input-backgroundImageUrl').typedInput({
+                    default: 'str',
+                    types: ['str']
+                })
+
+                // use jQuery UI tooltip to convert the plain old title attribute to a nice tooltip
+                $('.ui-node-popover-title').tooltip({
+                    show: {
+                        effect: 'slideDown',
+                        delay: 150
+                    }
+                })
+
+                $('#node-input-mode').on('change', (evt) => {
+                    const mode = $('#node-input-mode').find(':selected').val()
+                    if (mode === 'textarea') {
+                        this.sendOnEnter = false
+                        $('#node-input-container-sendOnEnter').hide()
+                    } else {
+                        $('#node-input-container-sendOnEnter').show()
+                    }
+                })
+
+                $('#node-input-delay').on('change', (evt) => {
+                    const delay = $('#node-input-delay').val()
+                    if (delay === '' || delay === '0') {
+                        this.sendOnDelay = false
+                        if ($('#node-input-sendOnDelay').is(':checked')) {
+                            $('#node-input-sendOnDelay').click()
+                        }
+                    } else {
+                        this.sendOnDelay = true
+                        if (!$('#node-input-sendOnDelay').is(':checked')) {
+                            $('#node-input-sendOnDelay').click()
+                        }
+                    }
+                })
+            },
+            label: function () {
+                return this.name || (~this.label.indexOf('{' + '{') ? null : this.label) || this.mode + ' input'
+            },
+            labelStyle: function () { return this.name ? 'node_label_italic' : '' }
+        })
+    })()
+</script>
+
+<script type="text/html" data-template-name="ui-heatmap">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
+        <input type="text" id="node-input-group">
+    </div>
+    <div class="form-row">
+        <label><i class="fa fa-object-group"></i> Size</label>
+        <input type="hidden" id="node-input-width">
+        <input type="hidden" id="node-input-height">
+        <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row">
+        <label for="node-input-label"><i class="fa fa-i-cursor"></i> Label</label>
+        <input type="text" id="node-input-label">
+    </div>
+    <div class="form-row">
+        <label for="node-input-className"><i class="fa fa-code"></i> Class</label>
+        <div style="display: inline;">
+            <input style="width: 70%;" type="text" id="node-input-className" placeholder="Optional CSS class name(s)" style="flex-grow: 1;">
+            <a
+                data-html="true"
+                title="Dynamic Property: Class names can also be set by sending a message to the node with a msg.topic of 'ui-property:class' and a payload containing the class name(s) to be applied. NOTE: classes set at runtime will be applied in addition to any class(es) set in the nodes class field."
+                class="red-ui-button ui-node-popover-title"
+                style="margin-left: 4px; cursor: help; font-size: 0.625rem; border-radius: 50%; width: 24px; height: 24px; display: inline-flex; justify-content: center; align-items: center;">
+                <i style="font-family: ui-serif;">fx</i>
+            </a>
+        </div>
+    </div>
+    <div class="form-row">
+        <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
+        <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; margin-top: 0; margin-left: 3px;">
+    </div>
+    <div class="form-row">
+        <label for="node-input-rows"><i class="fa fa-arrows-alt"></i> Grid size</label>
+        <span for="node-input-rows">Rows</span>
+        <input type="text" id="node-input-rows" style="width:80px" min="1">
+        <span for="node-input-columns" style="margin-left:20px;"> Columns</span>
+        <input type="text" id="node-input-columns" style="width:80px" min="1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-pointRadius"><i class="fa fa-bullseye"></i> Radius</label>
+        <input type="number" id="node-input-pointRadius" min="1" step="1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-minDataValue"><i class="fa fa-level-up"></i> Min value</label>
+        <input type="number" id="node-input-minDataValue" min="0" step="1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-maxDataValue"><i class="fa fa-level-down"></i> Max value</label>
+        <input type="number" id="node-input-maxDataValue" min="0" step="1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-blurFactor"><i class="fa fa-soundcloud"></i> Blur</label>
+        <input type="number" id="node-input-blurFactor" min="0" max="1" step="0.1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-opacityFactor"><i class="fa fa-low-vision"></i> Opacity</label>
+        <input type="number" id="node-input-opacityFactor" min="0" max="1" step="0.1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-rotationAngle"><i class="fa fa-repeat"></i> Angle</label>
+        <input type="number" id="node-input-rotationAngle" min="0" max="360" step="1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-translateX"><i class="fa fa-arrows-h"></i> X</label>
+        <input type="number" id="node-input-translateX" min="0" step="1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-translateY"><i class="fa fa-arrows-v"></i> Y</label>
+        <input type="number" id="node-input-translateY" min="0" step="1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-zoomFactor"><i class="fa fa-search"></i> Zoom</label>
+        <input type="number" id="node-input-zoomFactor" min="1.0" step="0.1">
+    </div>
+    <div class="form-row">
+        <label for="node-input-backgroundImageUrl"><i class="fa fa-picture-o"></i> Background</label>
+        <input type="text" id="node-input-backgroundImageUrl">
+    </div>
+</script>

--- a/nodes/widgets/ui_heatmap.html
+++ b/nodes/widgets/ui_heatmap.html
@@ -223,7 +223,7 @@
                 })
 
                 let colorGradientList = $("#node-input-colorgradient-container").css('min-height','200px').editableList({
-                    header: $("<div>").css('padding-left','32px').append($.parseHTML(
+                    header: $("<div>").css({"margin-left":"28px","margin-right":"10x","padding-right":"0px"}).append($.parseHTML(
                        "<div style='width:30%; display: inline-grid'><b>Offset</b></div>" +
                        "<div style='width:30%; display: inline-grid'><b>Color</b></div>" +
                        "<div style='width:30%; display: inline-grid'><b>Opacity</b></div>" )),

--- a/nodes/widgets/ui_heatmap.js
+++ b/nodes/widgets/ui_heatmap.js
@@ -9,6 +9,7 @@ module.exports = function (RED) {
 
         // which group are we rendering this widget
         const group = RED.nodes.getNode(config.group)
+        const base = group.getBase()
 
         function getProperty (value, property) {
             const props = property.split('.')
@@ -43,10 +44,11 @@ module.exports = function (RED) {
                             let convertedInputArray = [];
                             for (let row = 0; row < config.rows; row++) {
                                 for (let column = 0; column < config.columns; column++) {
+                                    let index = row * config.columns + column
                                     convertedInputArray.push({
                                         row: row,
                                         column: column,
-                                        value: msg.payload[row + column]
+                                        value: msg.payload[index]
                                     })
                                 }
                             }
@@ -70,13 +72,13 @@ module.exports = function (RED) {
 
                 if (msg.topic == 'setData') {
                     // When a new data array is being set, store a copy of it
-                    datastore.save(node.id, msg.payload.slice());
+                    datastore.save(base, node, msg.payload.slice());
                 }
                 else if (msg.topic == 'addData') {
                     // When new data (array) is being added, append a copy of it to the currently stored array
                     let storedData = datastore.get(node.id) || [];
                     storedData.push(msg.payload.slice());
-                    datastore.save(storedData);
+                    datastore.save(base, node, storedData);
                 }
 
                 send(msg)

--- a/nodes/widgets/ui_heatmap.js
+++ b/nodes/widgets/ui_heatmap.js
@@ -1,0 +1,91 @@
+const datastore = require('../store/data.js')
+
+module.exports = function (RED) {
+    function HeatmapNode (config) {
+        const node = this
+
+        // create node in Node-RED
+        RED.nodes.createNode(this, config)
+
+        // which group are we rendering this widget
+        const group = RED.nodes.getNode(config.group)
+
+        function getProperty (value, property) {
+            const props = property.split('.')
+            props.forEach((prop) => {
+                if (value) {
+                    value = value[prop]
+                }
+            })
+            return value
+        }
+
+        const evts = {
+            // beforeSend will run before messages are sent client-side, as well as before sending on within Node-RED
+            // here, we use it to pre-process chart data to format it ready for plotting
+            beforeSend: function (msg) {
+                return msg
+            },
+            onInput: function (msg, send, done) {
+                debugger;
+                if (msg.topic == 'setData' || msg.topic == 'addData') {
+                    if (!Array.isArray(msg.payload)) {
+                        throw Error('For topic setData or addData the payload should contain an array');
+                    }
+
+                    if (msg.payload.length > 0) {
+                        if (msg.payload.every(element => typeof element === "number")) {
+                            if (msg.payload.length != config.rows * config.columns) {
+                                throw Error('When the payload is an array of numbers, there should be row * column numbers');
+                            }
+
+                            // Convert the array of integers to an array of objects (containing x, y, value properties)
+                            let convertedInputArray = [];
+                            for (let row = 0; row < config.rows; row++) {
+                                for (let column = 0; column < config.columns; column++) {
+                                    convertedInputArray.push({
+                                        row: row,
+                                        column: column,
+                                        value: msg.payload[row + column]
+                                    })
+                                }
+                            }
+                            msg.payload = convertedInputArray;
+                        }
+                        else {
+                            if (!msg.payload.every(item => typeof item === "object" &&
+                                                     item.hasOwnProperty('row') &&
+                                                     item.hasOwnProperty('column') &&
+                                                     item.hasOwnProperty('value') &&
+                                                     typeof item.row === "number" &&
+                                                     item.row < config.rows &&
+                                                     typeof item.column === "number" &&
+                                                     item.column < config.columns &&
+                                                     typeof item.value === "number")) {
+                                throw Error('The payload should be an array of numbers or an array of objects (with row,column,value properties)');
+                            }
+                        }
+                    }
+                }
+
+                if (msg.topic == 'setData') {
+                    // When a new data array is being set, store a copy of it
+                    datastore.save(node.id, msg.payload.slice());
+                }
+                else if (msg.topic == 'addData') {
+                    // When new data (array) is being added, append a copy of it to the currently stored array
+                    let storedData = datastore.get(node.id) || [];
+                    storedData.push(msg.payload.slice());
+                    datastore.save(storedData);
+                }
+
+                send(msg)
+            }
+        }
+
+        // inform the dashboard UI that we are adding this node
+        group.register(node, config, evts)
+    }
+
+    RED.nodes.registerType('ui-heatmap', HeatmapNode);
+}

--- a/nodes/widgets/ui_heatmap.js
+++ b/nodes/widgets/ui_heatmap.js
@@ -97,6 +97,9 @@ module.exports = function (RED) {
                         storedData.push(msg.payload.slice());
                         datastore.save(base, node, storedData);
                         break;
+                    case 'clear':
+                        datastore.clear();
+                        break;
                 }
 
                 send(msg)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@flowfuse/node-red-dashboard",
-    "version": "0.11.6",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@flowfuse/node-red-dashboard",
-            "version": "0.11.6",
+            "version": "1.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "acorn": "^8.11.2",
@@ -49,6 +49,7 @@
                 "sinon": "^15.2.0",
                 "socket.io-client": "^4.7.2",
                 "sort-package-json": "^2.6.0",
+                "visual-heatmap": "^1.1.0",
                 "vite": "^5.0.0",
                 "vitepress": "^1.0.0-rc.40",
                 "vue-router": "^4.2.4",
@@ -12025,6 +12026,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+            "dev": true
+        },
+        "node_modules/visual-heatmap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/visual-heatmap/-/visual-heatmap-1.1.0.tgz",
+            "integrity": "sha512-GUh21hxa2Bs3BuSEPOlaskXUtzBpyjZjf+exzlIbjWdFQzXVZ94Lmf4LZ+jPAocOLbDKip3zV5DYpTXQxZMBdg==",
             "dev": true
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "sinon": "^15.2.0",
         "socket.io-client": "^4.7.2",
         "sort-package-json": "^2.6.0",
+        "visual-heatmap": "git+https://github.com/bartbutenaers/visual-heatmap.git",
         "vite": "^5.0.0",
         "vitepress": "^1.0.0-rc.40",
         "vue-router": "^4.2.4",
@@ -115,7 +116,8 @@
             "ui-markdown": "nodes/widgets/ui_markdown.js",
             "ui-template": "nodes/widgets/ui_template.js",
             "ui-event": "nodes/widgets/ui_event.js",
-            "ui-control": "nodes/widgets/ui_control.js"
+            "ui-control": "nodes/widgets/ui_control.js",
+            "ui-heatmap": "nodes/widgets/ui_heatmap.js"
         }
     },
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "sinon": "^15.2.0",
         "socket.io-client": "^4.7.2",
         "sort-package-json": "^2.6.0",
-        "visual-heatmap": "git+https://github.com/bartbutenaers/visual-heatmap.git",
+        "visual-heatmap": "^1.1.0",
         "vite": "^5.0.0",
         "vitepress": "^1.0.0-rc.40",
         "vue-router": "^4.2.4",

--- a/ui/src/widgets/index.mjs
+++ b/ui/src/widgets/index.mjs
@@ -4,6 +4,7 @@ import UIControl from './ui-control/UIControl.vue'
 import UIDropdown from './ui-dropdown/UIDropdown.vue'
 import UIEvent from './ui-event/UIEvent.vue'
 import UIForm from './ui-form/UIForm.vue'
+import UIHeatmap from './ui-heatmap/UIHeatmap.vue'
 import UIMarkdown from './ui-markdown/UIMarkdown.vue'
 import UINotification from './ui-notification/UINotification.vue'
 import UIRadioGroup from './ui-radio-group/UIRadioGroup.vue'
@@ -22,6 +23,7 @@ export {
     UIDropdown,
     UIEvent,
     UIForm,
+    UIHeatmap,
     UIMarkdown,
     UINotification,
     UIRadioGroup,
@@ -44,6 +46,7 @@ export default {
     'ui-dropdown': UIDropdown,
     'ui-event': UIEvent,
     'ui-form': UIForm,
+    'ui-heatmap': UIHeatmap,
     'ui-markdown': UIMarkdown,
     'ui-notification': UINotification,
     'ui-radio-group': UIRadioGroup,

--- a/ui/src/widgets/ui-heatmap/UIHeatmap.vue
+++ b/ui/src/widgets/ui-heatmap/UIHeatmap.vue
@@ -1,0 +1,175 @@
+<template>
+    <div ref="heatmap_container" :class="className" style="border:1px solid black;width:100%; height:100%;" />
+</template>
+
+<script>
+
+import Heatmap from 'visual-heatmap/dist/visualHeatmap.esm.browser.min.js' // eslint-disable-line import/no-named-as-default, import/order, n/file-extension-in-import
+import { useDataTracker } from '../data-tracker.mjs' // eslint-disable-line import/order
+import { shallowRef } from 'vue'
+import { mapState } from 'vuex' // eslint-disable-line import/order
+
+export default {
+    name: 'DBUIHeatmap',
+    inject: ['$socket'],
+    props: {
+        id: { type: String, required: true },
+        props: { type: Object, default: () => ({}) }
+    },
+    data () {
+        return {
+            heatmap: null
+        }
+    },
+    computed: {
+        ...mapState('data', ['messages']),
+        label: function () {
+            return this.props.label
+        },
+        type: function () {
+            return this.props.mode || 'heatmap'
+        },
+        value: {
+            get () {
+                return this.messages[this.id]?.payload
+            },
+            set (val) {
+                if (this.value === val) {
+                    return // no change
+                }
+                const msg = this.messages[this.id] || {}
+                msg.payload = val
+                this.messages[this.id] = msg
+            }
+        },
+        validation: function () {
+            // TODO currently no validation
+            return []
+        }
+    },
+    created () {
+        debugger
+        // can't do this in setup as we have custom onInput function
+        useDataTracker(this.id, this.onMsgInput)
+    },
+    mounted () {
+        let heatmapInstance = Heatmap(this.$refs.heatmap_container, {
+            size: this.props.pointRadius,                               // Radius of the data point (in pixels)µ
+            min: this.props.minDataValue,                               // Min data Value for relative gradient computation
+            max: this.props.maxDataValue,                               // Max data Value for relative gradient computation
+            blur: this.props.blurFactor,                                // Blur factor
+            opacity: this.props.opacityFactor,                          // Opacity factor
+            rotationAngle: this.props.rotationAngle,                    // Rotation angle
+            translate: [this.props.translateX, this.props.translateY],  // Translate vector [x, y]
+            zoom: this.props.zoomFactor,                                // Zoom Factor
+            gradient: this.props.colorGradient,                         // Color Gradient (array of objects with color value and offset)
+            backgroundImage: {
+                url: this.props.colorGradient                           // Url of the background image
+            }
+        });
+
+        let maxDataValue = this.props.maxDataValue;
+        if (maxDataValue == "") {
+            maxDataValue = Number.MAX_SAFE_INTEGER;
+        }
+
+        // don't want heatmap to be reactive, so we can use shallowRef
+        this.heatmapInstance = heatmapInstance  //shallowRef(heatmapInstance)
+    },
+    methods: {
+
+        onLoad (history) {
+            // we have received a history of data points
+            // we need to add them to the heatmap
+
+
+            // adding is then just the same process as receiving a new msg
+            this.onMsgInput(history)
+        },
+        onMsgInput (msg) {
+            debugger
+            // because this will get evaluated client-side, we have access to vue/this
+            const vue = this
+            console.log('custom onInput handler:')
+            console.log(msg)
+
+            if (msg.topic == 'setData' || msg.topic == 'addData') {
+                let cellWidth  = this.$refs.heatmap_container.clientWidth / (parseInt(this.props.columns));
+                let cellHeight = this.$refs.heatmap_container.clientHeight / (parseInt(this.props.rows));
+
+                // Calculate for every grid cell the corresponding x and y coordinates (of the center point)
+                msg.payload.forEach(cell => {
+                    cell.x = Math.floor((parseInt(cell.column) + 0.5) * cellWidth);
+                    cell.y = Math.floor((parseInt(cell.row) + 0.5) * cellHeight);
+                });
+            }
+
+            switch(msg.topic) {
+                case 'setBackgroundImageUrl':
+                    this.heatmapInstance.setBackgroundImage({ url: msg.payload })
+                    break
+                case 'setData':
+                    // array of data points with 'x', 'y' and 'value'
+                    this.heatmapInstance.renderData(msg.payload)
+                    break
+                case 'addData':
+                    // array of data points with 'x', 'y' and 'value'
+                    this.heatmapInstance.addData(msg.payload, false)
+                    break
+                case 'setMin':
+                    this.heatmapInstance.setMin(msg.payload)
+                    break
+                case 'setMax':
+                    this.heatmapInstance.setMax(msg.payload)
+                    break
+                case 'setTranslate':
+                    // array[x, y]
+                    this.heatmapInstance.setTranslate(msg.payload);
+                case 'setZoom':
+                    // float
+                    this.heatmapInstance.setZoom(msg.payload)
+                    break
+                case 'setRotationAngle':
+                    this.heatmapInstance.setRotationAngle(msg.payload)
+                    break
+                case 'setSize':
+                    this.heatmapInstance.setSize(msg.payload)
+                    break
+                case 'setBlur':
+                    this.heatmapInstance.setBlur(msg.payload)
+                    break
+                case 'setOpacity':
+                    this.heatmapInstance.setOpacity(msg.payload)
+                    break
+                case 'clear':
+                    this.heatmapInstance.clear()
+                    break
+            }
+            
+            // TODO in een functie moven
+            if (msg.topic == 'setData' || msg.topic == 'addData') {
+                // Get the canvas element which has been created by the visual-heatmap library
+                let canvas = this.$refs.heatmap_container.getElementsByTagName('canvas')[0];
+
+                // TODO moet text size automatisch berekend worden of instelbaar?  Of beide mogelijk?
+                let ctx = canvas.getContext("webgl");
+                ctx.font = "30px Arial";
+                ctx.fillStyle = "black";
+                ctx.textAlign = "center";
+
+                // Draw some text on top of the existing heatmap elements
+                // TODO eventueel een element.label tonen, die we op voorhand opvullen met bv. de waarde
+                this.heatmapInstance.rawData.every(element => ctx.fillText(element.value, element.x, element.y));
+            }
+        },
+        clear () {
+            // TODO this.chart.data.labels = []
+            // TODO this.chart.data.datasets = []
+            // TODO this.chart.update()
+        }
+    }
+}
+</script>
+
+<style scoped>
+</style>

--- a/ui/src/widgets/ui-heatmap/UIHeatmap.vue
+++ b/ui/src/widgets/ui-heatmap/UIHeatmap.vue
@@ -53,11 +53,22 @@ export default {
         useDataTracker(this.id, this.onMsgInput)
     },
     mounted () {
+        debugger
         this.cellWidth  = this.$refs.heatmap_container.clientWidth / (parseInt(this.props.columns));
         this.cellHeight = this.$refs.heatmap_container.clientHeight / (parseInt(this.props.rows));
 
         // Convert the point radius to pixels (average of X and Y direction because gl_PointSize in webgl is the same in both directions)
         let pointRadius = this.props.pointRadius * (this.cellWidth + this.cellHeight) / 2
+
+        // The heatmap package expects rgba colors, so the original hex color (e.g. #FF00FF) and the opacity should be combined to [R,G,B,A]
+        const colorGradient = this.props.colorGradient.map(({ color, opacity, offset }) => {
+            let hexColor = color
+            let r = parseInt(hexColor.slice(1, 3), 16)
+            let g = parseInt(hexColor.slice(3, 5), 16)
+            let b = parseInt(hexColor.slice(5, 7), 16)
+            let rgba = [r, g, b, parseFloat(opacity)]
+            return {color: rgba, offset: parseFloat(offset)}
+        })
 
         let heatmapInstance = Heatmap(this.$refs.heatmap_container, {
             size: pointRadius,                                          // Radius of the data point (in pixels)µ
@@ -67,7 +78,7 @@ export default {
             rotationAngle: this.props.rotationAngle,                    // Rotation angle
             translate: [this.props.translateX, this.props.translateY],  // Translate vector [x, y]
             zoom: this.props.zoomFactor,                                // Zoom Factor
-            gradient: this.props.colorGradient,                         // Color Gradient (array of objects with color value and offset)
+            gradient: colorGradient,                                    // Color Gradient (array of objects with color value and offset)
             backgroundImage: {
                 url: this.props.colorGradient                           // Url of the background image
             }

--- a/ui/src/widgets/ui-heatmap/UIHeatmap.vue
+++ b/ui/src/widgets/ui-heatmap/UIHeatmap.vue
@@ -52,12 +52,14 @@ export default {
         useDataTracker(this.id, this.onMsgInput)
     },
     mounted () {
-        debugger
         this.cellWidth  = this.$refs.heatmap_container.clientWidth / (parseInt(this.props.columns));
         this.cellHeight = this.$refs.heatmap_container.clientHeight / (parseInt(this.props.rows));
 
         // Convert the point radius to pixels (average of X and Y direction because gl_PointSize in webgl is the same in both directions)
         let pointRadius = this.props.pointRadius * (this.cellWidth + this.cellHeight) / 2
+
+        translateX = Math.floor((parseInt(this.props.translateX) + 0.5) * this.cellWidth);
+        translateY = Math.floor((parseInt(this.props.translateY) + 0.5) * this.cellHeight);
 
         // The heatmap package expects rgba colors, so the original hex color (e.g. #FF00FF) and the opacity should be combined to [R,G,B,A]
         let colorGradient = this.convertGradient(this.props.colorGradient)
@@ -68,7 +70,7 @@ export default {
             max: this.props.maxDataValue,                               // Max data Value for relative gradient computation
             opacity: this.props.opacityFactor,                          // Opacity factor
             rotationAngle: this.props.rotationAngle,                    // Rotation angle
-            translate: [this.props.translateX, this.props.translateY],  // Translate vector [x, y]
+            translate: [translateX, translateY],                        // Translate vector [x, y]
             zoom: this.props.zoomFactor,                                // Zoom Factor
             gradient: colorGradient,                                    // Color Gradient (array of objects with color value and offset)
             backgroundImage: {
@@ -113,9 +115,6 @@ export default {
             console.log(msg)
 
             if (msg.topic == 'setData' || msg.topic == 'addData') {
-                //let cellWidth  = this.$refs.heatmap_container.clientWidth / (parseInt(this.props.columns));
-                //let cellHeight = this.$refs.heatmap_container.clientHeight / (parseInt(this.props.rows));
-
                 // Since the heatmap can be displayed on all kind of devices, the server side uses rows and columns
                 // (instead of X and Y coordinates).  As a result, the X and Y coordinates need to be calculated
                 // for every grid cell (i.e. coordinates of the cell center point).

--- a/ui/src/widgets/ui-heatmap/UIHeatmap.vue
+++ b/ui/src/widgets/ui-heatmap/UIHeatmap.vue
@@ -58,8 +58,8 @@ export default {
         // Convert the point radius to pixels (average of X and Y direction because gl_PointSize in webgl is the same in both directions)
         let pointRadius = this.props.pointRadius * (this.cellWidth + this.cellHeight) / 2
 
-        translateX = Math.floor((parseInt(this.props.translateX) + 0.5) * this.cellWidth);
-        translateY = Math.floor((parseInt(this.props.translateY) + 0.5) * this.cellHeight);
+        let translateX = Math.floor((parseInt(this.props.translateX) + 0.5) * this.cellWidth);
+        let translateY = Math.floor((parseInt(this.props.translateY) + 0.5) * this.cellHeight);
 
         // The heatmap package expects rgba colors, so the original hex color (e.g. #FF00FF) and the opacity should be combined to [R,G,B,A]
         let colorGradient = this.convertGradient(this.props.colorGradient)
@@ -83,8 +83,7 @@ export default {
             maxDataValue = Number.MAX_SAFE_INTEGER;
         }
 
-        // don't want heatmap to be reactive, so we can use shallowRef
-        this.heatmapInstance = heatmapInstance  //shallowRef(heatmapInstance)
+        this.heatmapInstance = heatmapInstance
     },
     methods: {
 
@@ -108,12 +107,9 @@ export default {
             this.onMsgInput(history)
         },
         onMsgInput (msg) {
-            debugger
             // because this will get evaluated client-side, we have access to vue/this
             const vue = this
-            console.log('custom onInput handler:')
-            console.log(msg)
-
+            
             if (msg.topic == 'setData' || msg.topic == 'addData') {
                 // Since the heatmap can be displayed on all kind of devices, the server side uses rows and columns
                 // (instead of X and Y coordinates).  As a result, the X and Y coordinates need to be calculated
@@ -167,26 +163,18 @@ export default {
                     break
             }
             
-            // TODO in een functie moven
-            if (msg.topic == 'setData' || msg.topic == 'addData') {
-                // Get the canvas element which has been created by the visual-heatmap library
-                let canvas = this.$refs.heatmap_container.getElementsByTagName('canvas')[0];
-
-                // TODO moet text size automatisch berekend worden of instelbaar?  Of beide mogelijk?
-                let ctx = canvas.getContext("webgl");
-                ctx.font = "30px Arial";
-                ctx.fillStyle = "black";
-                ctx.textAlign = "center";
-
-                // Draw some text on top of the existing heatmap elements
-                // TODO eventueel een element.label tonen, die we op voorhand opvullen met bv. de waarde
-                this.heatmapInstance.rawData.every(element => ctx.fillText(element.value, element.x, element.y));
-            }
+            // TODO show labels on top of the heatmap
+            //if (msg.topic == 'setData' || msg.topic == 'addData') {
+            //    let canvas = this.$refs.heatmap_container.getElementsByTagName('canvas')[0];
+            //    let ctx = canvas.getContext("2D");
+            //    ctx.font = "30px Arial";
+            //    ctx.fillStyle = "black";
+            //    ctx.textAlign = "center";
+            //    this.heatmapInstance.rawData.every(element => ctx.fillText(element.value, element.x, element.y));
+            //}
         },
         clear () {
-            // TODO this.chart.data.labels = []
-            // TODO this.chart.data.datasets = []
-            // TODO this.chart.update()
+            // TODO ???
         }
     }
 }

--- a/ui/src/widgets/ui-heatmap/UIHeatmap.vue
+++ b/ui/src/widgets/ui-heatmap/UIHeatmap.vue
@@ -48,7 +48,6 @@ export default {
         }
     },
     created () {
-        debugger
         // can't do this in setup as we have custom onInput function
         useDataTracker(this.id, this.onMsgInput)
     },
@@ -61,14 +60,7 @@ export default {
         let pointRadius = this.props.pointRadius * (this.cellWidth + this.cellHeight) / 2
 
         // The heatmap package expects rgba colors, so the original hex color (e.g. #FF00FF) and the opacity should be combined to [R,G,B,A]
-        const colorGradient = this.props.colorGradient.map(({ color, opacity, offset }) => {
-            let hexColor = color
-            let r = parseInt(hexColor.slice(1, 3), 16)
-            let g = parseInt(hexColor.slice(3, 5), 16)
-            let b = parseInt(hexColor.slice(5, 7), 16)
-            let rgba = [r, g, b, parseFloat(opacity)]
-            return {color: rgba, offset: parseFloat(offset)}
-        })
+        let colorGradient = this.convertGradient(this.props.colorGradient)
 
         let heatmapInstance = Heatmap(this.$refs.heatmap_container, {
             size: pointRadius,                                          // Radius of the data point (in pixels)µ
@@ -94,6 +86,17 @@ export default {
     },
     methods: {
 
+        convertGradient(colorGradient) {
+            // The heatmap package expects rgba colors, so the original hex color (e.g. #FF00FF) and the opacity should be combined to [R,G,B,A]
+            return colorGradient.map(({ color, opacity, offset }) => {
+                let hexColor = color
+                let r = parseInt(hexColor.slice(1, 3), 16)
+                let g = parseInt(hexColor.slice(3, 5), 16)
+                let b = parseInt(hexColor.slice(5, 7), 16)
+                let rgba = [r, g, b, parseFloat(opacity)]
+                return {color: rgba, offset: parseFloat(offset)}
+            })
+        },
         onLoad (history) {
             // we have received a history of data points
             // we need to add them to the heatmap
@@ -134,6 +137,11 @@ export default {
                     // array of data points with 'x', 'y' and 'value'
                     this.heatmapInstance.addData(msg.payload, false)
                     break
+                case 'setGradient':
+                    // TODO find a way to apply the same validation rules as in the flow editor config page
+                    let colorGradient = this.convertGradient(msg.payload)
+                    this.heatmapInstance.setGradient(colorGradient)
+                    break
                 case 'setMin':
                     this.heatmapInstance.setMin(msg.payload)
                     break
@@ -141,10 +149,9 @@ export default {
                     this.heatmapInstance.setMax(msg.payload)
                     break
                 case 'setTranslate':
-                    // array[x, y]
-                    this.heatmapInstance.setTranslate(msg.payload);
+                    this.heatmapInstance.setTranslate(msg.payload)
+                    break
                 case 'setZoom':
-                    // float
                     this.heatmapInstance.setZoom(msg.payload)
                     break
                 case 'setRotationAngle':


### PR DESCRIPTION
## Description

As discussed with @joepavitt, this pull request is an attempt to migrate my [node-red-contrib-ui-heatmap](https://github.com/bartbutenaers/node-red-contrib-ui-heatmap) from D1 to D2, but now as a core UI node.

Demo:
![demo](https://github.com/FlowFuse/node-red-dashboard/assets/14224149/1aadc265-caef-4c2f-b5d7-34c0dc491750)

Demo flow included as a file, because it contains a base64 encoded image and was not accepted by Github in this readme:
[demo_flow.json](https://github.com/FlowFuse/node-red-dashboard/files/14272936/demo_flow.json)

My old ui node was based on the [heatmap.js](https://github.com/pa7/heatmap.js), but that is not maintained anymore for about 8 years.  Therefore I have used the [visual-heatmap](https://github.com/nswamy14/visual-heatmap) library for this one.  The author of that node has been very helpfull!  P.S. His visualHeatmap.esm.min.js file is about 16KB large.

TODO's:
- [ ]  When the view is **resized**, it doesn't fit anymore into the div.
- [ ]  When the browser is _**refreshed**_, the heatmap is empty. I think I have stored the data correctly in the datastore, but it is not used.
- [ ]  My [pull request](https://github.com/nswamy14/visual-heatmap/pull/22) (for _**dynamically setting gradients**_) has been merged, but we need to wait for a new version on npm.  Otherwise this option won't work...
- [ ]  Allow labels to be drawn on top of the heatmap (like in the old ui node).  
   Detail: I wanted to draw it on top of the visual-heatmap canvas, however it has a webgl context which does not support fonts.  Therefore the author of the visual-heatmap node has provided me another solution (see [demo](https://github.com/nswamy14/visual-heatmap/blob/master/demo/heatmapWithLabels.html)).  However it is based on his [i2djs](https://github.com/I2Djs/I2Djs) library, and that minified file is 237KB large.  Not sure if that is acceptable.  If we could have a canvas on top of the heatmap (which resizes the same way) that might be a better solution perhaps...

Question: when you injected an array of numeric values into my old ui node, these points were rendered from top to bottom and left to right (i.e. vertical columns).  Now with this node they are rendered from left to right and top to bottom (i.e. horizontal lines).  I could change it to make it more the same as in the old node, but I think it is more intuitive to do it this way?

P.S. I have not added unit tests, simply due to a severe lack of free time...

## Related Issue(s)

See [issue](https://github.com/FlowFuse/node-red-dashboard/issues/571).

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ X ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ X ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ X ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

