### PR TITLE
fix slider ticks positioning and allow easy user level customization

### DIFF
--- a/docs/nodes/widgets/ui-slider.md
+++ b/docs/nodes/widgets/ui-slider.md
@@ -79,22 +79,39 @@ You can set the value of the slider by passing in the respective value in `msg.p
 
 ### Customize ticks
 
-By default the tick is a round dot having the size same as the thickness of the track. This can be changed by overriding the CSS for slider. Different classes will be needed for vertical and horizontal slider.
+Ticks can customized by overriding the CSS for slider.
+
+The appearance of ticks can be changed by using the following CSS variables
+
+- <code>--tick-scaleX</code> to resize ticks horizontally
+- <code>--tick-scaleY</code> to resize ticks vertically
+- <code>--tick-color</code> to change ticks color
+
+Note that you may need to create different classes for vertical and horizontal slider.
+
 
 ```css
 .my-slider-horizontal.nrdb-ui-slider{
-    --nrdb-slider-tick-scaleX: 0.25;
-    --nrdb-slider-tick-scaleY: 4;
-    --nrdb-slider-tick-color:rgba(var(--v-theme-primary),0.7);
-    --nrdb-silder-tick-border-radius:0;
+    --tick-scaleX: 0.25;
+    --tick-scaleY: 4;
+    --tick-color: rgba(var(--v-theme-primary),0.7);
 }
 .my-slider-vertical.nrdb-ui-slider{
-     --nrdb-slider-tick-scaleX: 4;
-    --nrdb-slider-tick-scaleY: 0.25; 
-    --nrdb-slider-tick-color:rgba(var(--v-theme-primary),0.7);
-    --nrdb-silder-tick-border-radius:0;
+    --tick-scaleX: 4;
+    --tick-scaleY: 0.25; 
+    --tick-color: orange;
 }
 ```
+
+Different styles can be applied to the ticks of the filled part of the slider.
+
+```css
+.my-slider-horizontal.nrdb-ui-slider .v-slider-track__tick--filled{
+    --tick-color:violet;
+}
+```
+
+
 
 ## Example - Vertical Sliders
 

--- a/docs/nodes/widgets/ui-slider.md
+++ b/docs/nodes/widgets/ui-slider.md
@@ -77,6 +77,25 @@ You can set the value of the slider by passing in the respective value in `msg.p
 ![Example of a slider with ticks set to 'Always'](/images/node-examples/ui-slider-ticks.png "Example of a slider with ticks set to 'Always'"){data-zoomable}
 *Example of a slider with ticks set to 'Always'*
 
