### PR TITLE
UI Link - Fix warning in ui-base for undefined theme

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -868,7 +868,7 @@ module.exports = function (RED) {
             }
 
             // map themes by their ID
-            if (page && !node.ui.themes.has(page.theme)) {
+            if (page && page.type === 'ui-page' && !node.ui.themes.has(page.theme)) {
                 const theme = RED.nodes.getNode(page.theme)
                 if (theme) {
                     const { _wireCount, _inputCallback, _inputCallbacks, _closeCallbacks, wires, type, ...t } = theme


### PR DESCRIPTION
## Description

Checks if the `page` variable passed to `register()` function is in fact a `ui-page` before trying to extract `ui-theme` data. When we introduced `ui-link`, they're registered as pages, but have no theme.

## Related Issue(s)

Closes #868 