### PR TITLE
UI Group - Component-ise the widget-group rendering to ensure consistency

### DIFF
--- a/ui/src/layouts/Flex.vue
+++ b/ui/src/layouts/Flex.vue
@@ -15,19 +15,7 @@
                         {{ g.name }}
                     </template>
                     <template #text>
-                        <div class="nrdb-group-widgets nrdb-layout-group--grid" :style="`grid-template-columns: repeat(${ g.width }, 1fr); grid-template-rows: repeat(${g.height}, minmax(${rowHeight}px, auto)); `">
-                            <div
-                                v-for="w in widgetsByGroup(g.id)"
-                                :id="'nrdb-ui-widget-' + w.id"
-                                :key="w.id"
-                                class="nrdb-ui-widget"
-                                :class="getWidgetClass(w)"
-                                style="display: grid"
-                                :style="`grid-template-rows: repeat(${w.props.height}, minmax(${rowHeight}px, auto)); grid-column-end: span ${ w.props.width || g.width }`"
-                            >
-                                <component :is="w.component" :id="w.id" :props="w.props" :state="w.state" :style="`grid-row-end: span ${w.props.height}`" />
-                            </div>
-                        </div>
+                        <widget-group :group="g" :widgets="widgetsByGroup(g.id)" :row-height="rowHeight" />
                     </template>
                 </v-card>
             </div>
@@ -50,11 +38,13 @@
 import { mapGetters, mapState } from 'vuex'
 
 import BaselineLayout from './Baseline.vue'
+import WidgetGroup from './Group.vue'
 
 export default {
     name: 'LayoutFlex',
     components: {
-        BaselineLayout
+        BaselineLayout,
+        WidgetGroup
     },
     data () {
         return {

--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -12,22 +12,10 @@
             >
                 <v-card variant="outlined" class="bg-group-background">
                     <template v-if="g.showTitle" #title>
-                        {{ g.name }}
+                        {{ g.name }} grid-template-rows: {{ g.height }} {{ rowHeight }}
                     </template>
                     <template #text>
-                        <div class="nrdb-group-widgets nrdb-layout-group--grid" :style="`grid-template-columns: repeat(${ g.width }, 1fr); grid-template-rows: repeat(${g.height}, minmax(${rowHeight}, auto)); `">
-                            <div
-                                v-for="w in widgetsByGroup(g.id)"
-                                :id="'nrdb-ui-widget-' + w.id"
-                                :key="w.id"
-                                class="nrdb-ui-widget"
-                                :class="getWidgetClass(w)"
-                                style="display: grid"
-                                :style="`grid-template-rows: repeat(${w.props.height}, minmax(${rowHeight}px, auto));grid-row-end: span ${w.props.height}; grid-column-end: span ${ w.props.width || g.width }`"
-                            >
-                                <component :is="w.component" :id="w.id" :props="w.props" :state="w.state" :style="`grid-row-end: span ${w.props.height}`" />
-                            </div>
-                        </div>
+                        <widget-group :group="g" :widgets="widgetsByGroup(g.id)" :row-height="rowHeight" />
                     </template>
                 </v-card>
             </div>
@@ -49,13 +37,16 @@
 <script>
 // eslint-disable-next-line import/order
 import BaselineLayout from './Baseline.vue'
+import WidgetGroup from './Group.vue'
+
 // eslint-disable-next-line import/order, sort-imports
 import { mapState, mapGetters } from 'vuex'
 
 export default {
     name: 'LayoutGrid',
     components: {
-        BaselineLayout
+        BaselineLayout,
+        WidgetGroup
     },
     data () {
         return {

--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -12,7 +12,7 @@
             >
                 <v-card variant="outlined" class="bg-group-background">
                     <template v-if="g.showTitle" #title>
-                        {{ g.name }} grid-template-rows: {{ g.height }} {{ rowHeight }}
+                        {{ g.name }}
                     </template>
                     <template #text>
                         <widget-group :group="g" :widgets="widgetsByGroup(g.id)" :row-height="rowHeight" />

--- a/ui/src/layouts/Group.vue
+++ b/ui/src/layouts/Group.vue
@@ -1,0 +1,51 @@
+<template>
+    <div class="nrdb-layout-group--grid" :style="`grid-template-columns: repeat(${ group.width }, 1fr); grid-template-rows: repeat(${group.height}, minmax(${rowHeight}px, auto)); `">
+        <div
+            v-for="w in widgets"
+            :id="'nrdb-ui-widget-' + w.id"
+            :key="w.id"
+            class="nrdb-ui-widget"
+            :class="getWidgetClass(w)"
+            style="display: grid"
+            :style="`grid-template-rows: repeat(${w.props.height}, minmax(${rowHeight}px, auto)); grid-row-end: span ${w.props.height}; grid-column-end: span ${ w.props.width || group.width }`"
+        >
+            <component :is="w.component" :id="w.id" :props="w.props" :state="w.state" :style="`grid-row-end: span ${w.props.height}`" />
+        </div>
+    </div>
+</template>
+
+<script>
+
+export default {
+    name: 'WidgetGroup',
+    props: {
+        group: {
+            type: Object,
+            required: true
+        },
+        widgets: {
+            type: Array,
+            required: true
+        },
+        rowHeight: {
+            type: Number,
+            default: 48
+        }
+    },
+    methods: {
+        getWidgetClass (widget) {
+            const classes = []
+            // ensure each widget has a class for its type
+            classes.push(`nrdb-${widget.type}`)
+            if (widget.props.className) {
+                classes.push(widget.props.className)
+            }
+            if (widget.state.class) {
+                classes.push(widget.state.class)
+            }
+            return classes.join(' ')
+        }
+    }
+
+}
+</script>

--- a/ui/src/layouts/Notebook.vue
+++ b/ui/src/layouts/Notebook.vue
@@ -14,19 +14,7 @@
                         {{ g.name }}
                     </template>
                     <template #text>
-                        <div class="nrdb-layout-group--grid" :style="`grid-template-columns: repeat(${ g.width }, 1fr); grid-template-rows: repeat(${g.height}, minmax(${rowHeight}px, auto)); `">
-                            <div
-                                v-for="w in widgetsByGroup(g.id)"
-                                :id="'nrdb-ui-widget-' + w.id"
-                                :key="w.id"
-                                class="nrdb-ui-widget"
-                                :class="getWidgetClass(w)"
-                                style="display: grid"
-                                :style="`grid-template-rows: repeat(${w.props.height}, minmax(${rowHeight}px, auto)); grid-column-end: span ${ w.props.width || g.width }`"
-                            >
-                                <component :is="w.component" :id="w.id" :props="w.props" :state="w.state" :style="`grid-row-end: span ${w.props.height}`" />
-                            </div>
-                        </div>
+                        <widget-group :group="g" :widgets="widgetsByGroup(g.id)" :row-height="rowHeight" />
                     </template>
                 </v-card>
             </div>
@@ -49,11 +37,13 @@
 import { mapGetters, mapState } from 'vuex'
 
 import BaselineLayout from './Baseline.vue'
+import WidgetGroup from './Group.vue'
 
 export default {
     name: 'LayoutFlex',
     components: {
-        BaselineLayout
+        BaselineLayout,
+        WidgetGroup
     },
     data () {
         return {


### PR DESCRIPTION
## Description

- Creates a new `widget-group` Vue component
- This new component handles the layout rendering of widgets within a single group. Now centralised given that the different layouts only affect how _groups_ are laid out, not their contents.

## Related Issue(s)

Fixes #650