### PR TITLE
Use retry count based algorithm for socket reconnections

### DIFF
--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -108,10 +108,10 @@ fetch('_setup')
         store.commit('setup/set', setup)
 
         let disconnected = false
-        let retryCount = 0      // number of reconnection attempts made
+        let retryCount = 0 // number of reconnection attempts made
 
         let reconnectTO = null
-        const MAX_RETRIES = 22      // 4 at 2.5 seconds, 10 at 5 secs then 8 at 30 seconds
+        const MAX_RETRIES = 22 // 4 at 2.5 seconds, 10 at 5 secs then 8 at 30 seconds
 
         const socket = io({
             ...setup.socketio,

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -111,7 +111,7 @@ fetch('_setup')
         let retryCount = 0      // number of reconnection attempts made
 
         let reconnectTO = null
-        const MAX_RETRIES = 20      // 12 at 5 secs then 8 at 30 seconds
+        const MAX_RETRIES = 22      // 4 at 2.5 seconds, 10 at 5 secs then 8 at 30 seconds
 
         const socket = io({
             ...setup.socketio,
@@ -153,14 +153,18 @@ fetch('_setup')
             console.error('SIO connect error:', err, `err: ${JSON.stringify(err)}`)
         })
 
-        // default interval - every 5 seconds
-        function reconnect (interval = 5000) {
+        // default interval - every 2.5 seconds
+        function reconnect (interval = 2500) {
             if (disconnected) {
                 socket.connect()
-                if (retryCount++ >= 12) {
+                if (retryCount >= 14) {
                     // trying for over 1 minute
                     interval = 30000 // interval at 30 seconds
+                } else if (retryCount >= 4) {
+                    // trying for over 10 seconds
+                    interval = 5000 // interval at 5 seconds
                 }
+                retryCount++
                 // if still within our maximum retry count
                 if (retryCount <= MAX_RETRIES) {
                     // check for a connection again in <interval> milliseconds


### PR DESCRIPTION
## Description

Rather than using a time based algorithm for determining how often to retry a socket connection failure, use a count of how many retries have been performed.  This overcomes the fact that during laptop suspend, browser page in the background, Android putting a background to sleep, and other similar situations, the connection may fail as the page is suspended, and will not start retrying until the page is re-activated.  The result is that the existing code thinks that a long time has elapsed since the connection fails, and may just give up immediately.

## Related Issue(s)

Fixes issue #810, addresses the first class of failures in #946. Also see #784.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

