### PR TITLE
Dynamic Classes - handle both msg.ui_update.class and msg.class

### DIFF
--- a/cypress/fixtures/flows/dashboard-dynamic-class.json
+++ b/cypress/fixtures/flows/dashboard-dynamic-class.json
@@ -154,6 +154,66 @@
         ]
     },
     {
+        "id": "184c7c5789357136",
+        "type": "ui-button",
+        "z": "3069e2ce342ccdc8",
+        "group": "dashboard-ui-group-buttons",
+        "name": "",
+        "label": "Send Class (ui-button) - UI Update",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "[]",
+        "payloadType": "json",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 160,
+        "y": 60,
+        "wires": [
+            [
+                "fad2a458b82539ba"
+            ]
+        ]
+    },
+    {
+        "id": "fad2a458b82539ba",
+        "type": "change",
+        "z": "node-red-tab-slider",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "ui_update.class",
+                "pt": "msg",
+                "to": "test-class-ui-update",
+                "tot": "str"
+            },
+            {
+                "t": "delete",
+                "p": "payload",
+                "pt": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 400,
+        "y": 60,
+        "wires": [
+            [
+                "d506363d3f2c88cd"
+            ]
+        ]
+    },
+    {
         "id": "51dbeee0bbdbe4ee",
         "type": "ui-button",
         "z": "3069e2ce342ccdc8",

--- a/cypress/tests/behaviours/dynamic-class.spec.js
+++ b/cypress/tests/behaviours/dynamic-class.spec.js
@@ -4,7 +4,7 @@ describe('Node-RED Dashboard 2.0 - Allow for dynamic class assignments through m
         cy.visit('/dashboard/page1')
     })
 
-    it('UI Buttons', () => {
+    it('UI Buttons (msg.class)', () => {
         // Emitting strings
         cy.get('button').contains('Send Class (ui-button)').click()
 
@@ -16,6 +16,20 @@ describe('Node-RED Dashboard 2.0 - Allow for dynamic class assignments through m
 
         // ensure class is still there and data has persisted
         cy.get('#nrdb-ui-widget-d506363d3f2c88cd').should('have.class', 'test-class')
+    })
+
+    it('UI Buttons (msg.ui_update.class)', () => {
+        // Emitting strings
+        cy.clickAndWait(cy.get('button').contains('Send Class (ui-button) - UI Update'))
+
+        // check in our Dashboard that the class has been applied
+        cy.get('#nrdb-ui-widget-d506363d3f2c88cd').should('have.class', 'test-class-ui-update')
+
+        // refresh the page
+        cy.reloadDashboard()
+
+        // ensure class is still there and data has persisted
+        cy.get('#nrdb-ui-widget-d506363d3f2c88cd').should('have.class', 'test-class-ui-update')
     })
 
     it('UI Switch', () => {

--- a/docs/user/dynamic-properties.md
+++ b/docs/user/dynamic-properties.md
@@ -18,20 +18,19 @@ msg = {
 }
 ```
 
-
 ## Updating Classes
-
-Classes behave slightly differently to other properties, and the injection of `class` is not maintained within the `ui_updates` object. Instead, you can send a `msg` to the widget itself, with the `class` property set.
 
 If we consider an example with a `ui-button`, you can send the following `msg` to the button itself:
 
 ```json
-{
-    "class": "my-class"
+msg = {
+    "ui_update": {
+        "class": "my-class"
+    }
 }
 ```
 
-Please note that for `class` updates, the class is appended the widget's container, so this means that your class' style definitions may need to take that into account. If you want to affect the background-color of a button for example:
+Note that for `class` updates, the class is appended the widget's container, so this means that your class' style definitions may need to take that into account. If you want to affect the background-color of a button for example:
 
 ```css
 .my-class button.v-btn {
@@ -40,3 +39,7 @@ Please note that for `class` updates, the class is appended the widget's contain
 ```
 
 Will do the trick. Notice that we sometimes have to over-define the CSS selector to ensure that the style is applied correctly, overriding any underlying Vuetify/built-in stylesheets.
+
+The CSS itself can be defined in a `ui-template` node with a "CSS (Single Page)" or "CSS (All Pages)" scope.
+
+Note also that `msg.class` injection is still supported for legacy reasons, but it is recommended to use `ui_update.class` where possible.

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -955,8 +955,9 @@ module.exports = function (RED) {
                         if (hasProperty(msg, 'visible')) {
                             statestore.set(n, widgetNode, msg, 'visible', msg.visible)
                         }
-                        if (hasProperty(msg, 'class')) {
-                            statestore.set(n, widgetNode, msg, 'class', msg.class)
+                        if (hasProperty(msg, 'class') || (hasProperty(msg, 'ui_update') && hasProperty(msg.ui_update, 'class'))) {
+                            const cls = msg.class || msg.ui_update?.class
+                            statestore.set(n, widgetNode, msg, 'class', cls)
                         }
 
                         // run any node-specific handler defined in the Widget's component

--- a/ui/src/widgets/data-tracker.mjs
+++ b/ui/src/widgets/data-tracker.mjs
@@ -26,10 +26,11 @@ export function useDataTracker (widgetId, onInput, onLoad, onDynamicProperties) 
             })
         }
 
-        if ('class' in msg) {
+        if ('class' in msg || ('ui_update' in msg && 'class' in msg.ui_update)) {
+            const cls = msg.class || msg.ui_update?.class
             store.commit('ui/widgetState', {
                 widgetId,
-                class: msg.class
+                class: cls
             })
         }
 


### PR DESCRIPTION
## Description

- Legacy support `msg.class`, and we've recently switched dynamic classes to live under `msg.ui_update`. We updated documentation for this, but never actually added the support in.
- Added E2E test to check button coverage (this is all shared logic, so no need to overkill on a test for all widget types here)

## Related Issue(s)

Related to #833