### PR TITLE
Fix: Debug View with httpNodeRoot

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -126,7 +126,7 @@ export default {
                 // if we are running on a proxy, we need to change ui.path to whatever our proxy has been configured as
                 ui.path = this.setup.basePath
 
-                const path = (ui.root + ui.path + '/_debug').replace(/\/\//g, '/')
+                const path = (ui.path + '/_debug').replace(/\/\//g, '/')
                 this.$router?.addRoute({
                     path,
                     name: `${ui.id}_debug`,

--- a/ui/src/debug/DebugData.vue
+++ b/ui/src/debug/DebugData.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 export default {
     name: 'DebugData',
     props: {
@@ -21,6 +22,9 @@ export default {
             data: null
         }
     },
+    computed: {
+        ...mapState('setup', ['setup'])
+    },
     created () {
         this.getData()
     },
@@ -30,7 +34,7 @@ export default {
     methods: {
         getData () {
             const xhr = new XMLHttpRequest()
-            xhr.open('GET', `/dashboard/_debug/${this.store}store/${this.item}`)
+            xhr.open('GET', `${this.setup.basePath}/_debug/${this.store}store/${this.item}`)
             xhr.send()
             xhr.responseType = 'json'
             xhr.onload = () => {


### PR DESCRIPTION
## Description

- Noticed the URL and API call made in the `_debug` view were not working when running with `httpNodeRoot` set.

## Related Issue(s)

Extension of #581 