+### Customize ticks
+
+By default the tick is a round dot having the size same as the thickness of the track. This can be changed by overriding the CSS for slider. Different classes will be needed for vertical and horizontal slider.
+
+```css
+.my-slider-horizontal.nrdb-ui-slider{
+    --nrdb-slider-tick-scaleX: 0.25;
+    --nrdb-slider-tick-scaleY: 4;
+    --nrdb-slider-tick-color:rgba(var(--v-theme-primary),0.7);
+    --nrdb-silder-tick-border-radius:0;
+}
+.my-slider-vertical.nrdb-ui-slider{
+     --nrdb-slider-tick-scaleX: 4;
+    --nrdb-slider-tick-scaleY: 0.25; 
+    --nrdb-slider-tick-color:rgba(var(--v-theme-primary),0.7);
+    --nrdb-silder-tick-border-radius:0;
+}
+```
+
 ## Example - Vertical Sliders
 
 Sliders will automatically switch to a vertical orientation when the height is greater than the width.

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -356,12 +356,12 @@ main {
 }
 
 .v-slider-track__tick {
-    background-color: rgb(var(--v-theme-primary));
+    background-color: var(--nrdb-slider-tick-color,var(--nrdb-slider-track-color,rgb(var(--v-theme-primary))));
     border-radius: var(--nrdb-silder-tick-border-radius, var(--v-slider-tick-size));
 }
 
 .v-slider-track__tick--filled {
-    background-color: rgb(var(--v-theme-on-primary));
+    background-color: var(--nrdb-slider-tick-color,var(--nrdb-slider-track-color,rgb(var(--v-theme-on-primary))));
 }
 .nrdb-ui-slider .v-slider.v-input--horizontal{
     grid-template-rows: auto 0;
@@ -372,8 +372,7 @@ main {
 .nrdb-ui-slider .v-slider.v-input--horizontal .v-slider-track__tick{
     margin-block:unset;
     transform: translate(calc(var(--v-slider-tick-size) / -2), 0) scaleY(var(--nrdb-slider-tick-scaleY)) scaleX(var(--nrdb-slider-tick-scaleX));
-} 
-
+}
 
 .nrdb-ui-slider .v-slider.v-input--horizontal .v-slider-track__tick--first {
     margin-inline-start: calc(var(--v-slider-tick-size) / 2);
@@ -398,12 +397,9 @@ main {
 }
 
 .nrdb-ui-slider .v-slider-track {
-    --v-slider-tick-size: var(--v-slider-track-size); 
+    --v-slider-tick-size: var(--v-slider-track-size);
+}
 
-}
-.v-slider-track__tick--filled {
-    background-color: var(--nrdb-slider-tick-color,rgb(var(--v-theme-on-primary)));
-}
 .nrdb-ui-slider {
     
     --nrdb-slider-tick-scaleX: 1;

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -355,23 +355,28 @@ main {
    color: rgb(var(--v-theme-primary));
 }
 
-.v-slider-track__tick {
-    background-color: var(--nrdb-slider-tick-color,var(--nrdb-slider-track-color,rgb(var(--v-theme-primary))));
-    border-radius: var(--nrdb-silder-tick-border-radius, var(--v-slider-tick-size));
+.v-slider-track__tick,.v-slider-track__tick--filled { 
+    background-color:var(--tick-color,var(--nrdb-slider-track-color,rgba(var(--v-theme-primary),0.4)));
+    border-radius: var(--nrdb-silder-tick-border-radius, 0);
+}
+@supports (color: hsl(from red h s l / 40%)) {
+    .v-slider-track__tick,.v-slider-track__tick--filled{
+        background-color:var(--tick-color, hsl(from var(--nrdb-slider-track-color,rgb(var(--v-theme-primary))) h s l / 40%));        
+    }
 }
 
-.v-slider-track__tick--filled {
-    background-color: var(--nrdb-slider-tick-color,var(--nrdb-slider-track-color,rgb(var(--v-theme-on-primary))));
-}
 .nrdb-ui-slider .v-slider.v-input--horizontal{
     grid-template-rows: auto 0;
 }
 .nrdb-ui-slider  .v-slider-track__ticks {
     height: calc(var(--v-slider-tick-size));
+    z-index: -1;
 }
 .nrdb-ui-slider .v-slider.v-input--horizontal .v-slider-track__tick{
     margin-block:unset;
-    transform: translate(calc(var(--v-slider-tick-size) / -2), 0) scaleY(var(--nrdb-slider-tick-scaleY)) scaleX(var(--nrdb-slider-tick-scaleX));
+    transform: translate(calc(var(--v-slider-tick-size) / -2), 0)
+        scaleY(var(--tick-scaleY, var(--nrdb-slider-tick-scaleY))) 
+        scaleX(var(--tick-scaleX, var(--nrdb-slider-tick-scaleX)));
 }
 
 .nrdb-ui-slider .v-slider.v-input--horizontal .v-slider-track__tick--first {
@@ -387,7 +392,9 @@ main {
 
 .nrdb-ui-slider .v-slider.v-input--vertical .v-slider-track__tick{
     margin-inline: unset;
-    transform: translate(0,calc(var(--v-slider-tick-size) / 2)) scaleY(var(--nrdb-slider-tick-scaleY)) scaleX(var(--nrdb-slider-tick-scaleX));
+    transform: translate(0,calc(var(--v-slider-tick-size) / 2))
+        scaleY(var(--tick-scaleY, var(--nrdb-slider-tick-scaleY))) 
+        scaleX(var(--tick-scaleX, var(--nrdb-slider-tick-scaleX)));
 } 
 .nrdb-ui-slider .v-slider.v-input--vertical .v-slider-track__tick--last {
     bottom: calc(100% - var(--v-slider-tick-size) / 2);
@@ -400,12 +407,6 @@ main {
     --v-slider-tick-size: var(--v-slider-track-size);
 }
 
-.nrdb-ui-slider {
-    
-    --nrdb-slider-tick-scaleX: 1;
-    --nrdb-slider-tick-scaleY: 1;
-    
-}
 .v-slider.v-input--vertical>.v-input__control {
     min-height: initial;
 }

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -357,31 +357,58 @@ main {
 
 .v-slider-track__tick {
     background-color: rgb(var(--v-theme-primary));
+    border-radius: var(--nrdb-silder-tick-border-radius, var(--v-slider-tick-size));
 }
 
 .v-slider-track__tick--filled {
     background-color: rgb(var(--v-theme-on-primary));
 }
+.nrdb-ui-slider .v-slider.v-input--horizontal{
+    grid-template-rows: auto 0;
+}
+.nrdb-ui-slider  .v-slider-track__ticks {
+    height: calc(var(--v-slider-tick-size));
+}
+.nrdb-ui-slider .v-slider.v-input--horizontal .v-slider-track__tick{
+    margin-block:unset;
+    transform: translate(calc(var(--v-slider-tick-size) / -2), 0) scaleY(var(--nrdb-slider-tick-scaleY)) scaleX(var(--nrdb-slider-tick-scaleX));
+} 
 
-.v-slider.v-input--horizontal .v-slider-track__tick {
-    width: var(v-slider-track__tick);
-    height: calc(var(--v-slider-track-size) + 4px);
+
+.nrdb-ui-slider .v-slider.v-input--horizontal .v-slider-track__tick--first {
+    margin-inline-start: calc(var(--v-slider-tick-size) / 2);
+}
+.nrdb-ui-slider .v-slider.v-input--horizontal .v-slider-track__tick--last {
+    margin-inline-start: calc(100% - var(--v-slider-tick-size) / 2);
+}
+.nrdb-ui-slider .v-slider.v-input--vertical .v-slider-track__ticks {
+    height: 100%;
+    width: calc(var(--v-slider-tick-size));
 }
 
-.v-slider.v-input--vertical .v-slider-track__tick {
-    height: var(v-slider-track__tick);
-    width: calc(var(--v-slider-track-size) + 4px);
+.nrdb-ui-slider .v-slider.v-input--vertical .v-slider-track__tick{
+    margin-inline: unset;
+    transform: translate(0,calc(var(--v-slider-tick-size) / 2)) scaleY(var(--nrdb-slider-tick-scaleY)) scaleX(var(--nrdb-slider-tick-scaleX));
+} 
+.nrdb-ui-slider .v-slider.v-input--vertical .v-slider-track__tick--last {
+    bottom: calc(100% - var(--v-slider-tick-size) / 2);
+}
+.nrdb-ui-slider .v-slider.v-input--vertical .v-slider-track__tick--first {
+    bottom: calc(0% + var(--v-slider-tick-size) / 2);
 }
 
-/* re-calculate the margin for the thumb */
-.v-slider.v-input--horizontal .v-slider-track__tick {
-    margin-inline-start: 0;
-    margin-top: 0px;
-}
+.nrdb-ui-slider .v-slider-track {
+    --v-slider-tick-size: var(--v-slider-track-size); 
 
-.v-slider.v-input--vertical .v-slider-track__tick {
-    margin-inline-start: 0;
-    margin-left: 0px;
+}
+.v-slider-track__tick--filled {
+    background-color: var(--nrdb-slider-tick-color,rgb(var(--v-theme-on-primary)));
+}
+.nrdb-ui-slider {
+    
+    --nrdb-slider-tick-scaleX: 1;
+    --nrdb-slider-tick-scaleY: 1;
+    
 }
 .v-slider.v-input--vertical>.v-input__control {
     min-height: initial;

--- a/ui/src/widgets/ui-slider/UISlider.vue
+++ b/ui/src/widgets/ui-slider/UISlider.vue
@@ -3,7 +3,7 @@
 <template>
     <v-slider
         v-model="value" :disabled="!state.enabled" :label="label" hide-details="auto"
-        :class="className" :thumb-label="thumbLabel"
+        :class="className" :style="`--nrdb-slider-track-color:${colorTrack};`" :thumb-label="thumbLabel"
         :min="min" :direction="direction"
         :tick-size="4" :track-size="4"
         :color="color" :track-color="colorTrack" :thumb-color="colorThumb"

--- a/ui/src/widgets/ui-slider/UISlider.vue
+++ b/ui/src/widgets/ui-slider/UISlider.vue
@@ -3,7 +3,7 @@
 <template>
     <v-slider
         v-model="value" :disabled="!state.enabled" :label="label" hide-details="auto"
-        :class="className" :style="`--nrdb-slider-track-color:${colorTrack};`" :thumb-label="thumbLabel"
+        :class="className" :style="`--nrdb-slider-track-color:${colorTrack};--nrdb-slider-tick-scaleY:${tickScaleY};--nrdb-slider-tick-scaleX:${tickScaleX};`" :thumb-label="thumbLabel"
         :min="min" :direction="direction"
         :tick-size="4" :track-size="4"
         :color="color" :track-color="colorTrack" :thumb-color="colorThumb"
@@ -47,6 +47,12 @@ export default {
         },
         direction: function () {
             return this.props.height > this.props.width ? 'vertical' : 'horizontal'
+        },
+        tickScaleX: function() {
+            return this.props.height > this.props.width ? 3 : 0.5
+        },
+        tickScaleY: function() {
+            return this.props.height > this.props.width ? 0.5 : 3
         },
         label: function () {
             return this.dynamic.label !== null ? this.dynamic.label : this.props.label

--- a/ui/src/widgets/ui-slider/UISlider.vue
+++ b/ui/src/widgets/ui-slider/UISlider.vue
@@ -5,6 +5,7 @@
         v-model="value" :disabled="!state.enabled" :label="label" hide-details="auto"
         :class="className" :thumb-label="thumbLabel"
         :min="min" :direction="direction"
+        :tick-size="4" :track-size="4"
         :color="color" :track-color="colorTrack" :thumb-color="colorThumb"
         :max="max" :step="step || 1" :show-ticks="showTicks" @update:model-value="onChange"
         @end="onBlur"

--- a/ui/src/widgets/ui-slider/UISlider.vue
+++ b/ui/src/widgets/ui-slider/UISlider.vue
@@ -48,10 +48,10 @@ export default {
         direction: function () {
             return this.props.height > this.props.width ? 'vertical' : 'horizontal'
         },
-        tickScaleX: function() {
+        tickScaleX: function () {
             return this.props.height > this.props.width ? 3 : 0.5
         },
-        tickScaleY: function() {
+        tickScaleY: function () {
             return this.props.height > this.props.width ? 0.5 : 3
         },
         label: function () {


### PR DESCRIPTION
## Description

With a little bit different CSS treatment the slider ticks are now positioned correctly. 
But pay attention, the strategy stands on the `tick-size` property being equal to `track-size` which then both turned to CSS variables by vuetify. 

The user can override CSS (variables) to change the appearance of the ticks. Example added.

This change doesn't solve the problem with count of the ticks.


## Related Issue(s)

There's no direct issue rised but it is closely related to https://github.com/FlowFuse/node-red-dashboard/issues/1036



## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [X ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

