### PR TITLE
Account for httpRootNode being set in Node-RED Settings

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -453,7 +453,6 @@ module.exports = function (RED) {
          * @param {Socket} socket socket.io socket connecting to the server
          */
         function onConnection (socket) {
-            console.log('new connection', socket.id)
             // record mapping from connection to he ui-base node
             socket._baseId = node.id
 

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -117,9 +117,14 @@ module.exports = function (RED) {
             uiShared.app.use(config.path, uiShared.httpMiddleware, express.static(path.join(__dirname, '../../dist')))
 
             uiShared.app.get(config.path + '/_setup', uiShared.httpMiddleware, (req, res) => {
+                let socketPath = join(RED.settings.httpNodeRoot, config.path, 'socket.io')
+                // if no leading /, add one (happens sometimes depending on httpNodeRoot in settings.js)
+                if (socketPath[0] !== '/') {
+                    socketPath = '/' + socketPath
+                }
                 let resp = {
                     socketio: {
-                        path: `${config.path}/socket.io`
+                        path: socketPath
                     }
                 }
                 // Hook API - onSetup(RED, config, req, res)
@@ -258,6 +263,8 @@ module.exports = function (RED) {
         const node = this
 
         node._created = Date.now()
+
+        n.root = RED.settings.httpNodeRoot || '/'
 
         /** @type {Object.<string, Socket>} */
         // node.connections = {} // store socket.io connections for this node
@@ -446,6 +453,7 @@ module.exports = function (RED) {
          * @param {Socket} socket socket.io socket connecting to the server
          */
         function onConnection (socket) {
+            console.log('new connection', socket.id)
             // record mapping from connection to he ui-base node
             socket._baseId = node.id
 

--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -44,7 +44,6 @@
                 })
                 this.path = '/page' + (pageCount + 1)
                 $('#node-config-input-path').val(this.path)
-                console.log('setting path to', this.path)
             }
 
             $('#node-config-input-layout').typedInput({

--- a/nodes/widgets/ui_event.js
+++ b/nodes/widgets/ui_event.js
@@ -17,7 +17,6 @@ module.exports = function (RED) {
                         console.log('ui-event node not found', id)
                     }
                     if (wNode && id === node.id) {
-                        console.log('running ui-event handler', id)
                         // this was sent by this particular node
                         let msg = {
                             topic: evt,

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -121,8 +121,9 @@ export default {
 
             // Create Debug Endpoints
             Object.values(payload.dashboards).forEach(ui => {
+                const path = (ui.root + ui.path + '_debug').replace(/\/\//g, '/')
                 this.$router?.addRoute({
-                    path: `${ui.path}/_debug`,
+                    path,
                     name: `${ui.id}_debug`,
                     component: DebugView,
                     meta: {
@@ -135,7 +136,8 @@ export default {
             Object.values(payload.pages).forEach(page => {
                 // check that the page's bound UI is also in our config
                 if (payload.dashboards[page.ui]) {
-                    const route = payload.dashboards[page.ui].path + page.path
+                    const ui = payload.dashboards[page.ui]
+                    const route = (ui.root + ui.path + page.path).replace(/\/\//g, '/')
                     const routeName = 'Page:' + page.name
                     this.$router?.addRoute({
                         path: route,

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -174,8 +174,6 @@ export default {
             const colors = this.$vuetify.theme.themes.nrdb.colors // Modify the Vuetify Theming
             const sizes = this.customThemeDefinitions // Implement some of our own Theming
             if (this.theme) {
-                console.log('this.theme')
-                console.log(this.theme)
                 // convert NR Theming to Vuetify Theming
                 colors.surface = this.theme.colors.surface
                 // primary bg
@@ -193,8 +191,6 @@ export default {
                 sizes['--group-border-radius'] = this.theme.sizes.groupBorderRadius
                 sizes['--widget-gap'] = this.theme.sizes.widgetGap
             }
-            console.log(sizes)
-            console.log(this.customThemeDefinitions)
         },
         getPageLabel (page) {
             return page.name + (this.dashboard.showPathInSidebar ? ` (${page.path})` : '')

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -71,7 +71,7 @@ fetch('_setup')
         })
 
         socket.on('connect_error', (err) => {
-            console.log('SIO connect error:', err, err.data)
+            console.error('SIO connect error:', err, err.data)
         })
 
         /**

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,5 +19,5 @@ export default defineConfig({
         outDir: '../dist',
         emptyOutDir: true
     },
-    base: '/dashboard/'
+    base: './'
 })


### PR DESCRIPTION
## Description

- Change `base` to a relative path
- Ensure SocketIO is configured to account for `RED.settings.httpNodeRoot`
- Ensure `vue-router` takes into account the `ui.root` (now exposed in a UI's config via SocketIO so that SPA paths reflect the root too.

## Related Issue(s)

Fixes #437 

Possibly linked to #526 and #563 too - but can't be 100% this will fix them without verifying.