### PR TITLE
Ensure service worker is auto-updated on refresh

### DIFF
--- a/ui/src/sw.js
+++ b/ui/src/sw.js
@@ -6,6 +6,11 @@ self.addEventListener('message', (event) => {
     if (event.data && event.data.type === 'SKIP_WAITING') { self.skipWaiting() }
 })
 
+// https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/skipWaiting
+self.addEventListener('install', function (event) {
+    self.skipWaiting()
+})
+
 // self.__WB_MANIFEST is the default injection point
 precacheAndRoute(self.__WB_MANIFEST)
 


### PR DESCRIPTION
## Description

When developing locally, the new service worker introduced kept prompting a "reload" button every time I did a new build, and the UI would not correctly update until this was acknowledged.

This skips the confirmation requirement, and replaces the old service worker automatically, speeding up local development times.