### PR TITLE
Docs: Add clarity on difference between plugins & widgets

### DIFF
--- a/docs/contributing/plugins/index.md
+++ b/docs/contributing/plugins/index.md
@@ -6,9 +6,11 @@
 
 Node-RED supports the development of custom plugins that add behaviour and functionality to the Node-RED runtime. A really common use case of plugins is [custom Node-RED Themes](https://nodered.org/docs/api/ui/themes/), which modify the overall CSS/appearance of the underlying Node-RED Editor.
 
-Node-RED Dashboard 2.0 also supports plugins. This allows you to define custom behaviour for the Dashboard runtime. For now, we provide a collection of API hooks that allow the injection of code at various points in the Dashboard instantiation and runtime.
+Node-RED Dashboard 2.0 also supports plugins. This allows you to define custom behaviour for the Dashboard runtime, independent of particular nodes and widgets. For now, we provide a collection of [API hooks](#index-js) that allow the injection of code at various points in the Dashboard instantiation and runtime.
 
-To integrate, make sure your plugins are registered with `"type": "node-red-dashboard-2"` in the `package.json` file. This will tell Node-RED that this is a Dashboard 2.0 plugin.
+To integrate, make sure your Node-RED plugin is registered with `"type": "node-red-dashboard-2"` in the `package.json` file. This will tell Node-RED that this is a Dashboard 2.0 plugin.
+
+_Note: Plugins differ from [Third Party Widgets](../widgets/third-party.md). Third Party Widgets are built as nodes that become available in the Node-RED Editor, and can be dragged onto the Dashboard. Plugins are built to modify the behaviour of the Dashboard runtime itself._
 
 ## Plugin Structure
 

--- a/docs/contributing/widgets/core-widgets.md
+++ b/docs/contributing/widgets/core-widgets.md
@@ -1,5 +1,12 @@
 # Adding New Core Widgets
 
+A single widget consist of two key parts:
+
+1. A Node-RED node that will appear in the palette of the Node-RED Editor
+2. `.vue` and client-side code that renders the widget into a dashboard
+ 
+You can explore our collection of core widgets [here](../../nodes/widgets.md).
+
 We are always open to Pull Requests and new ideas on widgets that can be added to the core Dashboard repository.
 
 When adding a new widget to the core collection, you will need to follow the steps below to ensure that the widget is available in the Node-RED editor and renders correctly in the UI.

--- a/docs/contributing/widgets/third-party.md
+++ b/docs/contributing/widgets/third-party.md
@@ -4,7 +4,12 @@
 
 # Building Third Party Widgets <AddedIn version="0.8.0" />
 
-If you have an idea for a widget that you'd like to build in Dashboard 2.0 we are open to Pull Requests and ideas for additions to the [core collection](../../nodes/widgets.md) of Widgets.
+A single widget consist of two key parts:
+
+1. A Node-RED node that will appear in the palette of the Node-RED Editor
+2. `.vue` and client-side code that renders the widget into a dashboard
+ 
+You can explore our collection of core widgets [here](../../nodes/widgets.md). If you have an idea for a widget that you'd like to build in Dashboard 2.0 we are open to Pull Requests and you can read more in our [Adding Core Widgets](./core-widgets.md) guide.
 
 We do also realise though that there are many occasions where a standalone repository/package works better as was very popular in Dashboard 1.0.
 


### PR DESCRIPTION
## Description

- Explicitly defines a "widget"
- Offers clarity on the difference between a Plugin and a Widget