### PR TITLE
Fixed Layout: Define a default layout-columns for the groups in a Fixed layout

### DIFF
--- a/ui/src/layouts/Flex.vue
+++ b/ui/src/layouts/Flex.vue
@@ -113,6 +113,8 @@ export default {
 .nrdb-layout--flex {
     --layout-card-width: 320px;
     --layout-gap: 12px;
+    /* set large number, as the group width will always rule here */
+    --layout-columns: 100;
 }
 .nrdb-layout--flex {
     display: flex;


### PR DESCRIPTION
## Description

- Adds missing `--layout-columns` value for Fixed layouts
- This also sets a 3 column limit on mobile devices, to ensure some level of responsiveness for "Fixed" layouts.

### Background

There is a check in `Group.vue` which compares this value against the width of the group. This value is used for responsiveness, where, on smaller screens, we cap the number of "columns" in a group by defining `--layout-columns`

## Related Issue(s)

Closes #1003
Closes #1006 