### PR TITLE
Fix layout order editor crashing on subflows

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1083,7 +1083,7 @@
                 const subflowInstance = n
                 if (subflowDef && subflowDef.env && subflowDef.env.length > 0) {
                     /** @type {{name:String, type:String, value:String}[]} */
-                    const envDefsWithUIGroup = subflowDef.env.filter(env => env.type === 'ui-group' && env.ui.type === 'conf-types')
+                    const envDefsWithUIGroup = subflowDef.env.filter(env => env.type === 'ui-group' && env.ui?.type === 'conf-types')
                     for (const envDef of envDefsWithUIGroup) {
                         const groupNameAsEnv = '${' + envDef.name + '}'
 


### PR DESCRIPTION
## Description

Fixes that layout order editor is crashing when using UI nodes in subflows.

## Related Issue(s)

https://github.com/FlowFuse/node-red-dashboard/issues/709

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

