### PR TITLE
radiobutton false vs null fix

### DIFF
--- a/ui/src/widgets/ui-radio-group/UIRadioGroup.vue
+++ b/ui/src/widgets/ui-radio-group/UIRadioGroup.vue
@@ -83,6 +83,7 @@ export default {
                 widgetId: this.id,
                 msg
             })
+
             // When a msg comes in from Node-RED, we need support 2 operations:
             // 1. add/replace the radio options (to support dynamic options e.g: radiobuttons populated from a database)
             // 2. update the selected value(s)
@@ -103,13 +104,8 @@ export default {
         onChange () {
             // ensure our data binding with vuex store is updated
             const msg = this.messages[this.id] || {}
-            if (this.value) {
-                // return a single value
-                msg.payload = this.value
-            } else {
-                // return null
-                msg.payload = null
-            }
+            // return a single value
+            msg.payload = this.value
             this.$store.commit('data/bind', {
                 widgetId: this.id,
                 msg


### PR DESCRIPTION
## Description

Radiobutton with value `false` is being send in output msg payload as `null`.

## Related Issue(s)

See [970](https://github.com/FlowFuse/node-red-dashboard/issues/970)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ X ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

