### PR TITLE
Remove page order injected for debugging

### DIFF
--- a/cypress/tests/config-nodes/pages.spec.js
+++ b/cypress/tests/config-nodes/pages.spec.js
@@ -19,7 +19,9 @@ describe('Node-RED Dashboard 2.0', () => {
 
         // Check we have the pages listed
         cy.get('[data-nav="dashboard-ui-page-1"]').should('be.visible')
+        cy.get('[data-nav="dashboard-ui-page-1"]').should('have.text', 'Page 1')
         cy.get('[data-nav="dashboard-ui-page-2"]').should('be.visible')
+        cy.get('[data-nav="dashboard-ui-page-2"]').should('have.text', 'Page 2')
 
         // Click page 2
         cy.get('[data-nav="dashboard-ui-page-2"]').click({ force: true }) // for some reason Cypress thinks this element is off the screen - it isn't

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -224,7 +224,7 @@ export default {
             }
         },
         getPageLabel (page) {
-            return page.order + ' ' + page.name + (this.dashboard.showPathInSidebar ? ` (${page.path})` : '')
+            return page.name + (this.dashboard.showPathInSidebar ? ` (${page.path})` : '')
         },
         handleNavigationClick () {
             if (this.navigationStyle === 'fixed') {


### PR DESCRIPTION
## Description

- Removes hardcoded inclusion of `page.order` in the page name
- Add E2E check to prevent regression in the future