### PR TITLE
UI Table - row stays highlighted after click / select

### DIFF
--- a/ui/src/widgets/ui-table/UITable.vue
+++ b/ui/src/widgets/ui-table/UITable.vue
@@ -128,7 +128,7 @@ export default {
             }
         },
         onRowClick (row) {
-            this.selected = this.selected === row ? null : row;
+            this.selected = this.selected === row ? null : row
 
             const msg = {
                 payload: row

--- a/ui/src/widgets/ui-table/UITable.vue
+++ b/ui/src/widgets/ui-table/UITable.vue
@@ -11,7 +11,7 @@
         <template #item="{ index, item, internalItem }">
             <v-data-table-row
                 :index="index" :item="internalItem"
-                :class="{'nrdb-table-row-selectable': props.selectionType === 'click'}"
+                :class="{'nrdb-table-row-selectable': props.selectionType === 'click', 'nrdb-table-row-selected': selected === item}"
                 @click="props.selectionType === 'click' ? onRowClick(item) : {}"
             />
         </template>
@@ -128,14 +128,20 @@ export default {
             }
         },
         onRowClick (row) {
-            console.log(row)
+            if (this.selected === null) {
+                this.selected = row;
+            } else if (this.selected === row) {
+                this.selected = null;
+            } else {
+                this.selected = row;
+            }
+
             const msg = {
                 payload: row
             }
             this.$socket.emit('widget-action', this.id, msg)
         },
         onMultiSelect (selected) {
-            console.log(selected)
             const msg = {
                 payload: selected
             }
@@ -179,5 +185,8 @@ export default {
 }
 .nrdb-table-row-selectable:active {
     background-color: rgba(var(--v-theme-on-group-background), var(--v-selected-opacity));
+}
+.nrdb-table-row-selected {
+    background-color: rgba(var(--v-theme-primary), var(--v-selected-opacity));
 }
 </style>

--- a/ui/src/widgets/ui-table/UITable.vue
+++ b/ui/src/widgets/ui-table/UITable.vue
@@ -128,13 +128,7 @@ export default {
             }
         },
         onRowClick (row) {
-            if (this.selected === null) {
-                this.selected = row;
-            } else if (this.selected === row) {
-                this.selected = null;
-            } else {
-                this.selected = row;
-            }
+            this.selected = this.selected === row ? null : row;
 
             const msg = {
                 payload: row


### PR DESCRIPTION
## Description

This pull request introduces a UI enhancement to the v-data-table component used within our application. Specifically, it addresses the need to visually highlight the selected row to improve user interaction and clarity. When a user selects a row in the data table, the background color of that row changes, providing clear feedback on the selection. This change aims to enhance the user experience by making data navigation and interaction more intuitive.

## Related Issue(s)

Closes #734 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [X] Configuration details
      No additional configuration is required for this change. The highlighting is applied automatically when a row is selected.
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

