### PR TITLE
Docs - Improve rendering of "Dynamic Properties" table

### DIFF
--- a/docs/components/DynamicPropsTable.vue
+++ b/docs/components/DynamicPropsTable.vue
@@ -13,7 +13,12 @@
             <tr v-for="(value, property) in page.frontmatter?.dynamic" :key="property">
                 <td>{{ property }}</td>
                 <td><code>{{ value.payload }}</code></td>
-                <td><ul><li v-for="s in value.structure" :key="s"><code>{{ s }}</code></li></ul></td>
+                <td>
+                    <ul v-if="value.structure?.length > 1">
+                        <li v-for="s in value.structure" :key="s"><code>{{ s }}</code></li>
+                    </ul>
+                    <code v-else>{{ value.structure[0] }}</code>
+                </td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Description

Had a hardcoded `<ul>` for the property types, even when only one type was available. This now only renders the list if appropriate.

## Related Issue(s)

Relevant to all of the updates we're doing as part of #833 