### PR TITLE
Fix - In onLoad, check if hardcoded widget or not

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -654,7 +654,9 @@ module.exports = function (RED) {
             // console.log('conn:' + conn.id, 'on:widget-load:' + id, msg)
 
             const { wNode, widgetEvents } = getWidgetAndConfig(id)
-            if (!wNode) {
+            // any widgets we hard-code into our front end (e.g ui-notification for connection alerts) will start with ui-
+            // Node-RED built nodes will be a random UUID
+            if (!wNode && !id.startsWith('ui-')) {
                 console.log('widget does not exist any more')
                 return // widget does not exist any more (e.g. deleted from NR and deployed BUT the ui page was not refreshed)
             }

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -54,7 +54,7 @@
                 />
                 <!-- Explicitly render a notification widget for our own internal alerting -->
                 <ui-notification
-                    id="inline-alert" ref="alert"
+                    id="ui-inline-alert" ref="alert"
                     :props="{position: 'top right', showCountdown: alert.showCountdown, displayTime: alert.displayTime, raw: true, allowDismiss: alert.allowDismiss}"
                 />
             </div>


### PR DESCRIPTION
## Description

Fixes https://discourse.nodered.org/t/widget-does-not-exist-any-more/87500/3

With https://github.com/FlowFuse/node-red-dashboard/pull/790 we introduced the first ever hard-coded widget to the front end, a `ui-notification` that triggers when there are connectivity problems. This was firing a `widget-load` event (as all widgets do), but then, server-side, was trying to load that node form the flow.json, which didn't exist. As such, it reported it as a "deleted widget", which wasn't true.

As such, I've introduced a new `id` pattern, whereby any hard-coded front-end widgets we use will now have a `ui-<id>` `id` structure to differentiate them from flow-loaded nodes/widgets.

