### PR TITLE
Sidebar: Add layout configs from the sidebar

### DIFF
--- a/nodes/config/locales/en-US/ui_base.json
+++ b/nodes/config/locales/en-US/ui_base.json
@@ -34,7 +34,7 @@
         },
         "themes": {
             "header": "Themes",
-            "theme": "theme"
+            "theme": "Theme"
         },
         "colors": {
             "light": "var(--nrdb-node-light)",

--- a/nodes/config/locales/en-US/ui_base.json
+++ b/nodes/config/locales/en-US/ui_base.json
@@ -10,6 +10,7 @@
             "openDashboard": "Open Dashboard",
             "layout": "Layout",
             "layoutMessage": "Here you can re-order and move your widgets, groups and pages.",
+            "unattachedMessage": "The following Groups have do not have a parent page defined.",
             "theming": "Theming",
             "themingMessage": "Here you can can get quick access to your UI Themes, defined on your Dashboard.",
             "page": "Page",
@@ -31,7 +32,8 @@
             "edit": "Edit",
             "focus": "Focus",
             "collapse": "Collapse",
-            "expand": "Expand"
+            "expand": "Expand",
+            "unattachedGroups": "Unattached Groups"
         },
         "themes": {
             "header": "Themes",

--- a/nodes/config/locales/en-US/ui_base.json
+++ b/nodes/config/locales/en-US/ui_base.json
@@ -27,6 +27,7 @@
         "layout": {
             "pages": "Pages",
             "page": "Page",
+            "group": "Group",
             "edit": "Edit",
             "focus": "Focus",
             "collapse": "Collapse",

--- a/nodes/config/locales/en-US/ui_base.json
+++ b/nodes/config/locales/en-US/ui_base.json
@@ -26,13 +26,15 @@
         },
         "layout": {
             "pages": "Pages",
+            "page": "Page",
             "edit": "Edit",
             "focus": "Focus",
             "collapse": "Collapse",
             "expand": "Expand"
         },
         "themes": {
-            "header": "Themes"
+            "header": "Themes",
+            "theme": "theme"
         },
         "colors": {
             "light": "var(--nrdb-node-light)",

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -512,6 +512,21 @@
         return pageNode
     }
 
+    function addDefaultGroup (pageId) {
+        const group = RED.nodes.getType('ui-group')
+        const groupNode = {
+            _def: group,
+            id: RED.nodes.id(),
+            type: 'ui-group',
+            ...mapDefaults(group.defaults),
+            name: 'My Group',
+            page: pageId
+        }
+
+        addConfigNode(groupNode)
+        return groupNode
+    }
+
     function addDefaultTheme () {
         const theme = RED.nodes.getType('ui-theme')
         const themeNode = {
@@ -551,18 +566,7 @@
 
             const theme = addDefaultTheme()
             const page = addDefaultPage(base.id, theme.id)
-
-            const group = RED.nodes.getType('ui-group')
-            const groupNode = {
-                _def: group,
-                id: RED.nodes.id(),
-                type: 'ui-group',
-                ...mapDefaults(group.defaults),
-                name: 'My Group',
-                page: page.id
-            }
-
-            addConfigNode(groupNode)
+            const group = addDefaultGroup(page.id)
 
             // update existing `ui-` nodes to use the new base/page/theme/group
             RED.nodes.eachNode((node) => {
@@ -570,7 +574,7 @@
                     // if node has a group property
                     if (hasProperty(node._def.defaults, 'group') && !node.group) {
                         // group-scoped widgets - which is most of them
-                        node.group = groupNode.id
+                        node.group = group.id
                     } else if (hasProperty(node._def.defaults, 'page') && !node.page) {
                         // page-scoped widgets
                         node.page = page.id
@@ -661,7 +665,7 @@
      * @param {Object} parent - jQuery object to add this button group as a child element to
      * @param {DashboardItem} item - The page/group/widget that these actions are bound to
      */
-    function addRowActions (parent, item) {
+    function addRowActions (parent, item, list) {
         const configNodes = ['ui-base', 'ui-page', 'ui-group', 'ui-theme']
         const btnGroup = $('<div>', { class: 'nrdb2-sb-list-header-button-group', id: item.id }).appendTo(parent)
         if (!configNodes.includes(item.type)) {
@@ -671,6 +675,15 @@
                 evt.stopPropagation()
                 evt.preventDefault()
             })
+        }
+        if (item.type === 'ui-page') {
+            // add the "+ group" button
+            $('<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-plus"></i> ' + c_('layout.group') + '</a>')
+                .click(function (evt) {
+                    list.editableList('addItem')
+                    evt.preventDefault()
+                })
+                .appendTo(btnGroup)
         }
         const editButton = $('<a href="#" class="nr-db-sb-tab-edit-button editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-pencil"></i> ' + c_('layout.edit') + '</a>').appendTo(btnGroup)
         editButton.on('click', function (evt) {
@@ -783,13 +796,20 @@
      * @param {DashboardItemLookup} widgetsByGroup - The lookup of widgets by group
      */
     function addGroupOrderingList (pageId, container, groups, widgetsByGroup) {
-        // ordered list of groupss to live within a container (e.g. page list item)
+        // ordered list of groups to live within a container (e.g. page list item)
         const groupsOL = $('<ol>', { class: 'nrdb2-sb-group-list' }).appendTo(container).editableList({
             sortable: '.nrdb2-sb-groups-list-header',
             addButton: false,
             height: 'auto',
             connectWith: '.nrdb2-sb-group-list',
             addItem: function (container, i, group) {
+                if (!group || !group.id) {
+                    console.log('add group', group, 'to', pageId)
+                    // this is a new page that's been added and we need to setup the basics
+                    group = addDefaultGroup(pageId)
+                    RED.editor.editConfig('', group.type, group.id)
+                }
+
                 const widgets = widgetsByGroup[group.id] || []
                 const titleRow = $('<div>', { class: 'nrdb2-sb-list-header nrdb2-sb-groups-list-header' }).appendTo(container)
                 $('<i class="nrdb2-sb-list-handle nrdb2-sb-group-list-handle fa fa-bars"></i>').appendTo(titleRow)
@@ -848,6 +868,8 @@
             if (RED._db2debug) { if (RED._db2debug) { console.log('dashboard 2: ui_base.html: addGroupOrderingList: adding group', group) } }
             groupsOL.editableList('addItem', group)
         })
+
+        return groupsOL
     }
 
     /**
@@ -1103,16 +1125,14 @@
                 $('<span>', { class: 'nrdb2-sb-title' }).text(page.name || page.id).appendTo(titleRow)
                 $('<span>', { class: 'nrdb2-sb-info' }).text(`${groups.length} Groups`).appendTo(titleRow)
 
+                // adds groups within this page
+                titleRow.click(titleToggle(page.id, groupsList, chevron))
+                const groupsOL = addGroupOrderingList(page.id, groupsList, groups, widgetsByGroup)
+
                 // page - actions
                 const actions = $('<div>', { class: 'nrdb2-sb-list-header-actions' }).appendTo(titleRow)
-                addRowActions(actions, page)
+                addRowActions(actions, page, groupsOL)
                 addRowStateOptions(actions, page)
-
-                // adds groups within this page
-
-                titleRow.click(titleToggle(page.id, groupsList, chevron))
-
-                addGroupOrderingList(page.id, groupsList, groups, widgetsByGroup)
             },
             sortItems: function (items) {
                 // track any changes

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -312,7 +312,7 @@
      * Add Custom Dashboard Side Menu
      * */
 
-    function uiLink (id, name, path) {
+    function dashboardLink (id, name, path) {
         const base = RED.settings.httpNodeRoot || '/'
         const basePart = base.endsWith('/') ? base : `${base}/`
         const dashPart = path.startsWith('/') ? path.slice(1) : path
@@ -1119,6 +1119,17 @@
         const themeHeader = $('<div>', { class: 'nrdb2-sidebar-header' }).appendTo(divTabs)
         $('<b>').html(c_('themes.header')).appendTo(themeHeader)
 
+        // button group
+        const buttonGroup = $('<div>', { class: 'nrdb2-sb-list-button-group' }).appendTo(themeHeader)
+
+        // add theme button
+        $('<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-plus"></i> ' + c_('themes.theme') + '</a>')
+            .click(function (evt) {
+                console.log('add theme')
+                evt.preventDefault()
+            })
+            .appendTo(buttonGroup)
+
         divTabs.append('<div class="nrdb2-layout-helptext">' + c_('label.themingMessage') + '</div>')
 
         const themes = {}
@@ -1134,6 +1145,11 @@
             sortable: '.nrdb2-sb-pages-list-header',
             addButton: false,
             addItem: function (container, i, theme) {
+                console.log('theme')
+                console.log(theme)
+                if (!theme._def) {
+                    // this is a new theme that's been added and we need to setup the basics
+                }
                 container.addClass('nrdb2-sb-pages-list-item')
 
                 const titleRow = $('<div>', { class: 'nrdb2-sb-list-header nrdb2-sb-themes-list-header' }).appendTo(container)
@@ -1218,7 +1234,7 @@
                 RED.nodes.eachConfig(function (n) {
                     if (n.type === 'ui-base') {
                         const base = n
-                        sidebar.append(uiLink(base.id, base.name, base.path))
+                        sidebar.append(dashboardLink(base.id, base.name, base.path))
                         const divTab = $('<div class="red-ui-tabs">').appendTo(sidebar)
 
                         const ulDashboardTabs = $('<ul id="dashboard-tabs-list"></ul>').appendTo(divTab)

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -85,6 +85,11 @@
         padding: 0;
         border-bottom: 0;
     }
+    .nrdb2-sb-unattached-groups-list li {
+        padding: 0;
+        border-bottom: 0;
+        background-color: #ffefef;
+    }
     .nrdb2-sb-list-header {
         display: flex;
         gap: 6px;
@@ -676,15 +681,6 @@
                 evt.preventDefault()
             })
         }
-        if (item.type === 'ui-page') {
-            // add the "+ group" button
-            $('<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-plus"></i> ' + c_('layout.group') + '</a>')
-                .click(function (evt) {
-                    list.editableList('addItem')
-                    evt.preventDefault()
-                })
-                .appendTo(btnGroup)
-        }
         const editButton = $('<a href="#" class="nr-db-sb-tab-edit-button editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-pencil"></i> ' + c_('layout.edit') + '</a>').appendTo(btnGroup)
         editButton.on('click', function (evt) {
             if (configNodes.includes(item.type)) {
@@ -695,6 +691,15 @@
             evt.stopPropagation()
             evt.preventDefault()
         })
+        if (item.type === 'ui-page') {
+            // add the "+ group" button
+            $('<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-plus"></i> ' + c_('layout.group') + '</a>')
+                .click(function (evt) {
+                    list.editableList('addItem')
+                    evt.preventDefault()
+                })
+                .appendTo(btnGroup)
+        }
     }
 
     /**
@@ -1029,6 +1034,7 @@
         const pages = {}
         /** @type {DashboardItemLookup} */
         const groupsByPage = {}
+        const unattachedGroups = []
         /** @type {DashboardItemLookup} */
         const widgetsByGroup = {}
         const subflowDefinitions = new Map()
@@ -1037,11 +1043,16 @@
             if (n.type === 'ui-page' && !!n.ui) {
                 pages[n.id] = toDashboardItem(n)
             }
-            if (n.type === 'ui-group' && !!n.page) {
-                if (!groupsByPage[n.page]) {
-                    groupsByPage[n.page] = []
+            if (n.type === 'ui-group') {
+                const p = n.page
+                if (!p) {
+                    unattachedGroups.push(toDashboardItem(n))
+                } else {
+                    if (!groupsByPage[p]) {
+                        groupsByPage[p] = []
+                    }
+                    groupsByPage[p].push(toDashboardItem(n))
                 }
-                groupsByPage[n.page].push(toDashboardItem(n))
             }
         })
 
@@ -1157,6 +1168,41 @@
 
             // })
         })
+
+        // add Unattached Groups to the bottom
+        if (unattachedGroups.length > 0) {
+            const unattachedGroupsSection = $('<div>', { class: 'nrdb2-sidebar-header', style: 'padding-top: 12px;' }).appendTo(divTabs)
+            $('<b>').html(c_('layout.unattachedGroups')).appendTo(unattachedGroupsSection)
+            divTabs.append('<div class="nrdb2-layout-helptext">' + c_('label.unattachedMessage') + '</div>')
+
+            // we have some groups bound to a page that no longer exists
+            const unattachedGroupsOL = $('<ol>', { class: 'nrdb2-sb-unattached-groups-list' }).appendTo(divTabs).editableList({
+                sortable: '.nrdb2-sb-unattached-groups-list-header',
+                addButton: false,
+                addItem: function (container, i, group) {
+                    if (!group || !group.id) {
+                        // this is a new group that's been added and we need to setup the basics
+                        group = addDefaultGroup()
+                        RED.editor.editConfig('', group.type, group.id)
+                    }
+                    container.addClass('nrdb2-sb-unattached-groups-list-item')
+
+                    const titleRow = $('<div>', { class: 'nrdb2-sb-list-header nrdb2-sb-unattached-groups-list-header' }).appendTo(container)
+                    const tabicon = 'fa-table'
+                    $('<i>', { class: 'nrdb2-sb-icon nrdb2-sb-tab-icon fa ' + tabicon }).appendTo(titleRow)
+                    $('<span>', { class: 'nrdb2-sb-title' }).text(group.name || group.id).appendTo(titleRow)
+                    $('<span>', { class: 'nrdb2-sb-info' }).text('No Page Assigned').appendTo(titleRow)
+
+                    // group - actions
+                    const actions = $('<div>', { class: 'nrdb2-sb-list-header-actions' }).appendTo(titleRow)
+                    addRowActions(actions, group)
+                }
+            })
+
+            unattachedGroups.forEach(function (group) {
+                unattachedGroupsOL.editableList('addItem', group)
+            })
+        }
 
         // call updateLayoutVisibility to sync display level
         updateLayoutVisibility(layoutDisplayLevel)

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -477,6 +477,7 @@
             nodes: [node.id],
             dirty: RED.nodes.dirty()
         })
+        RED.nodes.dirty(true)
     }
 
     function mapDefaults (defaults) {
@@ -487,6 +488,20 @@
             }
         }
         return values
+    }
+
+    function addDefaultTheme () {
+        const theme = RED.nodes.getType('ui-theme')
+        const themeNode = {
+            _def: theme,
+            id: RED.nodes.id(),
+            type: 'ui-theme',
+            ...mapDefaults(theme.defaults),
+            name: 'Default Theme'
+        }
+
+        addConfigNode(themeNode)
+        return themeNode
     }
 
     function addLayoutsDefaults () {
@@ -512,16 +527,7 @@
 
             addConfigNode(baseNode)
 
-            const theme = RED.nodes.getType('ui-theme')
-            const themeNode = {
-                _def: theme,
-                id: RED.nodes.id(),
-                type: 'ui-theme',
-                ...mapDefaults(theme.defaults),
-                name: 'Default Theme'
-            }
-
-            addConfigNode(themeNode)
+            const theme = addDefaultTheme()
 
             const page = RED.nodes.getType('ui-page')
             const pageNode = {
@@ -531,7 +537,7 @@
                 ...mapDefaults(page.defaults),
                 name: 'Page 1',
                 ui: baseNode.id,
-                theme: themeNode.id,
+                theme: theme.id,
                 layout: 'grid'
             }
 
@@ -567,7 +573,6 @@
                 }
             })
 
-            RED.nodes.dirty(true)
             RED.view.redraw()
             RED.sidebar.config.refresh()
         }
@@ -586,7 +591,6 @@
     const conditionalSidebarRefresh = function (node, eventName) {
         // if the layout editor is not in view, don't refresh
         if ($('#ff-node-red-dashboard').parent().css('display') === 'none') { return }
-        if ($('#dashboard-2-pages').css('display') === 'none') { return }
         // if a refresh is in progress, don't refresh
         if (refreshBusy) { return }
         if (RED._db2debug) { console.log('dashboard 2: conditionalSidebarRefresh (node, eventName)', node, eventName) }
@@ -1125,7 +1129,7 @@
         // add theme button
         $('<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-plus"></i> ' + c_('themes.theme') + '</a>')
             .click(function (evt) {
-                console.log('add theme')
+                themesOL.editableList('addItem')
                 evt.preventDefault()
             })
             .appendTo(buttonGroup)
@@ -1145,10 +1149,10 @@
             sortable: '.nrdb2-sb-pages-list-header',
             addButton: false,
             addItem: function (container, i, theme) {
-                console.log('theme')
-                console.log(theme)
-                if (!theme._def) {
+                if (!theme || !theme.id) {
                     // this is a new theme that's been added and we need to setup the basics
+                    theme = addDefaultTheme()
+                    RED.editor.editConfig('', theme.type, theme.id)
                 }
                 container.addClass('nrdb2-sb-pages-list-item')
 

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -57,6 +57,10 @@
         background-color: #e3f2fd;
     }
     /* Dashboard 2.0 Sidebar */
+    .nrdb2-sb-list-button-group {
+        display: flex;
+        gap: 4px;
+    }
     .nrdb2-sidebar-tab-content {
         padding: 8px 10px;
         height: 100%;
@@ -490,6 +494,24 @@
         return values
     }
 
+    function addDefaultPage (baseId, themeId) {
+        const page = RED.nodes.getType('ui-page')
+        const pageNode = {
+            _def: page,
+            id: RED.nodes.id(),
+            type: 'ui-page',
+            ...mapDefaults(page.defaults),
+            path: '/pageN', // TODO: generate a unique path
+            name: 'Page N',
+            ui: baseId,
+            theme: themeId,
+            layout: 'grid'
+        }
+
+        addConfigNode(pageNode)
+        return pageNode
+    }
+
     function addDefaultTheme () {
         const theme = RED.nodes.getType('ui-theme')
         const themeNode = {
@@ -528,20 +550,7 @@
             addConfigNode(baseNode)
 
             const theme = addDefaultTheme()
-
-            const page = RED.nodes.getType('ui-page')
-            const pageNode = {
-                _def: page,
-                id: RED.nodes.id(),
-                type: 'ui-page',
-                ...mapDefaults(page.defaults),
-                name: 'Page 1',
-                ui: baseNode.id,
-                theme: theme.id,
-                layout: 'grid'
-            }
-
-            addConfigNode(pageNode)
+            const page = addDefaultPage(base.id, theme.id)
 
             const group = RED.nodes.getType('ui-group')
             const groupNode = {
@@ -550,7 +559,7 @@
                 type: 'ui-group',
                 ...mapDefaults(group.defaults),
                 name: 'My Group',
-                page: pageNode.id
+                page: page.id
             }
 
             addConfigNode(groupNode)
@@ -564,7 +573,7 @@
                         node.group = groupNode.id
                     } else if (hasProperty(node._def.defaults, 'page') && !node.page) {
                         // page-scoped widgets
-                        node.page = pageNode.id
+                        node.page = page.id
                     } else if (hasProperty(node._def.defaults, 'ui') && !node.ui) {
                         // base-scoped widgets, e.g. ui-notification/control
                         node.ui = baseNode.id
@@ -781,19 +790,20 @@
             height: 'auto',
             connectWith: '.nrdb2-sb-group-list',
             addItem: function (container, i, group) {
+                const widgets = widgetsByGroup[group.id] || []
                 const titleRow = $('<div>', { class: 'nrdb2-sb-list-header nrdb2-sb-groups-list-header' }).appendTo(container)
                 $('<i class="nrdb2-sb-list-handle nrdb2-sb-group-list-handle fa fa-bars"></i>').appendTo(titleRow)
                 const chevron = $('<i class="fa fa-angle-down nrdb2-sb-list-chevron">', { style: 'width:10px;' }).appendTo(titleRow)
                 const groupicon = 'fa-table'
                 $('<i>', { class: 'nrdb2-sb-icon nrdb2-sb-group-icon fa ' + groupicon }).appendTo(titleRow)
                 $('<span>', { class: 'nrdb2-sb-title' }).text(group.name || group.id).appendTo(titleRow)
+                $('<span>', { class: 'nrdb2-sb-info' }).text(`${widgets.length} Widgets`).appendTo(titleRow)
 
                 const actions = $('<div>', { class: 'nrdb2-sb-list-header-actions' }).appendTo(titleRow)
                 addRowActions(actions, group)
                 addRowStateOptions(actions, group)
 
                 // adds widgets within this group
-                const widgets = widgetsByGroup[group.id] || []
                 const widgetsList = $('<div>', { class: 'nrdb2-sb-widget-list-container' }).appendTo(container)
 
                 // add chevron/list toggle
@@ -983,6 +993,14 @@
             .appendTo(buttonGroup)
         RED.popover.tooltip(buttonExpand, c_('layout.expand'))
 
+        // add page button
+        $('<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-plus"></i> ' + c_('layout.page') + '</a>')
+            .click(function (evt) {
+                pagesOL.editableList('addItem')
+                evt.preventDefault()
+            })
+            .appendTo(buttonGroup)
+
         divTabs.append('<div class="nrdb2-layout-helptext">' + c_('label.layoutMessage') + '</div>')
 
         /** @type {DashboardItemLookup} */
@@ -1065,14 +1083,25 @@
             sortable: '.nrdb2-sb-pages-list-header',
             addButton: false,
             addItem: function (container, i, page) {
+                if (!page || !page.id) {
+                    // this is a new page that's been added and we need to setup the basics
+                    page = addDefaultPage()
+                    RED.editor.editConfig('', page.type, page.id)
+                }
+                const groups = groupsByPage[page.id] || []
+
                 container.addClass('nrdb2-sb-pages-list-item')
 
                 const titleRow = $('<div>', { class: 'nrdb2-sb-list-header nrdb2-sb-pages-list-header' }).appendTo(container)
+                const groupsList = $('<div>', { class: 'nrdb2-sb-group-list-container' }).appendTo(container)
+
+                // build title row
                 $('<i class="nrdb2-sb-list-handle nrdb2-sb-page-list-handle fa fa-bars"></i>').appendTo(titleRow)
                 const chevron = $('<i class="fa fa-angle-down nrdb2-sb-list-chevron">', { style: 'width:10px;' }).appendTo(titleRow)
                 const tabicon = 'fa-object-group'
                 $('<i>', { class: 'nrdb2-sb-icon nrdb2-sb-tab-icon fa ' + tabicon }).appendTo(titleRow)
                 $('<span>', { class: 'nrdb2-sb-title' }).text(page.name || page.id).appendTo(titleRow)
+                $('<span>', { class: 'nrdb2-sb-info' }).text(`${groups.length} Groups`).appendTo(titleRow)
 
                 // page - actions
                 const actions = $('<div>', { class: 'nrdb2-sb-list-header-actions' }).appendTo(titleRow)
@@ -1080,8 +1109,6 @@
                 addRowStateOptions(actions, page)
 
                 // adds groups within this page
-                const groups = groupsByPage[page.id] || []
-                const groupsList = $('<div>', { class: 'nrdb2-sb-group-list-container' }).appendTo(container)
 
                 titleRow.click(titleToggle(page.id, groupsList, chevron))
 
@@ -1100,9 +1127,9 @@
             }
         })
 
-        Object.values(groupsByPage).sort((a, b) => a.order - b.order).forEach(function (groups) {
+        Object.values(pages).sort((a, b) => a.order - b.order).forEach(function (page) {
+            const groups = groupsByPage[page.id] || []
             if (RED._db2debug) { console.log('dashboard 2: ui_base.html: buildLayoutOrderEditor: adding groups', groups) }
-            const page = pages[groups[0].page]
             if (page) {
                 pagesOL.editableList('addItem', page)
             }


### PR DESCRIPTION
## Description

Adds in functionality to add pages/themes/groups from the Dashboard sidebar (as per Dashboard 1.0), to avoid the unintuitive/nested Node-RED config node approach

- [x] Add Themes 
- [x] Add Pages
- [x] Add Groups

Also ensure that _all_ pages and groups are listed in the Dashboard 2.0 sidebar, without the need for them to have a direct child/parent relationship.

### Outstanding Items:

- [x] List unattached groups and widgets when their respective parents are deleted

## Related Issue(s)

Closes #585 
Fixed #684

This will also then support work for #387 