### PR TITLE
Lead with [Page Name] for group selection

### DIFF
--- a/nodes/config/ui_group.html
+++ b/nodes/config/ui_group.html
@@ -17,7 +17,7 @@
         },
         label: function () {
             const page = RED.nodes.node(this.page)?.name || ''
-            return `${this.name} [${page}]` || 'UI Group'
+            return `[${page}] ${this.name}` || 'UI Group'
         },
         oneditprepare: function () {
             if (this.disp) {


### PR DESCRIPTION
## Description

- The Node-RED config input selector is driven by `label` for sorting, as such, to order as per the request (which does make life _a lot_ easier) we need to change our group config node labels
- This changes the label to be page _first_, enclosed in `[ ]`

## Related Issue(s)

Closes #660 

### Before:

<img width="460" alt="Screenshot 2024-05-24 at 12 01 18" src="https://github.com/FlowFuse/node-red-dashboard/assets/99246719/d054fb54-13c6-4bce-9dc8-fbc57b159572">

### After:
<img width="460" alt="Screenshot 2024-05-24 at 11 59 51" src="https://github.com/FlowFuse/node-red-dashboard/assets/99246719/04d392e7-adfe-4a8a-a70c-eefa568eb8ce">
