### PR TITLE
Force page reload on socket connect error 'parser error'

### DIFF
--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -151,13 +151,13 @@ fetch('_setup')
 
         socket.on('connect_error', (err) => {
             console.error('SIO connect error:', err, `err: ${JSON.stringify(err)}`)
-            if (err?.code === "parser error") {
+            if (err?.code === 'parser error') {
                 // There has been a 'parser error' during the attempt to connect. This means that socket.io
                 // does not like the response from the server from the attempt to connect.
                 // This happens if there is a proxy server in front of node red that has redirected to
                 // a login page. There may also be other situations under which this error occurs, but whatever the
                 // cause it doesn't seem that we can do much other than force a reload.
-                forcePageReload("parser error")
+                forcePageReload('parser error')
             }
         })
 

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -151,6 +151,14 @@ fetch('_setup')
 
         socket.on('connect_error', (err) => {
             console.error('SIO connect error:', err, `err: ${JSON.stringify(err)}`)
+            if (err?.code === "parser error") {
+                // There has been a 'parser error' during the attempt to connect. This means that socket.io
+                // does not like the response from the server from the attempt to connect.
+                // This happens if there is a proxy server in front of node red that has redirected to
+                // a login page. There may also be other situations under which this error occurs, but whatever the
+                // cause it doesn't seem that we can do much other than force a reload.
+                forcePageReload("parser error")
+            }
         })
 
         // default interval - every 2.5 seconds


### PR DESCRIPTION
## Description

If there is a proxy server which requires a user login if the authorisation token expires, and the dashboard socket is already connected at this time, then the dashboard continues as normal, presumably because the connection is already open.  If, however, the connection is dropped then the reconnect attempt fails as the request is forwarded to the login page.  The result is that there is a connect error and the returned error object contains just `{"code":"parser error"}`.  This is a permanent error, so retrying the connection is pointless.
This PR recognises that code and forces a page reload, so that the user is directed to the login page.

There may be other reasons for a 'parser error', but whatever the reason there is little that we can do other than force a reload.

See discussions in #946, which this PR closes

## Related Issue(s)

See discussions in #946, which this PR closes.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

