### PR TITLE
UI Page - Better handling of dropdown boolean types for visibility

### DIFF
--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -69,12 +69,12 @@
             }
 
             // backwards compatibility
-            if (this.disabled === undefined || this.visible === 'false' || this.disabled === false) {
-                this.disabled = false
-                $('#node-config-input-disabled').val('false')
-            } else if (this.disabled === 'true' || this.disabled === true) {
+            if (this.disabled === 'true' || this.disabled === true) {
                 this.disabled = true
                 $('#node-config-input-disabled').val('true')
+            } else {
+                this.disabled = false
+                $('#node-config-input-disabled').val('false')
             }
         },
         oneditsave: function () {

--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -59,15 +59,22 @@
                 typeField: '#node-input-layoutType'
             })
 
-            // backwards compatibility
-            if (this.visible === undefined || this.visible === 'true') {
+            // backwards compatibility - because NR can't do boolean values on dropdowns
+            if (this.visible === undefined || this.visible === true || this.visible === 'true') {
                 this.visible = true
                 $('#node-config-input-visible').val('true')
+            } else if (this.visible === false || this.visible === 'false') {
+                this.visible = false
+                $('#node-config-input-visible').val('false')
             }
+
             // backwards compatibility
-            if (this.disabled === undefined || this.visible === 'false') {
+            if (this.disabled === undefined || this.visible === 'false' || this.disabled === false) {
                 this.disabled = false
                 $('#node-config-input-disabled').val('false')
+            } else if (this.disabled === 'true' || this.disabled === true) {
+                this.disabled = true
+                $('#node-config-input-disabled').val('true')
             }
         },
         oneditsave: function () {

--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -60,12 +60,12 @@
             })
 
             // backwards compatibility - because NR can't do boolean values on dropdowns
-            if (this.visible === undefined || this.visible === true || this.visible === 'true') {
-                this.visible = true
-                $('#node-config-input-visible').val('true')
-            } else if (this.visible === false || this.visible === 'false') {
+            if (this.visible === false || this.visible === 'false') {
                 this.visible = false
                 $('#node-config-input-visible').val('false')
+            } else {
+                this.visible = true
+                $('#node-config-input-visible').val('true')
             }
 
             // backwards compatibility


### PR DESCRIPTION
## Description

Because NR/html jquery dropdown doesn't support boolean types, we fell into some type inconsistency traps. This handles those cases where older pages may have different visibility/disabled values.

## Related Issue(s)

Closes #1004