### PR TITLE
Docs: Clean up legacy docs from Dashboard 1.0 for ui-group

### DIFF
--- a/nodes/config/locales/en-US/ui_group.html
+++ b/nodes/config/locales/en-US/ui_group.html
@@ -1,4 +1,6 @@
 <script type="text/html" data-help-name="ui-group">
     <p>Group</p>
-    <p>If a <b>Class</b> is specified, it will be added to the parent card. This way you can style the card and the elements inside it with custom CSS. The Class can be set at runtime by setting a <code>msg.className</code> string property.</p>
+    <p>
+        A container for multiple UI Widgets. Groups can be used to organize and manage the layout of UI Widgets.
+    </p>
 </script>


### PR DESCRIPTION
## Description

Updated in-Editor documentation to better reflect the purpose of `ui-group`, and remove mention `className` injection which isn't supported functionality

## Related Issue(s)

Closes #533 