### PR TITLE
Bump NR devDependency to force new express version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "medium-zoom": "^1.0.8",
                 "mermaid": "^10.4.0",
                 "mocha": "^10.2.0",
-                "node-red": "^3.1.0",
+                "node-red": "^3.1.9",
                 "node-red-node-test-helper": "^0.3.3",
                 "npm-run-all": "^4.1.5",
                 "should": "^13.2.3",
@@ -311,9 +311,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
-            "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+            "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
             "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -1164,18 +1164,18 @@
             "dev": true
         },
         "node_modules/@node-red/editor-api": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-3.1.7.tgz",
-            "integrity": "sha512-u0UzXmIhJmvAQTWdiMFi9JoA7hvvBn4egXcgrnfRlWzvcRd8igi4LWth4vKo9/VUYsmXrnxv+JE+qm4RLfIvKA==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-3.1.9.tgz",
+            "integrity": "sha512-HHhFiwxmD8V5+U/xe+Gl9T0oAnwFeA7zisG8VW+Ruh3apGQvV9l5UoL9Yg00jEPDOhL99k/wqcXI42lakEkiKw==",
             "dev": true,
             "dependencies": {
-                "@node-red/editor-client": "3.1.7",
-                "@node-red/util": "3.1.7",
+                "@node-red/editor-client": "3.1.9",
+                "@node-red/util": "3.1.9",
                 "bcryptjs": "2.4.3",
                 "body-parser": "1.20.2",
                 "clone": "2.1.2",
                 "cors": "2.8.5",
-                "express": "4.18.2",
+                "express": "4.19.2",
                 "express-session": "1.17.3",
                 "memorystore": "1.6.7",
                 "mime": "3.0.0",
@@ -1191,90 +1191,6 @@
                 "bcrypt": "5.1.0"
             }
         },
-        "node_modules/@node-red/editor-api/node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@node-red/editor-api/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/@node-red/editor-api/node_modules/express": {
-            "version": "4.18.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
-            "dev": true,
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.1",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.5.0",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.11.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            }
-        },
-        "node_modules/@node-red/editor-api/node_modules/express/node_modules/body-parser": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.11.0",
-                "raw-body": "2.5.1",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
         "node_modules/@node-red/editor-api/node_modules/mime": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -1285,27 +1201,6 @@
             },
             "engines": {
                 "node": ">=10.0.0"
-            }
-        },
-        "node_modules/@node-red/editor-api/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true
-        },
-        "node_modules/@node-red/editor-api/node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/@node-red/editor-api/node_modules/ws": {
@@ -1330,15 +1225,15 @@
             }
         },
         "node_modules/@node-red/editor-client": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-3.1.7.tgz",
-            "integrity": "sha512-L6E04FAFcBgssFuGroLmau+Mdhbt7NcLIWxDDkdvdmVKP4LQwOvfQP8uVHQyiMzotkIfng5nQqTBpHrnsBA+Ww==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-3.1.9.tgz",
+            "integrity": "sha512-k8ik9fqcUxwsjEL0bBywNRYoFk7VZxdcoXRKCtcB3H8T/KRgQBDZu4j27dtff/5WPqnvtmXOQBbdDrhluMO0ng==",
             "dev": true
         },
         "node_modules/@node-red/nodes": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-3.1.7.tgz",
-            "integrity": "sha512-aRlwKHRkbaS+Sd1kcK+W/wafY2t4J8CDlkRL79mPXINBLZCsg3Y8mXqgmWb4lpHU68dkMp6HOl1V+imlr80yJQ==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-3.1.9.tgz",
+            "integrity": "sha512-H0ZJjgmc7tbDBExF8WWIab7VJ1PBJxqExc6HWfb5FJQcOyA9mzCXwBduirWGxWAbQzZvq5GLgzy5ECzDJIjbSQ==",
             "dev": true,
             "dependencies": {
                 "acorn": "8.8.2",
@@ -1460,16 +1355,16 @@
             }
         },
         "node_modules/@node-red/registry": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-3.1.7.tgz",
-            "integrity": "sha512-bSAIBTTYkEckOC0I9kYLNP/rMFzR7b8/kb8Z9NKYYEMMEf32DjjwXEIq14/6+E+zUkenFv5Vy7V6zrox1JqNTA==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-3.1.9.tgz",
+            "integrity": "sha512-lm1jNGO5ebax5kw5A2stOymMVQpuAGJ24M+3bfPYj3djzgBq4qKbNX6EAJLtyLHlCKecAybJoXDNpNcCnl7BXQ==",
             "dev": true,
             "dependencies": {
-                "@node-red/util": "3.1.7",
+                "@node-red/util": "3.1.9",
                 "clone": "2.1.2",
                 "fs-extra": "11.1.1",
                 "semver": "7.5.4",
-                "tar": "6.1.13",
+                "tar": "6.2.1",
                 "uglify-js": "3.17.4"
             }
         },
@@ -1507,129 +1402,24 @@
             "dev": true
         },
         "node_modules/@node-red/runtime": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-3.1.7.tgz",
-            "integrity": "sha512-8Fq2GDqb8Tfc+QDGtTwEHs1mPtT3aRJzgfr5yUCbVSNkB6eewsuVHrPWnj58caUcJm/b9wB+7SBPcaVOifdssg==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-3.1.9.tgz",
+            "integrity": "sha512-tpuHE5gEqLx9OoRjSxsyh683yGCnBlAAwbjkVv5lonqYqLJwE3DCJnMuHYj1lPUDzSc0QzhE9efm+LIhAhBU4g==",
             "dev": true,
             "dependencies": {
-                "@node-red/registry": "3.1.7",
-                "@node-red/util": "3.1.7",
+                "@node-red/registry": "3.1.9",
+                "@node-red/util": "3.1.9",
                 "async-mutex": "0.4.0",
                 "clone": "2.1.2",
-                "express": "4.18.2",
+                "express": "4.19.2",
                 "fs-extra": "11.1.1",
                 "json-stringify-safe": "5.0.1"
             }
         },
