### PR TITLE
UI Chart - Have the default bg color for points as that defined in the NR Editor

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -240,15 +240,16 @@ export default {
          */
         addToLine (datapoint, label) {
             // consider msg.topic (label) as the label for the series
-            const datalabels = [...new Set(this.chart.data.datasets?.map((set) => {
+            const dataLabels = [...new Set(this.chart.data.datasets?.map((set) => {
                 return set.label
             }))]
-            const index = datalabels?.indexOf(label)
+            const index = dataLabels?.indexOf(label)
             // the chart is empty, we're adding a new series
             if (index === -1) {
                 const radius = this.props.pointRadius ? this.props.pointRadius : 4
                 this.chart.data.datasets.push({
-                    borderColor: this.props.colors[datalabels.length],
+                    borderColor: this.props.colors[dataLabels.length],
+                    backgroundColor: this.props.colors[dataLabels.length],
                     pointStyle: this.props.pointShape === 'false' ? false : this.props.pointShape || 'circle',
                     pointRadius: radius,
                     pointHoverRadius: radius * 1.25,


### PR DESCRIPTION
## Description

- Scatter plots were difficult to read as the background color was semi-transparent grey for all points. As such, we're changing the default to be a solid colour instead,

## Related Issue(s)

https://discourse.nodered.org/t/add-axis-labels-to-ui-chart/86097/6