### PR TITLE
Docs - detail v-data-table case sensitivity examples

### DIFF
--- a/docs/examples/template-data-table.json
+++ b/docs/examples/template-data-table.json
@@ -1,0 +1,102 @@
+[
+    {
+        "id": "b91222a816a4b3af",
+        "type": "ui-template",
+        "z": "9c18a4bf6ab4e5c1",
+        "group": "73a5677f40da71fe",
+        "page": "",
+        "ui": "",
+        "name": "",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "head": "",
+        "format": "<template>\n    <div id=\"app\">\n        <v-text-field v-model=\"search\" label=\"Search\" prepend-inner-icon=\"mdi-magnify\" single-line variant=\"outlined\"\n            hide-details></v-text-field>\n        <v-data-table v-model:search=\"search\" :headers=\"headers\" :items=\"msg?.payload\" class=\"elevation-1\" :items-per-page=\"20\">\n            <template v-slot:header.lowercase>\n                <div>custom <b>html</b> title</div>\n            </template>\n            <template v-slot:item.snake_case=\"{ item }\">\n                ${{ 3 * item.snake_case }}\n            </template>\n        </v-data-table>\n    </div>\n</template>\n\n<script>\n    export default {\n    data () {\n      return {\n        search: '',\n        headers: [\n            // a basic header definition\n            { title: 'kebab-case', key: 'kebab-case' },\n            { title: 'slithering', key: 'snake_case'},\n            // we can also use v-slot (see in HTML above) to define\n            // our titles with more customisation\n            { key: 'lowercase' },\n            // if we need to transform due to case sensitivity, we can do so like this:\n            { title: 'Date & Time', key: 'camel-case', value: item => item['camelCase']},\n            // we can also add JS transformation to our values too\n            { title: 'All Caps', key: 'macro-case', value: item => item['MACRO_CASE'].toUpperCase()}\n        ],\n      }\n    },\n  }\n</script>",
+        "storeOutMessages": true,
+        "passthru": true,
+        "resendOnRefresh": true,
+        "templateScope": "local",
+        "className": "",
+        "x": 280,
+        "y": 60,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "cfa65c8026f897a7",
+        "type": "inject",
+        "z": "9c18a4bf6ab4e5c1",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "[{\"lowercase\":\"abc\",\"kebab-case\":52,\"camelCase\":\"2024-05-05T16:00:00\",\"snake_case\":123,\"MACRO_CASE\":\"Some Text\"},{\"lowercase\":\"def\",\"kebab-case\":64,\"camelCase\":\"2024-05-05T16:00:00\",\"snake_case\":123,\"MACRO_CASE\":\"Some Different Text\"}]",
+        "payloadType": "json",
+        "x": 110,
+        "y": 60,
+        "wires": [
+            [
+                "b91222a816a4b3af"
+            ]
+        ]
+    },
+    {
+        "id": "73a5677f40da71fe",
+        "type": "ui-group",
+        "name": "Custom Tables",
+        "page": "a9b32250ebfa989b",
+        "width": "12",
+        "height": "1",
+        "order": -1,
+        "showTitle": true,
+        "className": "",
+        "visible": "true",
+        "disabled": "false"
+    },
+    {
+        "id": "a9b32250ebfa989b",
+        "type": "ui-page",
+        "name": "Template Examples",
+        "ui": "c2e1aa56f50f03bd",
+        "path": "/templates",
+        "icon": "view-dashboard",
+        "layout": "flex",
+        "theme": "129e99574def90a3",
+        "order": 14,
+        "className": ""
+    },
+    {
+        "id": "c2e1aa56f50f03bd",
+        "type": "ui-base",
+        "name": "Dashboard",
+        "path": "/dashboard",
+        "showPathInSidebar": false,
+        "navigationStyle": "default"
+    },
+    {
+        "id": "129e99574def90a3",
+        "type": "ui-theme",
+        "name": "Another Theme",
+        "colors": {
+            "surface": "#000000",
+            "primary": "#ff4000",
+            "bgPage": "#f0f0f0",
+            "groupBg": "#ffffff",
+            "groupOutline": "#d9d9d9"
+        },
+        "sizes": {
+            "pagePadding": "9px",
+            "groupGap": "12px",
+            "groupBorderRadius": "9px",
+            "widgetGap": "6px"
+        }
+    }
+]

