### PR TITLE
Generate source map during development

### DIFF
--- a/docs/contributing/widgets/third-party.md
+++ b/docs/contributing/widgets/third-party.md
@@ -61,7 +61,7 @@ To start working with your own third-party widget, locally on your machine:
    ```bash
    npm install /path/to/your/local/node-red-dashboard-example-node
    ```
-5. Optionally skip minification of the code, to simplify debugging of the frontend code in the browser.  On Linux this can be achieved by:
+5. Optionally generate a source map (to map the minified code to the original code), to simplify debugging of the frontend code in the browser.  On Linux this can be achieved by:
    ```bash
    export NODE_ENV=development
    ```

--- a/docs/contributing/widgets/third-party.md
+++ b/docs/contributing/widgets/third-party.md
@@ -56,15 +56,19 @@ To start working with your own third-party widget, locally on your machine:
 
 1. Install Node-RED
 2. Install `@flowfuse/node-red-dashboard` into Node-RED via the "Manage Palette" option.
-2. Fork our [Example Node repository](https://github.com/FlowFuse/node-red-dashboard-example-node) and clone it locally to your machine.
-3. Navigate to your local Node-RED directory and install the local copy of the Example Node:
-```bash
-npm install /path/to/your/local/node-red-dashboard-example-node
-```
-4. Inside the Example Node directory, build the Example Node's `.umd.js` file, this will generate it's `/resources` folder, loaded by Node-RED.
-```bash
-npm run build
-```
+3. Fork our [Example Node repository](https://github.com/FlowFuse/node-red-dashboard-example-node) and clone it locally to your machine.
+4. Navigate to your local Node-RED directory and install the local copy of the Example Node:
+   ```bash
+   npm install /path/to/your/local/node-red-dashboard-example-node
+   ```
+5. Optionally skip minification of the code, to simplify debugging of the frontend code in the browser.  On Linux this can be achieved by:
+   ```bash
+   export NODE_ENV=development
+   ```
+6. Inside the Example Node directory, build the Example Node's `.umd.js` file, this will generate it's `/resources` folder, loaded by Node-RED.
+   ```bash
+   npm run build
+   ```
 
 _Note: Any local changes you make inside the `/ui` folder of the third party widget, you'll need to re-run `npm run build` in order to update the `umd.js` file, which is what Dashboard loads to render the widget._
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,6 +36,8 @@ export default defineConfig({
     ],
     root: 'ui',
     build: {
+        // Skip minification in dev mode
+        minify: process.env.NODE_ENV !== 'development',
         outDir: '../dist',
         emptyOutDir: true
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,8 +36,8 @@ export default defineConfig({
     ],
     root: 'ui',
     build: {
-        // Skip minification in dev mode
-        minify: process.env.NODE_ENV !== 'development',
+        // Generate a source map in dev mode
+        sourcemap: process.env.NODE_ENV === 'development',
         outDir: '../dist',
         emptyOutDir: true
     },


### PR DESCRIPTION
## Description

During the Vite build phase, the frontend code is being minified.  Which made it quite hard for me to contribute to this repo.  This pull request uses the same mechanism as in the [node-red-dashboard-2-ui-example](https://github.com/FlowFuse/node-red-dashboard-2-ui-example/blob/main/vite.config.js#L16) repo to allow skipping minification during the development phase.

I have also added an extra (optional) step to the documentation, but imho the [developing locally](https://github.com/bartbutenaers/node-red-dashboard/blob/main/docs/contributing/widgets/third-party.md#developing-locally) section should be not under third-party widgets, because it is also required when you want to contribute to the dashboard...

## Related Issue(s)

See [819](https://github.com/FlowFuse/node-red-dashboard/issues/819)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ X ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

