### PR TITLE
Cleaner error handling in node.deregister

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -661,6 +661,7 @@
             addLayoutsDefaultsDebounced()
         }
     })
+
     RED.events.on('nodes:remove', function (event) {
         conditionalSidebarRefresh(event, 'nodes:remove')
     })

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -1001,7 +1001,7 @@ module.exports = function (RED) {
             // remove widget from our UI config
             if (widgetNode) {
                 const widget = node.ui.widgets.get(widgetNode.id)
-                if (widget.hooks.onSocket) {
+                if (widget.hooks?.onSocket) {
                     // We have some custom socketIO hooks to remove
 
                     // loop over SocketIO connections


### PR DESCRIPTION
## Description

- Was getting a suppressed error when `deregister` was run for deleted nodes. It meant that the UI was not being told that the node was removed from the `ui-config`

## Related Issue(s)

Closes #612 