### PR TITLE
Docs: Fix the SideBySide component

### DIFF
--- a/docs/components/SideBySideImages.vue
+++ b/docs/components/SideBySideImages.vue
@@ -1,8 +1,8 @@
 <template>
 <div class="side-by-side">
     <div class="side-by-side-images">
-        <img :src="left" data-zoomable />
-        <img :src="right" data-zoomable />
+        <img :src="left" ref="left-img" />
+        <img :src="right" ref="right-img" />
     </div>
     <em>{{ caption }}</em>
 </div>
@@ -28,7 +28,8 @@ export default {
         }
     },
     mounted () {
-        mediumZoom('[data-zoomable]')
+        mediumZoom(this.$refs['left-img'])
+        mediumZoom(this.$refs['right-img'])
     }
 }
 </script>

--- a/docs/nodes/config/ui-base.md
+++ b/docs/nodes/config/ui-base.md
@@ -24,8 +24,8 @@ Some details here about the ui-base config node
 
 <SideBySideImages
     caption="Example of how the 'Collapsing' option looks when open (left) and closed (right)."
-    left="../../public/images/node-examples/ui-base-layout-default-open.png"
-    right="../../public/images/node-examples/ui-base-layout-sidebar-closed.png"
+    left="/images/node-examples/ui-base-layout-default-open.png"
+    right="/images/node-examples/ui-base-layout-sidebar-closed.png"
 />
 
 This open will shift the entire content of the Dashboard when opened, and not be visisble at all when closed.


### PR DESCRIPTION
## Description

Noticed some broken URLs in the docs build, as well as the `data-zoomable` being broken on any page that uses the `<SideBySide />` component (`ui-base)