### PR TITLE
Dropdown multiselection select fix

### DIFF
--- a/ui/src/widgets/ui-dropdown/UIDropdown.vue
+++ b/ui/src/widgets/ui-dropdown/UIDropdown.vue
@@ -102,18 +102,18 @@ export default {
             // 1. add/replace the dropdown options (to support dynamic options e.g: nested dropdowns populated from a database)
             // 2. update the selected value(s)
 
-            const payload = msg.payload
-            if (payload !== undefined) {
-                // 2. update the selected value(s)
-                this.select(payload)
-            }
-
             // keep options out for backward compatibility
             const options = msg.options
             if (options) {
                 // 1. add/replace the dropdown options
                 // TODO: Error handling if options is not an array
                 this.items = options
+            }
+
+            const payload = msg.payload
+            if (payload !== undefined) {
+                // 2. update the selected value(s)
+                this.select(payload)
             }
 
             // update the UI with any other changes
@@ -153,6 +153,7 @@ export default {
             this.$socket.emit('widget-change', this.id, msg.payload)
         },
         select (value) {
+debugger
             if (value !== undefined) {
                 // first, if we have a single value, we need to convert it to an array
                 if (!Array.isArray(value)) {

--- a/ui/src/widgets/ui-dropdown/UIDropdown.vue
+++ b/ui/src/widgets/ui-dropdown/UIDropdown.vue
@@ -153,7 +153,6 @@ export default {
             this.$socket.emit('widget-change', this.id, msg.payload)
         },
         select (value) {
-debugger
             if (value !== undefined) {
                 // first, if we have a single value, we need to convert it to an array
                 if (!Array.isArray(value)) {


### PR DESCRIPTION
## Description

When a single input message contains both `msg.options` and `msg.payload` (containing one of the options that needs to be selected), then the specified value was not selected.  

BTW there is a test flow in the Discourse discussion (see link in the issue).

## Related Issue(s)

See [992](https://github.com/FlowFuse/node-red-dashboard/issues/992)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ X ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

