### PR TITLE
UI Gauge - Fix the re-ordering of the gauge segments in the NR Editor

### DIFF
--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -155,7 +155,7 @@
 
             $('#node-input-segments-container').sortable({
                 axis: 'y',
-                handle: '.node-input-option-handle',
+                handle: '.node-input-segment-handle',
                 cursor: 'move'
             })
 


### PR DESCRIPTION
## Description

Fixes the typo from the copy/pasted code (from `ui-dropdown`) which meant the sorting selector wasn't properly enabled.

## Related Issue(s)

Close #558