### PR TITLE
Dependency: Update mdi-icons font version to ^7.4.47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "vue": "^3.4.5"
             },
             "devDependencies": {
-                "@mdi/font": "~6.9.96",
+                "@mdi/font": "~7.4.47",
                 "@unhead/vue": "^1.7.4",
                 "@vitejs/plugin-vue": "^4.5.0",
                 "chart.js": "^4.4.0",
@@ -1158,9 +1158,9 @@
             "optional": true
         },
         "node_modules/@mdi/font": {
-            "version": "6.9.96",
-            "resolved": "https://registry.npmjs.org/@mdi/font/-/font-6.9.96.tgz",
-            "integrity": "sha512-z3QVZStyHVwkDsFR7A7F2PIvZJPWgdSFw4BEEy2Gc9HUN5NfK9mGbjgaYClRcbMWiYEV45srmiYtczmBtCqR8w==",
+            "version": "7.4.47",
+            "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
+            "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
             "dev": true
         },
         "node_modules/@node-red/editor-api": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "vue": "^3.4.5"
     },
     "devDependencies": {
-        "@mdi/font": "~6.9.96",
+        "@mdi/font": "^7.4.47",
         "@unhead/vue": "^1.7.4",
         "@vitejs/plugin-vue": "^4.5.0",
         "chart.js": "^4.4.0",


### PR DESCRIPTION
## Description

Version bump from `~6.9.96` to `^7.4.47` for `@mdi/font`

## Related Issue(s)

Closes #685 