### PR TITLE
Docs - Add reference to "guides" from core docs & add gauge-classic example

### DIFF
--- a/docs/contributing/widgets/core-widgets.md
+++ b/docs/contributing/widgets/core-widgets.md
@@ -15,6 +15,15 @@ We are always open to Pull Requests and new ideas on widgets that can be added t
 
 When adding a new widget to the core collection, you will need to follow the steps below to ensure that the widget is available in the Node-RED editor and renders correctly in the UI.
 
+## Recommended Reading
+
+On the left-side navigation you'll find a "Useful Guides" section, we recommend taking a look through these as they give a good overview of the structure of the Dashboard 2.0 codebase and some of the underlying architectural principles it is built upon.
+
+In particular, the following are recommended:
+
+- [Events Architecture](/contributing/guides/state-management.html)
+- [State Management](/contributing/guides/state-management.html)
+
 ## Checklist
 
 When adding a new widget to Dashboard 2.0, you'll need to ensure that the following steps have been followed for that new widget to be recognised and included in a Dashboard 2.0 build:

--- a/docs/contributing/widgets/third-party.md
+++ b/docs/contributing/widgets/third-party.md
@@ -16,6 +16,15 @@ You can explore our collection of core widgets [here](../../nodes/widgets.md). I
 
 We do also realise though that there are many occasions where a standalone repository/package works better as was very popular in Dashboard 1.0.
 
+## Recommended Reading
+
+On the left-side navigation you'll find a "Useful Guides" section, we recommend taking a look through these as they give a good overview of the structure of the Dashboard 2.0 codebase and some of the underlying architectural principles it is built upon.
+
+In particular, the following are recommended:
+
+- [Events Architecture](/contributing/guides/state-management.html)
+- [State Management](/contributing/guides/state-management.html)
+
 ## How Widgets are Loaded
 
 Dashboard 2.0 is built on top of [VueJS](https://vuejs.org/), and as such, all widgets needs to be mapped to a Vue component. The process works as follows:
@@ -152,11 +161,13 @@ module.exports = function(RED) {
 
 ## Guides
 
+The below are guides and examples on building third-party widgets. We also have the "Useful Guides" Section in the left navigation which provide more generalized development guides when contributing to Dashboard 2.0.
+
 ### The Basics of VueJS
 
 Aware that a lot of developers that may want to contribute to Dashboard 2.0, may be new to VueJS, so we've detailed a few fundamentals here.
 
-It is very common place since VueJS to see Vue applications using the "Composition API", whilst this is lighter weight way of building your applications, it isn't the most intuitive for those unfamiliar with VueJS, as such, we're mostly using the "Options API" structure across Dashboard 2.0 and in our examples for readibility.
+It is very common place since VueJS to see Vue applications using the "Composition API", whilst this is lighter weight way of building your applications, it isn't the most intuitive for those unfamiliar with VueJS, as such, we're mostly using the "Options API" structure across Dashboard 2.0 and in our examples for readability.
 
 With the Options API, a Vue component has the following structure:
 
@@ -318,8 +329,10 @@ const base = group.getBase()
 Then, whenever you want to store data in the datastore, you can do so with:
 
 ```js
-base.stores.data.save(base, node.id, msg)
+base.stores.data.save(base, node, msg)
 ```
+
+You can read more about the Node-RED data store in our [State Management](../guides/state-management.md) guide.
 
 #### Node-RED State Store
 

--- a/docs/nodes/widgets.md
+++ b/docs/nodes/widgets.md
@@ -133,6 +133,8 @@ Here is a list of the third-party widgets we're aware of to make it easier to fi
 - [@sumit_shinde_84/ui-webcam](https://flows.nodered.org/node/@sumit_shinde_84/node-red-dashboard-2-ui-webcam): Enables users to integrate webcam functionality into Node-RED Dashboard 2.0, allowing users to capture images and stream video through different cameras.
 - [@flowfuse/ui-iframe](https://flows.nodered.org/node/@flowfuse/node-red-dashboard-2-ui-iframe): Embed an external webpage into your Dashboard using an iframe.
 - [@flowfuse/ui-led](https://flows.nodered.org/node/@flowfuse/node-red-dashboard-2-ui-led): Adds an LED status indicator to your Dashboard.
+- [@colinl/node-red-dashboard-2-ui-gauge-classic](https://flows.nodered.org/node/@colinl/node-red-dashboard-2-ui-gauge-classic): Render a multi-needle gauge on your Dashboard, with a more "Classic" visual style.
+
 
 ### In-Development
 


### PR DESCRIPTION
## Description

Improves docs as discussed here: https://discourse.nodered.org/t/questions-about-creating-d2-ui-nodes-and-the-node-red-data-stores/88316