### PR TITLE
Add a setting to specify maximum size for SocketIO communication

### DIFF
--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -80,3 +80,16 @@ dashboard: {
 }
 ```
 
+#### `maxHttpBufferSize`
+
+This set the maximum message size (in bytes) the socket can send.
+Default value is 1MiB (1E6 bytes).
+
+Change this value to allow larger files to be uploaded.
+
+```js
+dashboard: {
+    maxHttpBufferSize: 1e8 // size in bytes, example: 100 MB
+}
+```
+

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -181,7 +181,8 @@ module.exports = function (RED) {
                 const socketIoPath = join('/', fullPath, 'socket.io')
                 /** @type {import('socket.io/dist').ServerOptions} */
                 const serverOptions = {
-                    path: socketIoPath
+                    path: socketIoPath,
+                    maxHttpBufferSize: uiShared.settings.maxHttpBufferSize || 1e6 // SocketIO default size
                 }
                 // console.log('Creating socket.io server at path', socketIoPath) // disable - noisy in tests
                 // store reference to the SocketIO Server


### PR DESCRIPTION
## Description

Add a setting `dashboard: { maxHttpBufferSize }` to modify the maximum size for SocketIO communication.
Allow to upload larger files than ~1 MiB.

Set the default size to 1 MiB to keep backward compatibility.

## Related Issue(s)

Closes #509

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
