### PR TITLE
Remove msg.req and msg.res

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -883,6 +883,10 @@ module.exports = function (RED) {
 
                 // add Node-RED listener to the widget for when it's corresponding node receives a msg in Node-RED
                 widgetNode?.on('input', async function (msg, send, done) {
+                    // clean msg - #668
+                    delete msg.res
+                    delete msg.req
+
                     // ensure we have latest instance of the widget's node
                     const wNode = RED.nodes.getNode(widgetNode.id)
                     if (!wNode) {


### PR DESCRIPTION
## Description

Ensures we don't gain a circular dependency inn our `onInput` handler when connected to a `http-in` node from Node-RED.

## Related Issue(s)

Closes #668 