### PR TITLE
Radio group help panel

### DIFF
--- a/nodes/widgets/locales/en-US/ui_radio_group.html
+++ b/nodes/widgets/locales/en-US/ui_radio_group.html
@@ -1,0 +1,34 @@
+<script type="text/html" data-help-name="ui-radio-group">
+    <p>
+        Adds a radio group to your dashboard that will emit values
+        in Node-RED under `msg.payload` anytime a value is selected.
+    </p>
+    <p>
+        In the case where an option is selected, returns the object detailing that selection.
+    </p>
+    <h3>Selecting Options via <code>msg.</code></h3>
+    <p>
+        You can dynamically make selections for this dropdown by passing in the respective <code>value</code> to <code>msg.payload</code>.
+    </p>
+    <p>
+        To make a selection, pass in the <code>value</code> of the option as <code>msg.payload</code>, e.g. <code>msg.payload = "option1"</code>.
+    </p>
+    <p>
+        To clear any selection for a dropdown, pass an empty string <code>""</code> as <code>msg.payload</code>.
+    </p>
+    <h3>Dynamic Properties (Inputs)</h3>
+    <p>Any of the following can be appended to a <code>msg.</code> in order to override or set properties on this node at runtime.</p>
+    <dl class="message-properties">
+        <dt class="optional">options <span class="property-type">array</span></dt>
+        <dd>
+            Change the options available in the dropdown at runtime
+            <ul>
+                <li><code>Array&lt;string&gt;</code></li>
+                <li><code>Array&lt;{value: String}&gt;</code></li>
+                <li><code>Array&lt;{value: String, label: String}&gt;</code></li>
+            </ul>
+        </dd>
+        <dt class="optional">class <span class="property-type">string</span></dt>
+        <dd>Add a CSS class, or more, to the Button at runtime.</dd>
+    </dl>
+</script>


### PR DESCRIPTION
## Description

There was not yet a help panel for the the radio group node.
I created one similar to the dropdown node, based on the the info from the radio group readme page.

![image](https://github.com/FlowFuse/node-red-dashboard/assets/14224149/e559b52e-1b67-46fe-afa8-a7024591a606)

## Related Issue(s)

See [838](https://github.com/FlowFuse/node-red-dashboard/issues/838)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ X ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ X ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

