### PR TITLE
Ensure we are deep-cloning objects in our datastore, and prevent memory overlap

### DIFF
--- a/nodes/store/data.js
+++ b/nodes/store/data.js
@@ -86,7 +86,7 @@ const setters = {
             if (!data[node.id]) {
                 data[node.id] = []
             }
-            data[node.id].push(structuredClone(msg))
+            data[node.id].push(config.RED.util.cloneMessage(msg))
         }
     }
 }

--- a/nodes/store/data.js
+++ b/nodes/store/data.js
@@ -69,7 +69,7 @@ const setters = {
             const filtered = []
             for (const m of msg) {
                 if (canSaveInStore(base, node, m)) {
-                    filtered.push(structuredClone(m))
+                    filtered.push(config.RED.util.cloneMessage(m))
                 }
             }
             data[node.id] = filtered

--- a/nodes/store/data.js
+++ b/nodes/store/data.js
@@ -75,7 +75,7 @@ const setters = {
             data[node.id] = filtered
         } else {
             if (canSaveInStore(base, node, msg)) {
-                data[node.id] = structuredClone(msg)
+                data[node.id] = config.RED.util.cloneMessage(msg)
             }
         }
     },

--- a/nodes/store/data.js
+++ b/nodes/store/data.js
@@ -69,13 +69,13 @@ const setters = {
             const filtered = []
             for (const m of msg) {
                 if (canSaveInStore(base, node, m)) {
-                    filtered.push(m)
+                    filtered.push(structuredClone(m))
                 }
             }
             data[node.id] = filtered
         } else {
             if (canSaveInStore(base, node, msg)) {
-                data[node.id] = msg
+                data[node.id] = structuredClone(msg)
             }
         }
     },
@@ -86,7 +86,7 @@ const setters = {
             if (!data[node.id]) {
                 data[node.id] = []
             }
-            data[node.id].push(msg)
+            data[node.id].push(structuredClone(msg))
         }
     }
 }


### PR DESCRIPTION
## Description

Memory overlap occurring because modifications to `msg` _after_ a `msg` was stored in a datastore, still updated the `datastore` entry, even though they're meant to be point in time captures.

## Related Issue(s)

Close #692 