### PR TITLE
More robust path replacement to account for proxy & httpNodeRoot configs

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -141,11 +141,10 @@ export default {
             Object.values(payload.pages).forEach(page => {
                 // check that the page's bound UI is also in our config
                 if (payload.dashboards[page.ui]) {
-                    const ui = payload.dashboards[page.ui]
-                    // re-write base path in case of proxy
-                    ui.path = this.setup.basePath
+                    // const ui = payload.dashboards[page.ui]
+                    // re-write base path in case of proxy & httpNodeRoot
+                    const route = (this.setup.basePath + page.path).replace(/\/\//g, '/')
 
-                    const route = (ui.root + ui.path + page.path).replace(/\/\//g, '/')
                     const routeName = 'Page:' + page.name
                     this.$router?.addRoute({
                         path: route,

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -62,8 +62,10 @@ fetch('_setup')
         setup.basePath = basePath
 
         if (setup.socketio?.path) {
-            // TODO: be better here, rather than depend on /dashboard
-            setup.socketio.path = setup.socketio.path.replace('/dashboard', basePath)
+            // get text before /socket.io and replace it with the calculated basePath
+            // basePath would have taken into account any proxy and/or httpNodeRoot settings
+            const replace = setup.socketio.path.split('/socket.io')[0]
+            setup.socketio.path = setup.socketio.path.replace(replace, basePath)
         }
 
         store.commit('setup/set', setup)


### PR DESCRIPTION
## Description

- Ensure we have a more robust SocketIO path replacement, which was introduced in #595 (for #526) and had broken the work we'd done in #581 (a fix for #437)

## Related Issue(s)

Fixes #563 