### PR TITLE
Debug - Add a console.warn when a component file is missing

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -197,7 +197,8 @@ export default {
                     const resource = `${widget.src.package}/${widget.src.src}`
                     widget.component = markRaw(importExternalComponent(resource, widget.src.name, widget.src.component))
                 } else {
-                    // Old Third Party Widgets
+                    // Old Third Party Widgets - of which there shouldn't be any in the wild
+                    console.warn('No Vue component found for ', widget.type, ' - falling back to ui-template')
                     widget.component = markRaw(widgetComponents['ui-template'])
                 }
             })


### PR DESCRIPTION
## Description

We don't have anyone using old UI Templates, and with the third party nodes requiring a restart of NR, they fall into the same catch when assigning `widget.component`, this warning informs users (at least in the console/dev tools) that a widget is not found.