### PR TITLE
UI Dropdown - Fix `options` based on `ui_update

### DIFF
--- a/ui/src/widgets/ui-dropdown/UIDropdown.vue
+++ b/ui/src/widgets/ui-dropdown/UIDropdown.vue
@@ -1,18 +1,8 @@
 <template>
     <v-combobox
-        v-model="value"
-        :disabled="!state.enabled"
-        :class="className"
-        :label="label"
-        :multiple="multiple"
-        :chips="chips"
-        :clearable="clearable"
-        :items="options"
-        item-title="label"
-        item-value="value"
-        variant="outlined"
-        hide-details="auto"
-        :error-messages="options?.length ? '' : 'No options available'"
+        v-model="value" :disabled="!state.enabled" :class="className" :label="label" :multiple="multiple"
+        :chips="chips" :clearable="clearable" :items="options" item-title="label" item-value="value" variant="outlined"
+        hide-details="auto" :error-messages="options?.length ? '' : 'No options available'"
         @update:model-value="onChange"
     />
 </template>
@@ -103,11 +93,13 @@ export default {
             // 2. update the selected value(s)
 
             // keep options out for backward compatibility
-            const options = msg.options
+            // Check for booth possible methods to setup the options
+            const options = msg.options || msg.ui_update?.options
             if (options) {
                 // 1. add/replace the dropdown options
-                // TODO: Error handling if options is not an array
-                this.items = options
+                if (Array.isArray(options)) {
+                    this.items = options
+                }
             }
 
             const payload = msg.payload
@@ -120,9 +112,6 @@ export default {
             const updates = msg.ui_update
 
             if (updates) {
-                if (Array.isArray(updates.options)) {
-                    this.items = updates.options
-                }
                 if (typeof updates.label !== 'undefined') {
                     this.dynamic.label = updates.label
                 }
@@ -186,5 +175,4 @@ export default {
 }
 </script>
 
-<style scoped>
-</style>
+<style scoped></style>


### PR DESCRIPTION
Fix issue #1022 assuming that from now on the users use the property `msg.ui_update.options` instead of `msg.options` to load the item list.

- Also added check to use either `msg.options` or `msg.ui_update.options` to load the item list before checking for `payload` to set the new value
- Validate that `options` is an Array before use

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

