### PR TITLE
Add indicator option into migration docs for ui-switch

### DIFF
--- a/docs/user/migration/ui_switch.json
+++ b/docs/user/migration/ui_switch.json
@@ -63,6 +63,11 @@
             "notes": null
         },
         {
+            "property": "indicator",
+            "changes": -1,
+            "notes": "<a href='https://github.com/FlowFuse/node-red-dashboard/issues/210' target='_blank'>Issue #210</a>"
+        },
+        {
             "property": "'on' payload",
             "changes": null,
             "notes": null


### PR DESCRIPTION
## Description

This adds in the missing `indicator` option into the migration guide for ui-switch.
I have run the docs locally and checked it shows correctly.

## Related Issue(s)

Closes #318

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