-        "node_modules/@node-red/runtime/node_modules/body-parser": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.11.0",
-                "raw-body": "2.5.1",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/@node-red/runtime/node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@node-red/runtime/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/@node-red/runtime/node_modules/express": {
-            "version": "4.18.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
-            "dev": true,
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.1",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.5.0",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.11.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            }
-        },
-        "node_modules/@node-red/runtime/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true
-        },
-        "node_modules/@node-red/runtime/node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/@node-red/util": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/@node-red/util/-/util-3.1.7.tgz",
-            "integrity": "sha512-vUnuoOwVjGtJ3j5WcL468neXGciDRvZnRAqB0Fl//cjPLklTkipK6C5b0vYGTgy+cL5K+KjcV10yl3F2tiAOQw==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@node-red/util/-/util-3.1.9.tgz",
+            "integrity": "sha512-BT7mMds8MFrXwgGuNjmk/vY0X621hirLcqAOp5/ZrrFuzPVoK4PDgoNx5igYD/HVQbVcJTHfN1cRopSFPfdF2Q==",
             "dev": true,
             "dependencies": {
                 "fs-extra": "11.1.1",
@@ -2940,12 +2730,12 @@
             "dev": true
         },
         "node_modules/axios": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
             "dev": true,
             "dependencies": {
-                "follow-redirects": "^1.15.4",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -4724,9 +4514,9 @@
             }
         },
         "node_modules/detect-libc": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-            "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+            "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
             "dev": true,
             "optional": true,
             "engines": {
@@ -9367,20 +9157,20 @@
             }
         },
         "node_modules/node-red": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/node-red/-/node-red-3.1.7.tgz",
-            "integrity": "sha512-FQH9nEPNLjXrsSmcl8DL51htu800kW0BVvTmn4j0jldOiFZyW+LzmxVTp7HhLuG1MTMrYvjaimMcLbxTL8ytAA==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/node-red/-/node-red-3.1.9.tgz",
+            "integrity": "sha512-SNuXZoplH/UewibVbe/UPyMhsmeuoCGjDVmBmWo+Wj8arE14PF1cOoTKdnbv5F/vPc1kbUvd0+oWCm9kv7wfkw==",
             "dev": true,
             "dependencies": {
-                "@node-red/editor-api": "3.1.7",
-                "@node-red/nodes": "3.1.7",
-                "@node-red/runtime": "3.1.7",
-                "@node-red/util": "3.1.7",
+                "@node-red/editor-api": "3.1.9",
+                "@node-red/nodes": "3.1.9",
+                "@node-red/runtime": "3.1.9",
+                "@node-red/util": "3.1.9",
                 "basic-auth": "2.0.1",
                 "bcryptjs": "2.4.3",
-                "express": "4.18.2",
+                "express": "4.19.2",
                 "fs-extra": "11.1.1",
-                "node-red-admin": "^3.1.2",
+                "node-red-admin": "^3.1.3",
                 "nopt": "5.0.0",
                 "semver": "7.5.4"
             },
@@ -9396,13 +9186,13 @@
             }
         },
         "node_modules/node-red-admin": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/node-red-admin/-/node-red-admin-3.1.2.tgz",
-            "integrity": "sha512-UUNpi8QkUDIAReuzxAuZDm17fejkqJJzM49w5+0ScgVtPn6bRVTEnUvusPtKJftH5J3cH2QZ+rkvGz5KeyWxFQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/node-red-admin/-/node-red-admin-3.1.3.tgz",
+            "integrity": "sha512-RRkjwLjriCKW3bqiU21y3j+wpZ4bDf2EH3IEqxwP6hT4ccIwEK8Nt9dPZRWD6NyWGbEVDSTM5H0/whaRdFCqSw==",
             "dev": true,
             "dependencies": {
                 "ansi-colors": "^4.1.3",
-                "axios": "^1.6.7",
+                "axios": "^1.6.8",
                 "bcryptjs": "^2.4.3",
                 "cli-table": "^0.3.11",
                 "enquirer": "^2.3.6",
@@ -9556,90 +9346,6 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
-        "node_modules/node-red/node_modules/body-parser": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.11.0",
-                "raw-body": "2.5.1",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/node-red/node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/node-red/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/node-red/node_modules/express": {
-            "version": "4.18.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
-            "dev": true,
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.1",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.5.0",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.11.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            }
-        },
         "node_modules/node-red/node_modules/lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -9650,27 +9356,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/node-red/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true
-        },
-        "node_modules/node-red/node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/node-red/node_modules/semver": {
@@ -11911,14 +11596,14 @@
             "dev": true
         },
         "node_modules/tar": {
-            "version": "6.1.13",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-            "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
             "dev": true,
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^4.0.0",
+                "minipass": "^5.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
@@ -11928,9 +11613,9 @@
             }
         },
         "node_modules/tar/node_modules/minipass": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "medium-zoom": "^1.0.8",
         "mermaid": "^10.4.0",
         "mocha": "^10.2.0",
-        "node-red": "^3.1.0",
+        "node-red": "^3.1.9",
         "node-red-node-test-helper": "^0.3.3",
         "npm-run-all": "^4.1.5",
         "should": "^13.2.3",


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Bump the version of Node-RED to ensure the new version of express is pulled to close open CVE