### PR TITLE
Clear radio by empty string (documentation fix)

### DIFF
--- a/docs/nodes/widgets/ui-radio-group.md
+++ b/docs/nodes/widgets/ui-radio-group.md
@@ -28,7 +28,7 @@ You can dynamically make selections for this dropdown by passing in the respecti
 
 ### Clear Selection
 
- To clear any selection for a dropdown, pass a `null` as `msg.payload`.
+ To clear any selection for a dropdown, pass an empty string `""` as `msg.payload`.
 
 ## Properties
 


### PR DESCRIPTION
## Description

The radio button selection can be cleared by injecting an empty string.  
Note: I have tested it again, and it works...

But the readme page showed that `null` should be injected (instead of empty string).  That is fixed now:

![image](https://github.com/FlowFuse/node-red-dashboard/assets/14224149/c91a7939-6eb4-452a-af7f-9fef33f711bb)

BTW There was no html (and json) file in the locales, so I did not have to change that.  
But  I will try to add these files later on, via a separate PR.

## Related Issue(s)

See [818](https://github.com/FlowFuse/node-red-dashboard/issues/818)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ X ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ X ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

