### PR TITLE
Show standard inputs for sizing in widgets in a subflow (env var support)

### DIFF
--- a/docs/user/subflows.md
+++ b/docs/user/subflows.md
@@ -53,11 +53,11 @@ It's worth stressing that support for config nodes within a subflow (and consequ
 In total, Dashboard 2.0 has 4 types of config nodes:
 
 - `ui-base` - Stores configuration for the full dashboard
-- `ui-page` - Stores configuration for a single page, there can be mltiple pages within a single `ui-base`.
+- `ui-page` - Stores configuration for a single page, there can be multiple pages within a single `ui-base`.
 - `ui-group` - Stores configuration for a single group, there can be multiple groups within a single `ui-page`.
 - `ui-theme` - Stores configuration for the theme of the dashboard. These themes are assigned on a page-by-page basis.
 
-Any of the first three here can be utilise within a subflow. It is not possible to use `ui-theme` as that's only a configurtion option on _another_ config node, `ui-page`.
+Any of the first three here can be utilise within a subflow. It is not possible to use `ui-theme` as that's only a configuration option on _another_ config node, `ui-page`.
 
 ![Screenshot of Node-RED, showing how to assign a ui-group type to a subflow property](../assets/images/subflow-config-group.png){data-zoomable}
 *Screenshot of Node-RED, showing how to assign a ui-group type to a subflow property*
@@ -69,11 +69,11 @@ Then, for each instance of our subflow, we can now define a `ui-group` to render
 
 #### Surfacing Node Properties
 
-If you have a Dashboard 2.0 node within a subflow, you can configure your nodes such that their properties can instead be defined at the subflow-level, and so be unique for each instance of that subdflow, e.g. a `ui-slider`'s label could be unique everytime you use the subflow. 
+If you have a Dashboard 2.0 node within a subflow, you can configure your nodes such that their properties can instead be defined at the subflow-level, and so be unique for each instance of that subflow, e.g. a `ui-slider`'s label could be unique every time you use the subflow. 
 
 Under the covers, subflows work by setting scoped Node-RED environment variables. These can then be utilised by the nodes within the subflow.
 
-Let's say we want to set the `label` of a `ui-slider` within a subflow through a property on the subflow itself. First we have a new property (Environment Vairable) on the subflow:
+Let's say we want to set the `label` of a `ui-slider` within a subflow through a property on the subflow itself. First we have a new property (Environment Variable) on the subflow:
 
 ![Screenshot of Node-RED, showing a "label" option defined on a subflow](../assets/images/subflow-config-label.png){data-zoomable}
 *Screenshot of Node-RED, showing a "label" option defined on a subflow*
