### PR TITLE
Layout: Fix Grid responsiveness on mobile

### DIFF
--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -8,7 +8,7 @@
                 class="nrdb-ui-group"
                 :disabled="g.disabled === true ? 'disabled' : null"
                 :class="getGroupClass(g)"
-                :style="`grid-column-end: span ${ g.width }`"
+                :style="`grid-column-end: span min(${ g.width }, var(--layout-columns)`"
             >
                 <v-card variant="outlined" class="bg-group-background">
                     <template v-if="g.showTitle" #title>
@@ -50,7 +50,6 @@ export default {
     },
     data () {
         return {
-            columns: 12,
             rowHeight: 48
         }
     },


### PR DESCRIPTION
## Description

Ads missing `min` declaration to ensure we have the `--layout-columns` overriding.

### Before:

With 2 x blocks defined as 6 wide, each:

<img width="353" alt="Screenshot 2024-07-02 at 12 47 28" src="https://github.com/FlowFuse/node-red-dashboard/assets/99246719/7d3d2980-f929-468a-827c-42bafca503bb">

### After:

On mid-level responsiveness, they should appear below each other:

<img width="708" alt="Screenshot 2024-07-02 at 12 46 56" src="https://github.com/FlowFuse/node-red-dashboard/assets/99246719/9d8b3c1c-0e34-4c44-986d-364ebe3cffda">
