### PR TITLE
docs: fix docs typos and spelling mistakes

### DIFF
--- a/docs/user/migration/ui_template.json
+++ b/docs/user/migration/ui_template.json
@@ -40,7 +40,7 @@
         {
             "property": "reload on refresh",
             "changes": "modified",
-            "notes": "Default behaviour is that, if there is a known state, it will atomatically be restored."
+            "notes": "Default behaviour is that, if there is a known state, it will automatically be restored."
         },
         {
             "property": "store output",

--- a/docs/user/migration/ui_template.json
+++ b/docs/user/migration/ui_template.json
@@ -45,7 +45,7 @@
         {
             "property": "store output",
             "changes": "modified",
-            "notes": "If using the new in-buil;d 'send' function from within a template, this will store the output of the send function in the nodes state."
+            "notes": "If using the new built-in 'send' function from within a template, this will store the output of the send function in the nodes state."
         }
     ]
 }

--- a/docs/user/migration/ui_toast.json
+++ b/docs/user/migration/ui_toast.json
@@ -1,6 +1,6 @@
 {
     "node": "ui_toast",
-    "description": "'UI Tast' has been renamed to 'UI Notification' in Dashboard 2.0, but most of the functionality is identical.'",
+    "description": "'UI Toast' has been renamed to 'UI Notification' in Dashboard 2.0, but most of the functionality is identical.'",
     "properties": [
         {
             "property": "name",

--- a/docs/user/migration/ui_toast.json
+++ b/docs/user/migration/ui_toast.json
@@ -25,7 +25,7 @@
         {
             "property": "highlight",
             "changes": "color",
-            "notes": "Instead of now just defining a single 'border' colour, the 'highlight' is used on the left-side of the notification'"
+            "notes": "Instead of now just defining a single 'border' colour, the 'highlight' is used on the left-side of the notification."
         },
         {
             "property": "raw injection",

--- a/docs/user/migration/ui_toast.json
+++ b/docs/user/migration/ui_toast.json
@@ -1,6 +1,6 @@
 {
     "node": "ui_toast",
-    "description": "'UI Toast' has been renamed to 'UI Notification' in Dashboard 2.0, but most of the functionality is identical.'",
+    "description": "'UI Toast' has been renamed to 'UI Notification' in Dashboard 2.0, but most of the functionality is identical.",
     "properties": [
         {
             "property": "name",


### PR DESCRIPTION
## Description
I found a few small typo's and spelling mistakes when I was reading through the docs.

They are under:
[Migration ui_template](https://dashboard.flowfuse.com/user/migration.html#ui-template)
[Migration ui_toast](https://dashboard.flowfuse.com/user/migration.html#ui-toast)

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

