### PR TITLE
Ensure SocketIO and Vue Router path construction are reverse proxy friendly

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -39,6 +39,7 @@ export default {
     },
     computed: {
         ...mapState('ui', ['dashboards', 'pages', 'widgets']),
+        ...mapState('setup', ['setup']),
         status: function () {
             if (this.dashboards) {
                 const dashboards = Object.keys(this.dashboards)
@@ -121,7 +122,11 @@ export default {
 
             // Create Debug Endpoints
             Object.values(payload.dashboards).forEach(ui => {
-                const path = (ui.root + ui.path + '_debug').replace(/\/\//g, '/')
+                // currently, we can only have one ui
+                // if we are running on a proxy, we need to change ui.path to whatever our proxy has been configured as
+                ui.path = this.setup.basePath
+
+                const path = (ui.root + ui.path + '/_debug').replace(/\/\//g, '/')
                 this.$router?.addRoute({
                     path,
                     name: `${ui.id}_debug`,
@@ -137,6 +142,9 @@ export default {
                 // check that the page's bound UI is also in our config
                 if (payload.dashboards[page.ui]) {
                     const ui = payload.dashboards[page.ui]
+                    // re-write base path in case of proxy
+                    ui.path = this.setup.basePath
+
                     const route = (ui.root + ui.path + page.path).replace(/\/\//g, '/')
                     const routeName = 'Page:' + page.name
                     this.$router?.addRoute({

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -53,10 +53,19 @@ const vuetify = createVuetify({
 
 // GET our SocketIO Config from Node-RED & any other bits plugins have added to the _setup endpoint
 fetch('_setup')
-    .then((response) => {
-        return response.json()
-    })
-    .then((setup) => {
+    .then(async (response) => {
+        const url = new URL(response.url)
+        const basePath = url.pathname.replace('/_setup', '')
+
+        // get the setup JSON from the server
+        const setup = await response.json()
+        setup.basePath = basePath
+
+        if (setup.socketio?.path) {
+            // TODO: be better here, rather than depend on /dashboard
+            setup.socketio.path = setup.socketio.path.replace('/dashboard', basePath)
+        }
+
         store.commit('setup/set', setup)
 
         const socket = io(setup.socketio)


### PR DESCRIPTION
## Description

- Will now override the `/dashboard` endpoint for the underlying UI if the initial `/_setup` API makes it apparent that we are running Dashboard behind a proxy
- Issues caused by SocketIO not allowing relative path (so isn't aware of base path), but we can utilise the `/setup` call which returns or SocketIO connection details, to tell us if we've been proxied.
- We then use this new proxy base when also setting up the VueJS Router endpoints

## Related Issue(s)

Closes #526 