### PR TITLE
UI Table - Ensure table is scrollable when content overflows

### DIFF
--- a/ui/src/widgets/ui-table/UITable.vue
+++ b/ui/src/widgets/ui-table/UITable.vue
@@ -146,6 +146,10 @@ export default {
 </script>
 
 <style>
+.nrdb-ui-table {
+    overflow-y: auto;
+}
+
 .nrdb-table.v-table {
     background: rgb(var(--v-theme-group-background));
 }


### PR DESCRIPTION
## Description

As a very quick iteration of #76 this at least makes the table scrollable anf therefore the content accessible on mobile.