### PR TITLE
UI Gauge: Account for "auto" sized gauges

### DIFF
--- a/ui/src/widgets/ui-gauge/UIGauge.vue
+++ b/ui/src/widgets/ui-gauge/UIGauge.vue
@@ -102,7 +102,7 @@ export default {
             this.sizes.titleHeight = this.$refs.title ? this.$refs.title.clientHeight : 0
 
             this.width = this.$refs.container.clientWidth
-            this.height = this.$refs.container.clientHeight - this.sizes.titleHeight
+            this.height = this.props.height ? this.$refs.container.clientHeight - this.sizes.titleHeight : 150
 
             // heights for the SVG
             const w = this.width

--- a/ui/src/widgets/ui-gauge/UIGauge.vue
+++ b/ui/src/widgets/ui-gauge/UIGauge.vue
@@ -102,7 +102,7 @@ export default {
             this.sizes.titleHeight = this.$refs.title ? this.$refs.title.clientHeight : 0
 
             this.width = this.$refs.container.clientWidth
-            this.height = this.props.height ? this.$refs.container.clientHeight - this.sizes.titleHeight : 150
+            this.height = this.props.height ? this.$refs.container.clientHeight - this.sizes.titleHeight : (this.props.gtype === 'gauge-half' ? 150 : 300)
 
             // heights for the SVG
             const w = this.width


### PR DESCRIPTION
## Description

- Gauges created before `1.4.0` would have `auto` sizing, which, when rendered with the new changes causes the gauges to be tiny.
- This introduces the backup heights of 150 (for halg gauges) and 300 (for 3/4 gauges) as per the defaults before `1.4.0` for backward compatibility.

## Related Issue(s)

https://discourse.nodered.org/t/new-1-4-0-release-node-red-dashboard-2-0/86402/5?u=joepavitt