--- a/docs/user/template-examples.md
+++ b/docs/user/template-examples.md
@@ -7,9 +7,11 @@ description: Get inspired with a variety of UI template examples in Node-RED Das
     import { ref } from 'vue'
     import FlowViewer from '../components/FlowViewer.vue'
     import ExampleFlowWorldmap from '../examples/template-worldmap.json'
+    import ExampleDataTable from '../examples/template-data-table.json'
 
     const examples = ref({
-      'worldmap': ExampleFlowWorldmap
+      'worldmap': ExampleFlowWorldmap,
+      'custom-data-table': ExampleDataTable
     })
 </script>
 
@@ -86,19 +88,19 @@ Where we pass in data such as:
 ```json
 [
     {
-        "Room": "Living Room",
+        "room": "Living Room",
         "id": "1234",
         "target": 18.1,
         "current": 20
     },
     {
-        "Room": "Bathroom Room",
+        "room": "Bathroom Room",
         "id": "5678",
         "target": 19.5,
         "current": 18
     },
     {
-        "Room": "Kitchen Room",
+        "room": "Kitchen Room",
         "id": "9101",
         "target": 18.1,
         "current": 17.6
@@ -107,6 +109,67 @@ Where we pass in data such as:
 ```
 
 Vuetify's Data Table will automatically render a column for each item in the data provided, by default it will just render it as text (as we do in `ui-table`). However, we can also use the `<template v-slot:item.property />` syntax to override how we render a particular cell.
+
+#### Important Note: Case Sensitivity
+
+This is only relevant if you wish to use `<template>` overrides in your `v-data-table` to customize the appearance of a cell or header.
+
+Due to a limitation in the way that HTML renders, you cannot use capital letters in DOM templates. This means that if you have a property in your data called `myProperty` or `My_Property`, then we need to transform it to an HTML-friendly format, before we can include it in `<template v-slot:item.property="{ item }">`. 
+
+This transformation can be achieved using the `v-data-table`'s `headers` option which allows us to map values and keys.
+
+```vue
+<template>
+    <div id="app">
+        <v-text-field v-model="search" label="Search" prepend-inner-icon="mdi-magnify" single-line variant="outlined"
+            hide-details></v-text-field>
+        <v-data-table v-model:search="search" :headers="headers" :items="msg?.payload" class="elevation-1" :items-per-page="20">
+            <template v-slot:header.lowercase>
+                <div>custom <b>html</b> title</div>
+            </template>
+            <template v-slot:item.snake_case="{ item }">
+                ${{ 3 * item.snake_case }}
+            </template>
+        </v-data-table>
+    </div>
+</template>
+
+<script>
+    export default {
+    data () {
+      return {
+        search: '',
+        headers: [
+            // a basic header definition
+            { title: 'kebab-case', key: 'kebab-case' },
+            { title: 'slithering', key: 'snake_case'},
+            // we can also skip defining a title here,
+            // and use v-slot (see in HTML above) instead
+            { key: 'lowercase' },
+            // if we need to transform due to case sensitivity, we can do so like this:
+            { title: 'Date & Time', key: 'camel-case', value: item => item['camelCase']},
+            // we can also add JS transformation to our values too
+            { title: 'All Caps', key: 'macro-case', value: item => item['MACRO_CASE'].toUpperCase()}
+        ],
+      }
+    },
+  }
+</script>
+```
+
+In summary, the different ways to handle case sensitivity are:
+
+| Type | Transform Required |
+|------|--------------------|
+| `kebab-case` | No |
+| `snake_case` | No |
+| `lowercase` | No |
+| `camelCase` | Yes |
+| `MACRO_CASE` | Yes |
+
+You can try out the above example with this flow:
+
+<FlowViewer :flow="examples['custom-data-table']" height="200px"/>
 
 ### World Map
 


### PR DESCRIPTION
## Description

A significant gotcha for Vuetify data tables is the case sensitivity of the `v-slot` feature to define custom cell and header formatting. This details in our docs how to circumvent this, and work with a collection of different case types.

## Related Issue(s)

Closes #840 