### PR TITLE
Sidebar - Properly set the active tab on first load

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1308,7 +1308,7 @@
         $(`<li id="dashboard-2-tab-${id}" class="red-ui-tab" style="width: 90px"><a class="red-ui-tab-label" title="Layout"><span>${label}</span></a></li>`).appendTo(tabs)
 
         // Add in Tab Content
-        const content = $(`<div id="dashboard-2-${id}" class="red-ui-tab-content" style="height: calc(100% - 72px)"></div>`).appendTo(sidebar)
+        const content = $(`<div id="dashboard-2-${id}" class="red-ui-tab-content" style="height: calc(100% - 72px);"></div>`).appendTo(sidebar)
         return content
     }
 
@@ -1353,9 +1353,6 @@
                             }
                         })
 
-                        // default to first tab
-                        ulDashboardTabs.children().first().addClass('active')
-
                         // on tab click, show the tab content, and hide the others
                         ulDashboardTabs.children().on('click', function (evt) {
                             const tab = $(this)
@@ -1366,6 +1363,9 @@
                             tabContent.show()
                             evt.preventDefault()
                         })
+
+                        // default to first tab
+                        ulDashboardTabs.children().first().trigger('click')
 
                         // add page/layout editor
                         buildLayoutOrderEditor(pagesContent)


### PR DESCRIPTION
## Description

We were assigning the `active` class to make it appear as if the `Layout` tab was active, but in actual fact, this was not also ensuring other tabs were properly hidden. 

This PR ensures we run the functionality consistent with a `click` of the tab to open it.

## Related Issue(s)

Closes #706