### PR TITLE
Fix plugin tab labels & scaling

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1306,7 +1306,7 @@
     }
 
     function addSidebarTab (label, id, tabs, sidebar) {
-        $(`<li id="dashboard-2-tab-${id}" class="red-ui-tab" style="width: 90px"><a class="red-ui-tab-label" title="Layout"><span>${label}</span></a></li>`).appendTo(tabs)
+        $(`<li id="dashboard-2-tab-${id}" class="red-ui-tab" style="min-width: 90px; width: fit-content"><a class="red-ui-tab-label" style="padding-inline: 12px" title="Layout"><span>${label}</span></a></li>`).appendTo(tabs)
 
         // Add in Tab Content
         const content = $(`<div id="dashboard-2-${id}" class="red-ui-tab-content" style="height: calc(100% - 72px);"></div>`).appendTo(sidebar)
@@ -1347,7 +1347,7 @@
                             if (plugin.tabs) {
                                 plugin.tabs.forEach(tab => {
                                     // add tab to sidebar
-                                    const container = addSidebarTab('FF Auth', 'ff-auth', ulDashboardTabs, sidebar)
+                                    const container = addSidebarTab(tab.label, tab.id, ulDashboardTabs, sidebar)
                                     container.hide()
                                     tab.init(base, container)
                                 })


### PR DESCRIPTION
## Description

This pull request improves plugin support by fixing D2.0 "tabs".

1. It allows plugin labels to be populated in the D2.0 tabs, where before they were hardcoded to "FF Auth".
2. It allows plugin labels to scale horizontally to fit their text, while keeping the min-width of 90px. 

## Related Issue(s)

- #758
- Closes #759

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
   - NA, this is simply a UI fix, to perform behavior already expected by users.
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
      - NA, no changes needed.
    - [ ] Configuration details
      - NA, no changes needed.
    - [ ] Concepts
      - NA, no changes needed.
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
      - NA, no changes needed.
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
      - NA, no changes needed.

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

