### PR TITLE
Prevent app setup call when unauthenticated responses are received

### DIFF
--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -74,6 +74,11 @@ function forcePageReload (err) {
 // GET our SocketIO Config from Node-RED & any other bits plugins have added to the _setup endpoint
 fetch('_setup')
     .then(async (response) => {
+        console.log('_setup', {
+            origin: (new URL(window.location)).origin,
+            responseUrl: response.url,
+            sameOrigin: !response.url.includes( new URL(window.location).origin)
+        })
         if (
             response.url &&
             typeof response.url === 'string' &&
@@ -82,10 +87,9 @@ fetch('_setup')
             // todo not sure if we should force redirect or just stop the setup process entirely
             // forcePageReload('origins do not match')
 
-            return;
+            return
         }
 
-        console.log('_setup', response, typeof response.url === 'string')
         const url = new URL(response.url)
         const basePath = url.pathname.replace('/_setup', '')
 

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -74,19 +74,8 @@ function forcePageReload (err) {
 // GET our SocketIO Config from Node-RED & any other bits plugins have added to the _setup endpoint
 fetch('_setup')
     .then(async (response) => {
-        console.log('_setup', {
-            origin: (new URL(window.location)).origin,
-            responseUrl: response.url,
-            sameOrigin: !response.url.includes( new URL(window.location).origin)
-        })
-        if (
-            response.url &&
-            typeof response.url === 'string' &&
-            !response.url.includes( new URL(window.location).origin)) {
-
-            // todo not sure if we should force redirect or just stop the setup process entirely
-            // forcePageReload('origins do not match')
-
+        if (!response.ok && response.status === 401) {
+            forcePageReload('origins do not match')
             return
         }
 
@@ -190,13 +179,8 @@ fetch('_setup')
         app.mount('#app')
     })
     .catch((err) => {
-        if (err instanceof TypeError) {
-            if (err.message === 'Failed to fetch') {
-                forcePageReload(err)
-            } else {
-                // handle general Type errors here
-                console.error('An error occurred:', err)
-            }
+        if (err instanceof TypeError && err.message === 'Failed to fetch') {
+            forcePageReload(err)
         } else {
             // handle general errors here
             console.error('An error occurred:', err)

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -57,11 +57,7 @@ const vuetify = createVuetify({
     }
 })
 
-/*
- * Configure SocketIO Client to Interact with Node-RED
- */
-
-// if our scoket disconnects, we should inform the user when it reconnects
+const host = new URL(window.location.href)
 
 function forcePageReload (err) {
     console.log('auth error:', err)
@@ -71,16 +67,15 @@ function forcePageReload (err) {
     window.location.replace(window.location.origin + '/dashboard' + '?' + 'reloadTime=' + Date.now().toString() + Math.random()) // Seems to work on Edge and Chrome on Windows, Chromium and Firefox on Linux, and also on Chrome Android (and also as PWA App)
 }
 
-const host = new URL(window.location.href)
+/*
+ * Configure SocketIO Client to Interact with Node-RED
+ */
+
+// if our scoket disconnects, we should inform the user when it reconnects
 
 // GET our SocketIO Config from Node-RED & any other bits plugins have added to the _setup endpoint
 fetch('_setup')
     .then(async (response) => {
-        console.log({
-            host,
-            response
-        })
-
         switch (true) {
         case !response.ok && response.status === 401:
             forcePageReload('Unauthenticated')
@@ -91,7 +86,6 @@ fetch('_setup')
         case host.origin !== new URL(response.url).origin:
             console.log('Following redirect:', response.url)
             window.location.replace(response.url)
-            // forcePageReload('Redirected to different origin')
             return
         default:
             break

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -75,7 +75,7 @@ function forcePageReload (err) {
 fetch('_setup')
     .then(async (response) => {
         if (!response.ok && response.status === 401) {
-            forcePageReload('origins do not match')
+            forcePageReload('Unauthenticated')
             return
         }
 

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -84,7 +84,7 @@ fetch('_setup')
         switch (true) {
         case !response.ok && response.status === 401:
             forcePageReload('Unauthenticated')
-            break
+            return
         case !response.ok:
             console.error('Failed to fetch setup data:', response)
             return

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -1,9 +1,17 @@
 /* eslint-disable n/file-extension-in-import */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/order */
-import { createHead, VueHeadMixin } from '@unhead/vue'
-import { io } from 'socket.io-client'
+import { VueHeadMixin, createHead } from '@unhead/vue'
 import * as Vue from 'vue'
+import * as vuex from 'vuex'
+import App from './App.vue'
+import { io } from 'socket.io-client'
+import router from './router.mjs'
+import Alerts from './services/alerts.js'
+
+// Vuetify
+import '@mdi/font/css/materialdesignicons.css'
+import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
@@ -13,14 +21,6 @@ import { VNumberInput } from 'vuetify/labs/VNumberInput'
 import { VTreeview } from 'vuetify/labs/VTreeview'
 
 import './stylesheets/common.css'
-import * as vuex from 'vuex'
-import App from './App.vue'
-import router from './router.mjs'
-import Alerts from './services/alerts.js'
-
-// Vuetify
-import '@mdi/font/css/materialdesignicons.css'
-import 'vuetify/styles'
 
 import store from './store/index.mjs'
 

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -67,17 +67,17 @@ function forcePageReload (err) {
     console.log('auth error:', err)
     console.log('redirecting to:', window.location.origin + '/dashboard')
 
-    // Reloading dashboard without using cache by apending a cache-busting string to fully reload page to allow redirecting to auth
+    // Reloading dashboard without using cache by appending a cache-busting string to fully reload page to allow redirecting to auth
     window.location.replace(window.location.origin + '/dashboard' + '?' + 'reloadTime=' + Date.now().toString() + Math.random()) // Seems to work on Edge and Chrome on Windows, Chromium and Firefox on Linux, and also on Chrome Android (and also as PWA App)
 }
 
-const origin = new URL(window.location.href)
+const host = new URL(window.location.href)
 
 // GET our SocketIO Config from Node-RED & any other bits plugins have added to the _setup endpoint
 fetch('_setup')
     .then(async (response) => {
         console.log({
-            origin,
+            host,
             response
         })
 
@@ -87,6 +87,11 @@ fetch('_setup')
             return
         case !response.ok:
             console.error('Failed to fetch setup data:', response)
+            return
+        case host.origin !== new URL(response.url).origin:
+            console.log('Following redirect:', response.url)
+            window.location.replace(response.url)
+            // forcePageReload('Redirected to different origin')
             return
         default:
             break

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -1,17 +1,9 @@
 /* eslint-disable n/file-extension-in-import */
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/order */
-import { VueHeadMixin, createHead } from '@unhead/vue'
-import * as Vue from 'vue'
-import * as vuex from 'vuex'
-import App from './App.vue'
+import { createHead, VueHeadMixin } from '@unhead/vue'
 import { io } from 'socket.io-client'
-import router from './router.mjs'
-import Alerts from './services/alerts.js'
-
-// Vuetify
-import '@mdi/font/css/materialdesignicons.css'
-import 'vuetify/styles'
+import * as Vue from 'vue'
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
@@ -21,6 +13,14 @@ import { VNumberInput } from 'vuetify/labs/VNumberInput'
 import { VTreeview } from 'vuetify/labs/VTreeview'
 
 import './stylesheets/common.css'
+import * as vuex from 'vuex'
+import App from './App.vue'
+import router from './router.mjs'
+import Alerts from './services/alerts.js'
+
+// Vuetify
+import '@mdi/font/css/materialdesignicons.css'
+import 'vuetify/styles'
 
 import store from './store/index.mjs'
 
@@ -71,12 +71,25 @@ function forcePageReload (err) {
     window.location.replace(window.location.origin + '/dashboard' + '?' + 'reloadTime=' + Date.now().toString() + Math.random()) // Seems to work on Edge and Chrome on Windows, Chromium and Firefox on Linux, and also on Chrome Android (and also as PWA App)
 }
 
+const origin = new URL(window.location.href)
+
 // GET our SocketIO Config from Node-RED & any other bits plugins have added to the _setup endpoint
 fetch('_setup')
     .then(async (response) => {
-        if (!response.ok && response.status === 401) {
+        console.log({
+            origin,
+            response
+        })
+
+        switch (true) {
+        case !response.ok && response.status === 401:
             forcePageReload('Unauthenticated')
+            break
+        case !response.ok:
+            console.error('Failed to fetch setup data:', response)
             return
+        default:
+            break
         }
 
         const url = new URL(response.url)


### PR DESCRIPTION
## Description

Handling 401 responses when the application set's up.
Because the fetch API treats [401 responses](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_that_the_fetch_was_successful) as successful ones, we can't rely on the setup's catch block to catch unauthenticated responses which are not valid json responses.


## Related Issue(s)

closes # #937

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

