### PR TITLE
UI-ButtonGroup - Fix issue when `ui_update.options` doesn't have `label`

### DIFF
--- a/nodes/widgets/locales/en-US/ui_button_group.html
+++ b/nodes/widgets/locales/en-US/ui_button_group.html
@@ -4,7 +4,7 @@
     <p>The active selection can be dynamically set by sending a <code>msg.payload</code> which matches a respective option's value.</p>
     <h3>Properties</h3>
     <p><strong>Label:</strong><br/>
-    The label that will be displayed on the left side of the button.</p>
+    The label that will be displayed on the left side of the button group.</p>
     <p><strong>Appearance:</strong><br/>
     Specify whether the shape of the widget should be rectangular or have rounded corners.</p>
     <p><strong>Use theme colors:</strong><br/>
@@ -28,10 +28,10 @@
     <p>Any of the following can be appended to a <code>msg.ui_update</code> in order to override or set properties on this node at runtime.</p>
     <dl class="message-properties">
         <dt class="optional">label <span class="property-type">string</span></dt>
-        <dd>The label displayed to explain the purpose of the dropdown.</dd>
+        <dd>The label displayed on the left side of the button group.</dd>
         <dt class="optional">options <span class="property-type">array</span></dt>
         <dd>
-            Change the options available in the dropdown at runtime
+            Change the options available in the button group at runtime
             <ul>
                 <li><code>Array&lt;string&gt;</code></li>
                 <li><code>Array&lt;{value: String}&gt;</code></li>
@@ -40,6 +40,6 @@
             </ul>
         </dd>
         <dt class="optional">class <span class="property-type">string</span></dt>
-        <dd>Add a CSS class, or more, to the Button at runtime.</dd>
+        <dd>Add a CSS class, or more, to the Button Group at runtime.</dd>
     </dl>
 </script>

--- a/ui/src/widgets/ui-button-group/UIButtonGroup.vue
+++ b/ui/src/widgets/ui-button-group/UIButtonGroup.vue
@@ -5,7 +5,7 @@
         </label>
         <v-btn-toggle v-model="selection" mandatory divided :rounded="props.rounded ? 'xl' : ''" :color="selectedColor" @update:model-value="onChange(selection)">
             <v-btn v-for="option in options" :key="option.value" :value="option.value">
-                <template v-if="option.icon && option.label !== ''" #prepend>
+                <template v-if="option.icon && option.label !== undefined && option.label !== ''" #prepend>
                     <v-icon size="x-large" :icon="`mdi-${option.icon.replace(/^mdi-/, '')}`" />
                 </template>
                 <v-icon v-if="option.icon && !option.label" :icon="`mdi-${option.icon.replace(/^mdi-/, '')}`" size="x-large" />


### PR DESCRIPTION
## Description

Using the `ui-buttongroup`, if updating the items to show via the `msg.ui_update.options`, in case the array of values sent doesn't contain the property `label` two symbols would be shown.

How it is in current version:
![image](https://github.com/FlowFuse/node-red-dashboard/assets/17281826/ed444c98-9338-444a-b695-59d962710c9a)

With the fix:
![image](https://github.com/FlowFuse/node-red-dashboard/assets/17281826/9eb24c25-b48c-429d-97bb-7a886fe1a84e)

Injecting the following message
```json
{
    "options": [
        {
            "value": "2",
            "icon": "led-off"
        },
        {
            "value": "1",
            "icon": "led-off"
        }
    ]
}
```

Also fix some text on the help tab for this widget, there where some references to Dropdown instead of Button Group

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

