### PR TITLE
UI Base - Add a helper function for retrieving Dashboard hosted URL

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -759,6 +759,17 @@ module.exports = function (RED) {
          */
         node.emit = emit
 
+        node.getBaseURL = function () {
+            // get the endpoint for the ui-base
+            const path = n.path || ''
+            // get our HTTP root, defined by NR Settings
+            const base = RED.settings.httpNodeRoot || '/'
+            const basePart = base.endsWith('/') ? base : `${base}/`
+            const dashPart = path.startsWith('/') ? path.slice(1) : path
+            const fullPath = `${basePart}${dashPart}`
+            return fullPath
+        }
+
         /**
          * Register allows for pages, widgets, groups, etc. to register themselves with the Base UI Node
          * @param {*} page


### PR DESCRIPTION
## Description

- Adds a new `base.getBaseURL()` function which will return the relevant URL where our Dashboard is hosted, taking into account the `RED.settings.httpNodeRoot`, and cleaning the concatenated path.

## Related Issue(s)

Closes #693 