### PR TITLE
GH Actions - Add "name" to artifact to match "github-pages"

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: actions/upload-artifact@v4
         with:
+          name: github-pages
           path: docs/.vitepress/dist
       - name: Deploy
         id: deployment


### PR DESCRIPTION
## Description

Still [failing](https://github.com/FlowFuse/node-red-dashboard/actions/runs/9305584418/job/25612869917#step:8:20), this is the latest attempt to fix as [this](https://github.com/actions/upload-pages-artifact?tab=readme-ov-file#artifact-validation) pointed out the name requirement in the validation.

Follow on from https://github.com/FlowFuse/node-red-dashboard/pull/921