### PR TITLE
Docs: Fix URL paths that break on production docs

### DIFF
--- a/docs/layouts/index.md
+++ b/docs/layouts/index.md
@@ -2,7 +2,7 @@
 
 Layouts are a configuration available on a page-by-page basis. They control how all of the [Groups](../nodes/config/ui-group) of widgets are laid out on a given [Page](../nodes/config/ui-page):
 
-![Screenshot of the layout options on a ui-page](../../assets/images/layouts-page-layout-option.png){data-zoomable}
+![Screenshot of the layout options on a ui-page](../assets/images/layouts-page-layout-option.png){data-zoomable}
 _Screenshot of the layout options on a `ui-page`_
 
 We currently offer three different layout options:
@@ -15,7 +15,7 @@ We currently offer three different layout options:
 
 A fundamental component of building out layouts in Dashboard 2.0 (which follows the Dashboard 1.0 principle) is the ability to control the size of each group and widget with the size selection widget:
 
-![Screenshot of the size selection widget for a ui-gauge](../../assets/images/layouts-sizing-options.png){data-zoomable}
+![Screenshot of the size selection widget for a ui-gauge](../assets/images/layouts-sizing-options.png){data-zoomable}
 _Screenshot of the size selection widget for a ui-gauge_
 
 Exactly what this sizing means does differ slightly depending on the layout you're using, but the general principle is that the size of a group or widget will control how much space it takes up in the layout. 
@@ -31,12 +31,12 @@ In addition to the core layout structure, defining how the groups are ordered an
 
 ### Configurable Options
 
-![Screenshot of the theme options available to control sizings of the layout](../../assets/images/layouts-theme-options.jpg){data-zoomable}
+![Screenshot of the theme options available to control sizings of the layout](../assets/images/layouts-theme-options.jpg){data-zoomable}
 _Screenshot of the theme options available to control sizings of the layout_
 
 Each color here correlates to the respective section in the following image:
 
-![Screenshot of the theme options available to control sizings of the layout](../../assets/images/layouts-theme-example.jpg){data-zoomable}
+![Screenshot of the theme options available to control sizings of the layout](../assets/images/layouts-theme-example.jpg){data-zoomable}
 _Screenshot of the theme options available to control sizings of the layout, here showing a "Grid" layout_
 
 - **Page Padding:** The spacing that encapsulates the full page's content, depicted above as the <span style="color: orange;">orange</span> space.

--- a/docs/user/migration.md
+++ b/docs/user/migration.md
@@ -233,9 +233,9 @@ Dashboard 2.0 follows a similar architecture to Dashboard 1.0 for managing hiera
 
 We currently have three layouts available in Dashboard 2.0:
 
-- [**Grid**](../layouts/grid.md) - Modelled with CSS's `grid` layout, this is the default layout, and uses a fixed 12 column approach, whereby content will scale horiztonally with screen width, making it far more friendly for responsive layouts.
-- [**Fixed**](../layouts/fixed.md) - This uses a CSS Flex Layout and is the most similar we currently have to the only layout in Dashboard 1.0. Improvements are required here to improve the "packing" nature of the layout though.
-- [**Notebook**](../layouts/notebook.md) - Mimicking a Jupyter Notebook layout, this provides content with a maxiimum width, scales with mobile devices, and allows for content to be stacked vertically.
+- [**Grid**](../layouts/types/grid.md) - Modelled with CSS's `grid` layout, this is the default layout, and uses a fixed 12 column approach, whereby content will scale horiztonally with screen width, making it far more friendly for responsive layouts.
+- [**Fixed**](../layouts/types/fixed.md) - This uses a CSS Flex Layout and is the most similar we currently have to the only layout in Dashboard 1.0. Improvements are required here to improve the "packing" nature of the layout though.
+- [**Notebook**](../layouts/types/notebook.md) - Mimicking a Jupyter Notebook layout, this provides content with a maxiimum width, scales with mobile devices, and allows for content to be stacked vertically.
 
 We also have future plans to support injection of third-party layouts, and even client-side editable layouts (e.g. drag-and-drop layout design).
 


### PR DESCRIPTION
## Description

Oddly this worked locally, but broke in production build. This makes sure the paths/images are correct.