### PR TITLE
Docs: Ensure we mark File Input availability & add note to template example

### DIFF
--- a/docs/nodes/widgets/ui-file-input.md
+++ b/docs/nodes/widgets/ui-file-input.md
@@ -13,7 +13,11 @@ props:
         description: Allow end-users to upload multiple files at once. Each file will be sent as a unique message.
 ---
 
-# File Upload
+<script setup>
+    import AddedIn from '../../components/AddedIn.vue';
+</script>
+
+# File Upload <AddedIn version="1.12.0" />
 
 The File Upload widget allows users to upload files to Node-RED. The widget can be configured to accept specific file types and allow for multiple files.
 

--- a/docs/user/template-examples.md
+++ b/docs/user/template-examples.md
@@ -175,6 +175,8 @@ You can try out the above example with this flow:
 
 ### File Upload
 
+_Update: Whilst this example will continue to work, and can be used for more customized use cases with file uploads, as of `v1.12.0`, we do also now offer a native [File Input](../nodes/widgets/ui-file-input.md) widget._
+
 When building applications with Node-RED, there's often a need to process files for analysis. In such cases, we require a file upload widget which is not currently available. Fortunately, we can achieve this easily using the `ui-template` widget and Vuetify JS components.
 
 To do that we will use the [`v-file-input`](https://vuetifyjs.com/en/components/file-inputs/) component which provides the interface for uploading files.


### PR DESCRIPTION
## Description

- Adds the `AddedIn` widget to the File Input to ensure users are aware of the minimum version requirements
- Adds a note to the "File Input" example in the "UI Template Examples" page to say we now have a native node for this functionality.