### PR TITLE
Fix UIText text color being fixed color

### DIFF
--- a/ui/src/widgets/ui-text/UIText.vue
+++ b/ui/src/widgets/ui-text/UIText.vue
@@ -35,7 +35,6 @@ export default {
     flex-direction: row;
     gap: 2px;
     font-size: 1rem;
-    color: #717171;
     font-family: Helvetica;
 }
 .nrdb-ui-text-value {


### PR DESCRIPTION
Removed the `color` parameter from the css `.nrdb-ui-text`. This allows the color to be automatic depending on background

## Description

Remove the `color` attribute from the css `.nrdb-ui-text`

## Related Issue(s)

Partially closes #644 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

