### PR TITLE
Markdown: Change architecture to allow for more dynamic updating

### DIFF
--- a/cypress/fixtures/flows/dashboard-markdown.json
+++ b/cypress/fixtures/flows/dashboard-markdown.json
@@ -1,0 +1,227 @@
+[
+    {
+        "id": "node-red-tab-markdown",
+        "type": "tab",
+        "label": "UI Markdown",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "dashboard-ui-base",
+        "type": "ui-base",
+        "name": "UI Name",
+        "path": "/dashboard",
+        "includeClientData": true,
+        "acceptsClientConfig": [
+            "ui-notification",
+            "ui-control"
+        ]
+    },
+    {
+        "id": "dashboard-ui-page-1",
+        "type": "ui-page",
+        "name": "Page 1",
+        "ui": "dashboard-ui-base",
+        "path": "/page1",
+        "icon": "",
+        "layout": "grid",
+        "theme": "dashboard-ui-theme",
+        "order": -1,
+        "className": "",
+        "visible": "true",
+        "disabled": false
+    },
+    {
+        "id": "dashboard-ui-theme",
+        "type": "ui-theme",
+        "name": "Theme Name",
+        "colors": {
+            "surface": "#ffffff",
+            "primary": "#0094ce",
+            "bgPage": "#eeeeee",
+            "groupBg": "#ffffff",
+            "groupOutline": "#cccccc"
+        }
+    },
+    {
+        "id": "dashboard-ui-group",
+        "type": "ui-group",
+        "name": "Group 1",
+        "page": "dashboard-ui-page-1",
+        "width": "6",
+        "height": "1",
+        "order": -1,
+        "showTitle": true,
+        "className": "",
+        "visible": "true",
+        "disabled": "false"
+    },
+    {
+        "id": "dashboard-ui-markdown-static",
+        "type": "ui-markdown",
+        "z": "node-red-tab-markdown",
+        "group": "dashboard-ui-group",
+        "name": "",
+        "order": 1,
+        "width": 0,
+        "height": 0,
+        "content": "# Static Markdown",
+        "className": "",
+        "x": 330,
+        "y": 100,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "dashboard-ui-markdown-1",
+        "type": "ui-markdown",
+        "z": "node-red-tab-markdown",
+        "group": "dashboard-ui-group",
+        "name": "",
+        "order": 1,
+        "width": 0,
+        "height": 0,
+        "content": "# Injected Payload Value\n\nGoes here - updated\n\nInjected content: {{ msg?.payload }}\n\n```mermaid\ngraph TD;\n    A-->B;\n    A-->C;\n    B-->D;\n    C-->D;\n    C-->F;\n```",
+        "className": "",
+        "x": 330,
+        "y": 60,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "dashboard-ui-markdown-2",
+        "type": "ui-markdown",
+        "z": "node-red-tab-markdown",
+        "group": "dashboard-ui-group",
+        "name": "Dynamic Mermaid",
+        "order": 2,
+        "width": 0,
+        "height": 0,
+        "content": "```mermaid\n{{ msg?.payload }}\n```",
+        "className": "",
+        "x": 350,
+        "y": 160,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "dashboard-ui-button-str",
+        "type": "ui-button",
+        "z": "node-red-tab-markdown",
+        "group": "dashboard-ui-group",
+        "name": "",
+        "label": "Button (str)",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "Hello World",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 150,
+        "y": 100,
+        "wires": [
+            [
+                "dashboard-ui-markdown-1"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-button-num",
+        "type": "ui-button",
+        "z": "node-red-tab-markdown",
+        "group": "dashboard-ui-group",
+        "name": "",
+        "label": "Button (num)",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "5",
+        "payloadType": "num",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 150,
+        "y": 60,
+        "wires": [
+            [
+                "dashboard-ui-markdown-1"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-button-graph-E",
+        "type": "ui-button",
+        "z": "node-red-tab-markdown",
+        "group": "dashboard-ui-group",
+        "name": "",
+        "label": "Graph with E",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "graph TD;     A-->B;     A-->C;     B-->D;     C-->E;",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 150,
+        "y": 160,
+        "wires": [
+            [
+                "dashboard-ui-markdown-2"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-button-graph-F",
+        "type": "ui-button",
+        "z": "node-red-tab-markdown",
+        "group": "dashboard-ui-group",
+        "name": "",
+        "label": "Graph with F",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "graph TD;     A-->B;     A-->C;     B-->D;     C-->F;",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 150,
+        "y": 200,
+        "wires": [
+            [
+                "dashboard-ui-markdown-2"
+            ]
+        ]
+    }
+]

--- a/cypress/tests/widgets/markdown.spec.js
+++ b/cypress/tests/widgets/markdown.spec.js
@@ -1,0 +1,43 @@
+describe('Node-RED Dashboard 2.0 - Markdown', () => {
+    beforeEach(() => {
+        cy.deployFixture('dashboard-markdown')
+        cy.visit('/dashboard/page1')
+    })
+
+    it('will render static markdown', () => {
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-static').should('exist')
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-static').find('h1').should('have.text', 'Static Markdown')
+    })
+
+    // this markdown node has dynamic markdown, with static mermaid
+    it('allow for dynamic markdown content and static mermaid charts', () => {
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-1').should('exist')
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-1').find('h1').should('have.text', 'Injected Payload Value')
+
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-str'))
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-1').should('contain.text', 'Injected content: Hello World')
+
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-num'))
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-1').should('contain.text', 'Injected content: 5')
+
+        cy.reloadDashboard()
+
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-1').should('contain.text', 'Injected content: 5')
+    })
+
+    // this markdown node has a full mermaid chart defined on msg.payload
+    it('allow for full mermaid charts to be defined by msg', () => {
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-graph-E'))
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-2').find('.nodes .node').should('have.length', 5)
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-2').find('.nodes .node').eq(4).should('have.text', 'E')
+
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-graph-F'))
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-2').find('.nodes .node').should('have.length', 5)
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-2').find('.nodes .node').eq(4).should('have.text', 'F')
+
+        cy.reloadDashboard()
+
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-2').find('.nodes .node').should('have.length', 5)
+        cy.get('#nrdb-ui-widget-dashboard-ui-markdown-2').find('.nodes .node').eq(4).should('have.text', 'F')
+    })
+})

--- a/ui/src/widgets/ui-markdown/UIMarkdown.vue
+++ b/ui/src/widgets/ui-markdown/UIMarkdown.vue
@@ -10,8 +10,6 @@ import DOMPurify from 'dompurify'
 import hljs from 'highlight.js'
 import { marked } from 'marked'
 import mermaid from 'mermaid'
-import { h } from 'vue'
-import { mapGetters, mapState } from 'vuex' // eslint-disable-line import/order
 
 import { useDataTracker } from '../data-tracker.mjs'
 
@@ -71,22 +69,24 @@ export default {
     watch: {
         'props.content': function () {
             // when the node's config changes, re-render the content
-            this.parseContent()
-            this.renderMermaid()
+            this.update()
         }
     },
     created () {
         // can't do this in setup as we have custom onInput function
         useDataTracker(this.id, this.onMsgInput, this.onMsgLoad)
         // make sure we render something on first creation
-        this.parseContent()
-        this.renderMermaid()
+        this.update()
     },
     errorCaptured: (err, vm, info) => {
         console.error('errorCaptured', err, vm, info)
         return false
     },
     methods: {
+        update () {
+            this.parseContent()
+            this.renderMermaid()
+        },
         onMsgLoad: function (msg) {
             this.$store.commit('data/bind', {
                 widgetId: this.id,
@@ -94,8 +94,7 @@ export default {
             })
             // if we're loading a msg from history,
             // re-load the content to account for any new msg values
-            this.parseContent()
-            this.renderMermaid()
+            this.update()
         },
         onMsgInput: function (msg) {
             // compare new msg and old message
@@ -109,8 +108,7 @@ export default {
                 })
             }
             // when we receive a new msg, re-render the content
-            this.parseContent()
-            this.renderMermaid()
+            this.update()
         },
         msgChanged (oldMsg, newMsg) {
             const ignoreKeys = ['_event', '_msgid']

--- a/ui/src/widgets/ui-markdown/UIMarkdown.vue
+++ b/ui/src/widgets/ui-markdown/UIMarkdown.vue
@@ -10,6 +10,7 @@ import DOMPurify from 'dompurify'
 import hljs from 'highlight.js'
 import { marked } from 'marked'
 import mermaid from 'mermaid'
+import { mapState } from 'vuex' // eslint-disable-line import/order
 
 import { useDataTracker } from '../data-tracker.mjs'
 


### PR DESCRIPTION
## Description

- Remove the use of `h()` within the Markdown node
- Instead, we now use `<component :is="" />`
- Create common `update()` function that handles (a) parsing Markdown and (b) rendering any Mermaid charts

## Related Issue(s)

Closes #552
Closes #584
Closes #643 

We still have the issue with injected HTML/Markdown from a `msg.payload` not being processed, but that will need to be a different solution/evolution of these improvements introduced.