### PR TITLE
UI Theme - Add "registerTheme" function to prevent ui-page dependency

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -773,6 +773,11 @@ module.exports = function (RED) {
             return fullPath
         }
 
+        node.registerTheme = function (theme) {
+            const { _wireCount, _inputCallback, _inputCallbacks, _closeCallbacks, wires, type, ...t } = theme
+            node.ui.themes.set(t.id, t)
+        }
+
         /**
          * Register allows for pages, widgets, groups, etc. to register themselves with the Base UI Node
          * @param {*} page
@@ -871,21 +876,21 @@ module.exports = function (RED) {
             if (page && page.type === 'ui-page' && !node.ui.themes.has(page.theme)) {
                 const theme = RED.nodes.getNode(page.theme)
                 if (theme) {
-                    const { _wireCount, _inputCallback, _inputCallbacks, _closeCallbacks, wires, type, ...t } = theme
-                    node.ui.themes.set(page.theme, t)
+                    node.registerTheme(theme)
                 } else {
                     node.warn(`Theme '${page.theme}' specified  in page '${page.id}' does not exist`)
                 }
             }
 
             // map pages by their ID
-            if (page && !node.ui.pages.has(page?.id)) {
+            if (page) {
+                // ensure we have the latest instance of the page's node
                 const { _users, ...p } = page
                 node.ui.pages.set(page.id, p)
             }
 
             // map groups on a page-by-page basis
-            if (group && !node.ui.groups.has(group?.id)) {
+            if (group) {
                 const { _user, type, ...g } = group
                 node.ui.groups.set(group.id, g)
             }

--- a/nodes/config/ui_theme.js
+++ b/nodes/config/ui_theme.js
@@ -34,6 +34,18 @@ module.exports = function (RED) {
 
         node.colors = { ...rest.colors }
         node.sizes = sizes
+
+        let uiBase = null
+        RED.nodes.eachNode(n => {
+            if (n.type === 'ui-base' && !uiBase) {
+                uiBase = n
+            }
+        })
+        if (uiBase) {
+            config.ui = uiBase.id
+            uiBase = RED.nodes.getNode(config.ui)
+        }
+        uiBase?.registerTheme(node)
     }
     RED.nodes.registerType('ui-theme', UIThemeNode)
 }


### PR DESCRIPTION
## Description

- Adds `registerTheme` function to `ui-base
- Removes the check to see if a config node has already been saved to the `nodes.ui` map in `ui-base` as on partial deploys, this gets called without it having been cleared, and so valid updates are missed
- Call `registerTheme` from the `ui-theme` constructor and consequently remove the dependency of `ui-page` to register `ui-theme`s, which was causing the bug in the first place (`ui-page` wasn't updating, so the partical deploy didn't re-register the `ui-theme`)

## Related Issue(s)

Closes #332