### PR TITLE
Theming: Isolate navigation theming to clean Vuetify overrides

### DIFF
--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -173,19 +173,22 @@ export default {
         updateTheme () {
             const colors = this.$vuetify.theme.themes.nrdb.colors // Modify the Vuetify Theming
             const sizes = this.customThemeDefinitions // Implement some of our own Theming
+            // convert NR Theming to Vuetify Theming
             if (this.theme) {
-                // convert NR Theming to Vuetify Theming
-                colors.surface = this.theme.colors.surface
+                colors['navigation-background'] = this.theme.colors.surface
                 // primary bg
                 colors.primary = this.theme.colors.primary
                 // primary font - auto calculated
                 colors['on-primary'] = getContrast(this.theme.colors.primary)
                 // UI Background
                 colors.background = this.theme.colors.bgPage
-                // Group Background
+                // Group Styling
                 colors['group-background'] = this.theme.colors.groupBg
                 colors['group-outline'] = this.theme.colors.groupOutline
+                // widget background
+                colors.surface = this.theme.colors.groupBg
 
+                // sizes
                 sizes['--page-padding'] = this.theme.sizes.pagePadding
                 sizes['--group-gap'] = this.theme.sizes.groupGap
                 sizes['--group-border-radius'] = this.theme.sizes.groupBorderRadius

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -24,6 +24,7 @@ const theme = {
     dark: false,
     colors: {
         background: '#fff',
+        'navigation-background': '#ffffff',
         'group-background': '#ffffff',
         primary: '#0000ff',
         accent: '#ff6b99',

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -357,3 +357,10 @@ main {
 .active .v-switch__thumb {
     opacity: 1.0;
 }
+
+/* Vuetify Overrides */
+.v-app-bar.v-toolbar,
+.v-navigation-drawer {
+    background: rgb(var(--v-theme-navigation-background));
+    color: rgba(var(--v-theme-on-navigation-background), var(--v-high-emphasis-opacity));
+}


### PR DESCRIPTION
## Description

- Not sure how, but Vuetify widgets started rendering with the background colour of the navigation header. Under the covers the Vuetify `surface` CSS variable is utilises as the default background colour for Vuetify widgets. We were using this client-side as the navigation header background.
- This PR creates a new Vuetify variable called `navigation-background`, which is set to the Node-RED side `surface` variable.
- Then, the client-side `surface` is now duplicating the value of `groupBg` to ensure consistency in rendering here.
 
## Related Issue(s)

Closes #698 