### PR TITLE
Vuetify Version Bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
                 "vite-plugin-pwa": "^0.19.8",
                 "vitepress": "^1.0.2",
                 "vue-router": "^4.2.4",
-                "vuetify": "^3.4.10",
+                "vuetify": "^3.5.17",
                 "vuex": "^4.1.0"
             },
             "engines": {
@@ -15462,9 +15462,9 @@
             }
         },
         "node_modules/vuetify": {
-            "version": "3.4.10",
-            "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.4.10.tgz",
-            "integrity": "sha512-tObGoumCJxuK26OpS/CLZZIJAgDtN2cnd31vJscVhpuf6jeMD7wh8IsgfZownAOXU1FcKWVQwn1RSDsoXk5cJA==",
+            "version": "3.5.17",
+            "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.17.tgz",
+            "integrity": "sha512-/Veklxxyu/l63q7QQOqJZeZukIKI2sBxY7FKMDcNup2KSGMjyjT+oYXy1DOdl7wlU3c3fKGQMFHqVWb0HDsyDw==",
             "dev": true,
             "engines": {
                 "node": "^12.20 || >=14.13"
@@ -15475,10 +15475,10 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.7",
-                "vite-plugin-vuetify": ">=1.0.0-alpha.12",
+                "vite-plugin-vuetify": ">=1.0.0",
                 "vue": "^3.3.0",
                 "vue-i18n": "^9.0.0",
-                "webpack-plugin-vuetify": ">=2.0.0-alpha.11"
+                "webpack-plugin-vuetify": ">=2.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "vite-plugin-pwa": "^0.19.8",
         "vitepress": "^1.0.2",
         "vue-router": "^4.2.4",
-        "vuetify": "^3.4.10",
+        "vuetify": "^3.5.17",
         "vuex": "^4.1.0"
     },
     "engines": {

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -16,6 +16,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 
 // Labs Imports
+import { VNumberInput } from 'vuetify/labs/VNumberInput'
 import { VSparkline } from 'vuetify/labs/VSparkline'
 import { VTreeview } from 'vuetify/labs/VTreeview'
 
@@ -50,6 +51,7 @@ const theme = {
 const vuetify = createVuetify({
     components: {
         ...components,
+        VNumberInput,
         VSparkline,
         VTreeview
     },

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -15,6 +15,10 @@ import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 
+// Labs Imports
+import { VSparkline } from 'vuetify/labs/VSparkline'
+import { VTreeview } from 'vuetify/labs/VTreeview'
+
 import './stylesheets/common.css'
 
 import store from './store/index.mjs'
@@ -44,7 +48,11 @@ const theme = {
 }
 
 const vuetify = createVuetify({
-    components,
+    components: {
+        ...components,
+        VSparkline,
+        VTreeview
+    },
     directives,
     theme: {
         defaultTheme: 'nrdb',


### PR DESCRIPTION
## Description

- Update vuetify dependency to `3.5.17`
- Allows for the inclusion of `v-sparkline` and `v-treeview` in a `ui-template `node.

## Related Issue(s)

Closes #798