@@ -85,12 +85,19 @@ To then access this in the child nodes, in our case the `ui-slider`, we can set 
 ![Screenshot of Node-RED, showing how to use the environment variable to dynamically set a property on a subflow's child node](../assets/images/subflow-config-label-slider.png){data-zoomable}
 *Screenshot of Node-RED, showing how to use the environment variable to dynamically set a property on a subflow's child node*
 
+##### Sizing
+
+When setting the size of a widget node like ui-text or ui-button within a subflow you will be presented with text input fields for width and height instead
+of the usual sizer widget. This is to permit setting the values externally via the subflow instance properties using the `${variable_name}` syntax.
+
+NOTE: You can still set the widget width and height to `0` to make the it perform auto sizing.
+
 ## Customising Appearance
 
 ![Screenshot of Node-RED, highlighting where the "Appearance" button is](../assets/images/subflow-appearance.png){data-zoomable}
 *Screenshot of Node-RED, highlighting where the "Appearance" button is*
 
-When editing a subflow's properties, you can click the "Appearance" tab in order to custmoise it's appearancde when the subflow is rendered in the workspace flows.
+When editing a subflow's properties, you can click the "Appearance" tab in order to customise it's appearance when the subflow is rendered in the workspace flows.
 
 You can control:
 

--- a/nodes/widgets/ui_button.html
+++ b/nodes/widgets/ui_button.html
@@ -49,11 +49,24 @@
             label: function () { return this.name || (~this.label.indexOf('{' + '{') ? null : this.label) || 'button' },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },
             oneditprepare: function () {
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
 
                 $('#node-input-payload').typedInput({
                     default: 'str',
@@ -88,13 +101,19 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-button.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
+    <div class="form-row nr-db-ui-element-sizer-row">
         <label><i class="fa fa-object-group"></i> <span data-i18n="ui-button.label.size"></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row form-row-flex">
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-button.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-button.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
+    </div>
+    <!--<div class="form-row">
         <label for="node-input-icon"><i class="fa fa-picture-o"></i> <span data-i18n="ui-button.label.icon"></label>
         <div style="display: flex; align-items: center; flex-grow: 1; padding-right: calc(30% - 104px); gap: 12px;">
             <input style="flex-grow: 1;" type="text" id="node-input-icon" data-i18n="[placeholder]ui-button.label.optionalIcon">

--- a/nodes/widgets/ui_button_group.html
+++ b/nodes/widgets/ui_button_group.html
@@ -44,11 +44,24 @@
             return this.name || (~this.label.indexOf('{{') ? null : this.label) || 'button group'
         },
         oneditprepare: function () {
-            $('#node-input-size').elementSizer({
-                width: '#node-input-width',
-                height: '#node-input-height',
-                group: '#node-input-group'
-            })
+            // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+            // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+            if (RED.nodes.subflow(this.z)) {
+                // change inputs from hidden to text & display them
+                $('#node-input-width').attr('type', 'text')
+                $('#node-input-height').attr('type', 'text')
+                $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                $('div.form-row.nr-db-ui-manual-size-row').show()
+            } else {
+                // not in a subflow, use the elementSizer
+                $('div.form-row.nr-db-ui-element-sizer-row').show()
+                $('div.form-row.nr-db-ui-manual-size-row').hide()
+                $('#node-input-size').elementSizer({
+                    width: '#node-input-width',
+                    height: '#node-input-height',
+                    group: '#node-input-group'
+                })
+            }
 
             $('#node-input-topic').typedInput({
                 default: 'str',
@@ -209,11 +222,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-button-group.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
+    <div class="form-row nr-db-ui-element-sizer-row">
         <label><i class="fa fa-object-group"></i> <span data-i18n="ui-button-group.label.size"></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-button-group.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-button-group.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-button-group.label.label"></span></label>

--- a/nodes/widgets/ui_chart.html
+++ b/nodes/widgets/ui_chart.html
@@ -97,11 +97,24 @@
             oneditprepare: function () {
                 const propertyType = { value: 'property', label: RED._('@flowfuse/node-red-dashboard/ui-chart:ui-chart.label.key') }
 
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
 
                 // use jQuery UI tooltip to convert the plain old title attribute to a nice tooltip
                 $('.ui-node-popover-title').tooltip({
@@ -268,11 +281,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-chart.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-chart.label.size"></span></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-chart-group.label.size"></label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-chart-group.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-chart-group.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-chart.label.label"></span></label>

--- a/nodes/widgets/ui_dropdown.html
+++ b/nodes/widgets/ui_dropdown.html
@@ -48,11 +48,24 @@
                 if (this.multiple === undefined) {
                     $('#node-input-multiple').prop('checked', false)
                 }
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
                 const un = new Set(this.options.map(function (o) { return o.value }))
                 if (this.options.length === un.size) { $('#valWarning').hide() } else { $('#valWarning').show() }
 
@@ -146,11 +159,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> Size</label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-dropdown.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-dropdown.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-dropdown.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-tag"></i> Label</label>

--- a/nodes/widgets/ui_form.html
+++ b/nodes/widgets/ui_form.html
@@ -62,11 +62,24 @@
             oneditprepare: function () {
                 if ($('#node-input-submit').val() === null) { $('#node-input-submit').val('submit') }
                 if ($('#node-input-cancel').val() === null) { $('#node-input-cancel').val('cancel') }
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
 
                 this.resizeRule = function (option, newWidth) {
                     // option.find(".node-input-option-type").width(newWidth);
@@ -300,11 +313,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-form.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-form.label.size"></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-form.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-form.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-form.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-tag"></i> <span data-i18n="ui-form.label.label"></label>

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -98,11 +98,24 @@
         label: function () { return this.name || this.title || this.gtype },
         labelStyle: function () { return this.name ? 'node_label_italic' : '' },
         oneditprepare: function () {
-            $('#node-input-size').elementSizer({
-                width: '#node-input-width',
-                height: '#node-input-height',
-                group: '#node-input-group'
-            })
+            // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+            // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+            if (RED.nodes.subflow(this.z)) {
+                // change inputs from hidden to text & display them
+                $('#node-input-width').attr('type', 'text')
+                $('#node-input-height').attr('type', 'text')
+                $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                $('div.form-row.nr-db-ui-manual-size-row').show()
+            } else {
+                // not in a subflow, use the elementSizer
+                $('div.form-row.nr-db-ui-element-sizer-row').show()
+                $('div.form-row.nr-db-ui-manual-size-row').hide()
+                $('#node-input-size').elementSizer({
+                    width: '#node-input-width',
+                    height: '#node-input-height',
+                    group: '#node-input-group'
+                })
+            }
 
             // check for duplicate values
             const unique = new Set(this.segments.map(function (o) { return o.from }))
@@ -177,11 +190,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-gauge.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-gauge.label.size"></span></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-gauge.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-gauge.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-gauge.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-gtype"><i class="fa fa-list"></i> <span data-i18n="ui-gauge.label.type"></span></label>

--- a/nodes/widgets/ui_markdown.html
+++ b/nodes/widgets/ui_markdown.html
@@ -40,11 +40,24 @@
                 if (RED.editor.__debug === true) {
                     console.log('ui-markdown: oneditprepare')
                 }
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
                 this.editor = RED.editor.createEditor({
                     id: 'node-input-content-editor',
                     mode: 'ace/mode/markdown',
@@ -99,11 +112,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
         <input style="flex-grow:1" type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> Size</label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-markdown.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-markdown.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-markdown.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-className"><i class="fa fa-code"></i> Class</label>

--- a/nodes/widgets/ui_radio_group.html
+++ b/nodes/widgets/ui_radio_group.html
@@ -47,11 +47,24 @@
                 if (this.multiple === undefined) {
                     $('#node-input-multiple').prop('checked', false)
                 }
-                // $("#node-input-size").elementSizer({
-                //     width: "#node-input-width",
-                //     height: "#node-input-height",
-                //     group: "#node-input-group"
-                // });
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
                 const un = new Set(this.options.map(function (o) { return o.value }))
                 if (this.options.length === un.size) { $('#valWarning').hide() } else { $('#valWarning').show() }
 
@@ -142,6 +155,18 @@
     <div class="form-row">
         <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
         <input type="text" id="node-input-group">
+    </div>
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-radio-group.label.size">Size</label>
+        <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-radio-group.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-radio-group.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-tag"></i> Label</label>

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -42,11 +42,24 @@
             label: function () { return this.name || (~this.label.indexOf('{' + '{') ? null : this.label) || 'slider' },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },
             oneditprepare: function () {
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
                 $('#node-input-topic').typedInput({
                     default: 'str',
                     typeField: $('#node-input-topicType'),
@@ -77,11 +90,17 @@
             <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
             <input type="text" id="node-input-group">
         </div>
-        <div class="form-row">
-            <label><i class="fa fa-object-group"></i> Size</label>
-            <input type="hidden" id="node-input-width">
-            <input type="hidden" id="node-input-height">
+        <div class="form-row nr-db-ui-element-sizer-row">
+            <label><i class="fa fa-object-group"></i> <span data-i18n="ui-slider.label.size">Size</label>
             <button class="editor-button" id="node-input-size"></button>
+        </div>
+        <div class="form-row nr-db-ui-manual-size-row">
+            <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-slider.label.width">Width</label>
+            <input type="hidden" id="node-input-width">
+        </div>
+        <div class="form-row nr-db-ui-manual-size-row">
+            <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-slider.label.height">Height</label>
+            <input type="hidden" id="node-input-height">
         </div>
         <div class="form-row">
             <label for="node-input-className"><i class="fa fa-code"></i> Class</label>

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -47,11 +47,24 @@
             label: function () { return this.name || (~this.label.indexOf('{' + '{') ? null : this.label) || 'switch' },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },
             oneditprepare: function () {
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
                 $('#node-input-custom-icons').on('change', function () {
                     if ($('#node-input-custom-icons').val() === 'default') {
                         $('.form-row-custom-icons').hide()
@@ -123,11 +136,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> Size</label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-switch.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-switch.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-switch.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> Label</label>

--- a/nodes/widgets/ui_table.html
+++ b/nodes/widgets/ui_table.html
@@ -42,12 +42,25 @@
                 if (!validSelectionTypes.includes(this.selectionType)) {
                     $('#node-input-selectionType').val('none')
                 }
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
     
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
                 const autocols = $('#node-input-autocols')
 
                 $(autocols).change(() => {
@@ -128,11 +141,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-table.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-table.label.size"></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-table.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-table.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-table.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-maxrows"><i class="fa fa-tag"></i> <span data-i18n="ui-table.label.maxRows"></label>

--- a/nodes/widgets/ui_template.html
+++ b/nodes/widgets/ui_template.html
@@ -147,11 +147,24 @@
                 const that = this
                 const $templateScope = $('#node-input-templateScope')
     
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
 
                 if (typeof this.storeOutMessages === 'undefined') {
                     this.storeOutMessages = true
@@ -335,11 +348,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-template.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-template.label.size"></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-template.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-template.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-template.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <!--<div class="form-row" id="template-row-size">
         <label><i class="fa fa-object-group"></i> <span data-i18n="ui-template.label.size"></span></label>

--- a/nodes/widgets/ui_text.html
+++ b/nodes/widgets/ui_text.html
@@ -107,11 +107,24 @@
             label: function () { return this.name || (~this.label.indexOf('{' + '{') ? null : this.label) || 'text' },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },
             oneditprepare: function () {
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
 
                 $('.nr-db-text-layout-' + (this.layout || 'row-spread')).addClass('selected');
                 ['.nr-db-text-layout-row-left', '.nr-db-text-layout-row-center', '.nr-db-text-layout-row-right', '.nr-db-text-layout-row-spread', '.nr-db-text-layout-col-center']
@@ -213,11 +226,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-text.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
+    <div class="form-row nr-db-ui-element-sizer-row">
         <label><i class="fa fa-object-group"></i> <span data-i18n="ui-text.label.size"></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-text.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-text.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-text.label.label"></label>
@@ -357,6 +376,9 @@
         box-shadow: inset 0px 0px 0px 2px #fff;
         background: #333;
         border-color: #333;
+    }
+    .nr-db-ui-manual-size-row {
+        display: none;
     }
 
 </style>

--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -44,11 +44,24 @@
             icon: 'font-awesome/fa-i-cursor',
             paletteLabel: 'text input',
             oneditprepare: function () {
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
                 // topic
                 $('#node-input-topic').typedInput({
                     default: 'str',


### PR DESCRIPTION
closes #683

## Description

Displays text entry inputs in place of the element sizer control when a UI widget is inside a subflow.
This permits free entry and `{env}` syntax for usage subflow env var sizing.


## Related Issue(s)

#683

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

