### PR TITLE
Fix No Focus Styles Applied To Switch Input When Focused on Edit Form Node View

### DIFF
--- a/nodes/widgets/ui_form.html
+++ b/nodes/widgets/ui_form.html
@@ -273,7 +273,7 @@
             background-color: #910000;
         }
 
-        input:focus + .slider {
+        .switch:focus-within {
             box-shadow: 0 0 1px #2196F3;
         }
 


### PR DESCRIPTION
## Description

I use tabs when navigating fields on a form. On "Edit form node" screen, I noticed switch that indicates whether field is required or not is not showing any styles when focused.

It's a very small change but it helps with accessibility and such.

Does this needs any tests written out for?

## Related Issue(s)


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ x ]  I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

