### PR TITLE
Add Link to Icons to Documentation

### DIFF
--- a/nodes/widgets/locales/en-US/ui_button.html
+++ b/nodes/widgets/locales/en-US/ui_button.html
@@ -7,7 +7,7 @@
     <h3>Properties</h3>
     <dl class="message-properties">
         <dt>Icon <span class="property-type">string</span></dt>
-        <dd>Renders a Material Design icon within the button. There is no need to include the "mdi-" prefix</dd>
+        <dd>Renders a Material Design icon within the button. We use the Material Design Icons, you can see a full list of the available icons <a href="https://pictogrammers.com/library/mdi/">here</a>. There is no need to include the "mdi-" prefix, just the name of the icon.</dd>
         <dt>Icon Position<span class="property-type">left | right</span></dt>
         <dd>If "Icon" is defined, this property controls which side of the "Label" the icon will render on</dd>
         <dt>Label <span class="property-type">string</span></dt>

--- a/nodes/widgets/locales/en-US/ui_button_group.html
+++ b/nodes/widgets/locales/en-US/ui_button_group.html
@@ -16,7 +16,7 @@
     Specify which options need to be displayed:
         <ul>
             <li><i>Label: </i>(optional) The description that will be displayed.</li>
-            <li><i>Icon: </i>(optional) The icon to display for the given option.</li>
+            <li><i>Icon: </i>(optional) The icon to display for the given option. We use the Material Design Icons, you can see a full list of the available icons <a href="https://pictogrammers.com/library/mdi/">here</a>. There is no need to include the "mdi-" prefix, just the name of the icon.</li>
             <li><i>Value: </i>The value that will be send in input and output messages.</li>
             <li><i>Color: </i>The color of the option in the switch.</li>
         </ul>


### PR DESCRIPTION
## Description

Added a link to the list of possible icons to the documentation of `ui-button` and `ui-button-group` in the HTML documentation.

## Related Issue(s)

missing documentation link for icons.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass / not needed only documentation
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

