### PR TITLE
GH Action - Version ump actions/upload-page-artifact

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ jobs:
         env:
             VITE_POSTHOG_APIKEY: ${{ vars.POSTHOG_API_KEY }}
       - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: docs/.vitepress/dist
       - name: Deploy

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ jobs:
         env:
             VITE_POSTHOG_APIKEY: ${{ vars.POSTHOG_API_KEY }}
       - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist
       - name: Deploy


### PR DESCRIPTION
## Description

With the recent dependabot updates, we can no longer deploy our documentation. The [failing build](https://github.com/FlowFuse/node-red-dashboard/actions/runs/9304191790/job/25608198285) complains:

```
Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.
```

We aren't using that action, but are using https://github.com/actions/upload-pages-artifact which was still on `v1`, whereas `v3` is available, hoping this update resolves the problem.