### PR TITLE
onChange: Ensure custom handlers have context of any general changes made to the msg. object

### DIFF
--- a/docs/contributing/guides/registration.md
+++ b/docs/contributing/guides/registration.md
@@ -123,8 +123,6 @@ onChange: async function (msg, value) {
     const off = RED.util.evaluateNodeProperty(config.offvalue, config.offvalueType, wNode)
     msg.payload = value ? on : off
 
-    wNode._msg = msg
-
     // simulate Node-RED node receiving an input
     wNode.send(msg)
 }

--- a/docs/contributing/guides/registration.md
+++ b/docs/contributing/guides/registration.md
@@ -103,10 +103,14 @@ Similar to `onAction`, when used as a boolean, this flag will trigger the defaul
 Alternatively, you can override this default behaviour by providing a custom `onChange` function. An example of this is in the `ui-switch` node which needs to do `node.status` updates to in order for the Node-RED Editor to reflect it's latest status:
 
 ```js
-onChange: async function (value) {
+/**
+ * Handle the input from the widget
+ * @param {object} msg - the last known msg received (prior to this new value)
+ * @param {boolean} value - the updated value sent by the widget
+ */
+onChange: async function (msg, value) {
     // ensure we have latest instance of the widget's node
     const wNode = RED.nodes.getNode(node.id)
-    const msg = wNode._msg || {}
 
     node.status({
         fill: value ? 'green' : 'red',

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -561,7 +561,7 @@ module.exports = function (RED) {
 
             msg = addConnectionCredentials(RED, msg, conn, n)
 
-            async function defaultHandler (value) {
+            async function defaultHandler (msg, value) {
                 if (typeof (value) === 'object' && value !== null && hasProperty(value, 'payload')) {
                     msg.payload = value.payload
                 } else {
@@ -582,7 +582,7 @@ module.exports = function (RED) {
                 // Most of the time, we can just use this default handler,
                 // but sometimes a node needs to do something specific (e.g. ui-switch)
                 const handler = typeof (widgetEvents.onChange) === 'function' ? widgetEvents.onChange : defaultHandler
-                await handler(value)
+                await handler(msg, value)
             } catch (error) {
                 console.log(error)
                 let errorHandler = typeof (widgetEvents.onError) === 'function' ? widgetEvents.onError : null

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -17,10 +17,9 @@ module.exports = function (RED) {
         const evts = {
             // runs on UI interaction
             // value = true | false from the ui-switch
-            onChange: async function (value) {
+            onChange: async function (msg, value) {
                 // ensure we have latest instance of the widget's node
                 const wNode = RED.nodes.getNode(node.id)
-                const msg = datastore.get(node.id) || {}
 
                 node.status({
                     fill: value ? 'green' : 'red',


### PR DESCRIPTION
## Description

- When a widget was using a custom `onChange` handler (only currently used by `ui-switch`) we were only considering the `value` received server-side by the widget, and not any general changes made to `msg` by the global `onChange` parent handler. 
- Because the default handler is scoped _inside_ the parent, that worked fine when modifying the existing `msg.` object, which modifies the `msg` object to include `_client`.
- What's confused me the most is how it _ever_ works, even second/third time round, as I can't find the path by which that would have happened, can only think there is some odd two-way memory binding with JS through the datastore

## Related Issue(s)

Fixes #588 