### PR TITLE
UI-button: Make `ui_update` restore even after tab change / Page refresh

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -678,6 +678,9 @@ module.exports = function (RED) {
                     return
                 }
 
+                // Add ui_update parameter to message to be sent on widget load
+                msg.ui_update = statestore.getAll(id)
+
                 conn.emit('widget-load:' + id, msg)
             }
             // wrap execution in a try/catch to ensure we don't crash Node-RED

--- a/nodes/widgets/ui_button.js
+++ b/nodes/widgets/ui_button.js
@@ -1,3 +1,4 @@
+const datastore = require('../store/data.js')
 const statestore = require('../store/state.js')
 const { appendTopic } = require('../utils/index.js')
 
@@ -16,6 +17,8 @@ module.exports = function (RED) {
             // retrieve the payload we're sending from this button
             let payloadType = config.payloadType
             let payload = config.payload
+
+            console.log('Button Before Send Enter')
 
             if (payloadType === 'flow' || payloadType === 'global') {
                 try {
@@ -62,9 +65,22 @@ module.exports = function (RED) {
                     // dynamically set "label" property
                     statestore.set(group.getBase(), node, msg, 'iconPosition', updates.iconPosition)
                 }
+                if (typeof updates.enabled !== 'undefined') {
+                    // dynamically set "label" property
+                    statestore.set(group.getBase(), node, msg, 'enabled', updates.enabled)
+                }
+                if (typeof updates.visible !== 'undefined') {
+                    // dynamically set "label" property
+                    statestore.set(group.getBase(), node, msg, 'visible', updates.visible)
+                }
             }
+            console.log(statestore.getAll(node.id))
+            msg.ui_update = statestore.getAll(node.id)
+
+            console.log('Button Before Send Exit -> ' + error)
 
             if (!error) {
+                datastore.save(group.getBase(), node, msg)
                 return msg
             } else {
                 node.error(error)

--- a/nodes/widgets/ui_button.js
+++ b/nodes/widgets/ui_button.js
@@ -18,8 +18,6 @@ module.exports = function (RED) {
             let payloadType = config.payloadType
             let payload = config.payload
 
-            console.log('Button Before Send Enter')
-
             if (payloadType === 'flow' || payloadType === 'global') {
                 try {
                     const parts = RED.util.normalisePropertyExpression(payload)
@@ -69,15 +67,7 @@ module.exports = function (RED) {
                     // dynamically set "label" property
                     statestore.set(group.getBase(), node, msg, 'enabled', updates.enabled)
                 }
-                if (typeof updates.visible !== 'undefined') {
-                    // dynamically set "label" property
-                    statestore.set(group.getBase(), node, msg, 'visible', updates.visible)
-                }
             }
-            console.log(statestore.getAll(node.id))
-            msg.ui_update = statestore.getAll(node.id)
-
-            console.log('Button Before Send Exit -> ' + error)
 
             if (!error) {
                 datastore.save(group.getBase(), node, msg)

--- a/ui/src/widgets/data-tracker.mjs
+++ b/ui/src/widgets/data-tracker.mjs
@@ -12,17 +12,19 @@ export function useDataTracker (widgetId, onInput, onLoad, onDynamicProperties) 
 
     function checkDynamicProperties (msg) {
         // set standard dynamic properties states if passed into msg
-        if ('enabled' in msg) {
+        if ('enabled' in msg || ('ui_update' in msg && 'enabled' in msg.ui_update)) {
+            const enb = msg.enabled || msg.ui_update?.enabled
             store.commit('ui/widgetState', {
                 widgetId,
-                enabled: msg.enabled
+                enabled: enb
             })
         }
 
-        if ('visible' in msg) {
+        if ('visible' in msg || ('ui_update' in msg && 'visible' in msg.ui_update)) {
+            const vsl = msg.visible || msg.ui_update?.visible
             store.commit('ui/widgetState', {
                 widgetId,
-                visible: msg.visible
+                visible: vsl
             })
         }
 
@@ -54,6 +56,7 @@ export function useDataTracker (widgetId, onInput, onLoad, onDynamicProperties) 
                         })
                     }
                 }
+                checkDynamicProperties(msg)
             })
             // This will on in msg input for ALL components
             socket.on('msg-input:' + widgetId, (msg) => {
@@ -81,5 +84,6 @@ export function useDataTracker (widgetId, onInput, onLoad, onDynamicProperties) 
     })
     onUnmounted(() => {
         socket?.off('msg-input:' + widgetId)
+        socket?.off('widget-load:' + widgetId)
     })
 }

--- a/ui/src/widgets/data-tracker.mjs
+++ b/ui/src/widgets/data-tracker.mjs
@@ -56,7 +56,6 @@ export function useDataTracker (widgetId, onInput, onLoad, onDynamicProperties) 
                         })
                     }
                 }
-                checkDynamicProperties(msg)
             })
             // This will on in msg input for ALL components
             socket.on('msg-input:' + widgetId, (msg) => {

--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -1,8 +1,7 @@
 <template>
     <v-btn
-        block variant="flat" :disabled="!state.enabled" :prepend-icon="prependIcon"
-        :append-icon="appendIcon" :class="{'nrdb-ui-button--icon': iconOnly}"
-        :style="{'min-width': icon ?? 'auto'}" @click="action"
+        block variant="flat" :disabled="!isEnabled" :prepend-icon="prependIcon" :append-icon="appendIcon"
+        :class="{ 'nrdb-ui-button--icon': iconOnly }" :style="{ 'min-width': icon ?? 'auto' }" @click="action"
     >
         {{ label }}
     </v-btn>
@@ -20,7 +19,7 @@ export default {
         props: { type: Object, default: () => ({}) },
         state: { type: Object, default: () => ({}) }
     },
-    data() {
+    data () {
         return {
             dynamic: {
                 label: null,
@@ -32,48 +31,48 @@ export default {
     },
     computed: {
         ...mapState('data', ['messages']),
-        prependIcon() {
+        prependIcon () {
             const icon = this.getPropertyValue('icon')
             const mdiIcon = this.makeMdiIcon(icon)
             return icon && this.iconPosition === 'left' ? mdiIcon : undefined
         },
-        appendIcon() {
+        appendIcon () {
             const icon = this.getPropertyValue('icon')
             const mdiIcon = this.makeMdiIcon(icon)
             return icon && this.iconPosition === 'right' ? mdiIcon : undefined
         },
-        label() {
+        label () {
             return this.getPropertyValue('label')
         },
-        iconPosition() {
+        iconPosition () {
             return this.getPropertyValue('iconPosition')
         },
         iconOnly () {
             return this.getPropertyValue('icon') && !this.getPropertyValue('label')
+        },
+        isEnabled () {
+            return this.getPropertyValue('enabled')
         }
     },
-    created() {
-        console.log('Button Created')
+    created () {
         useDataTracker(this.id, null, this.onLoad, this.onDynamicProperties)
     },
     methods: {
-        action($evt) {
+        action ($evt) {
             const evt = {
                 type: $evt.type,
                 clientX: $evt.clientX,
                 clientY: $evt.clientY,
                 bbox: $evt.target.getBoundingClientRect()
             }
-            console.log(this.props)
             const msg = this.messages[this.id] || {}
             msg._event = evt
             this.$socket.emit('widget-action', this.id, msg)
         },
-        makeMdiIcon(icon) {
+        makeMdiIcon (icon) {
             return 'mdi-' + icon.replace(/^mdi-/, '')
         },
-        onDynamicProperties(msg) {
-            console.log('Button OnDynamic')
+        onDynamicProperties (msg) {
             const updates = msg.ui_update
             if (!updates) {
                 return
@@ -91,11 +90,10 @@ export default {
                 this.dynamic.enabled = updates.enabled
             }
         },
-        onLoad(msg) {
-            console.log('Button OnLoad')
-            console.log(msg)
+        onLoad (msg) {
+            this.onDynamicProperties(msg)
         },
-        getPropertyValue(property) {
+        getPropertyValue (property) {
             return this.dynamic[property] !== null ? this.dynamic[property] : this.props[property]
         }
     }
@@ -106,6 +104,7 @@ export default {
 .nrdb-ui-button--icon .v-btn__append {
     margin-left: 0;
 }
+
 .nrdb-ui-button--icon .v-btn__prepend {
     margin-right: 0;
 }
@@ -113,6 +112,7 @@ export default {
 .nrdb-ui-button .v-btn .v-icon {
     --v-icon-size-multiplier: 1;
 }
+
 .nrdb-ui-button .nrdb-ui-button--icon .v-icon {
     --v-icon-size-multiplier: 1.1;
 }

--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -20,56 +20,60 @@ export default {
         props: { type: Object, default: () => ({}) },
         state: { type: Object, default: () => ({}) }
     },
-    data () {
+    data() {
         return {
             dynamic: {
                 label: null,
                 icon: null,
-                iconPosition: null
+                iconPosition: null,
+                enabled: true
             }
         }
     },
     computed: {
         ...mapState('data', ['messages']),
-        prependIcon () {
+        prependIcon() {
             const icon = this.getPropertyValue('icon')
             const mdiIcon = this.makeMdiIcon(icon)
             return icon && this.iconPosition === 'left' ? mdiIcon : undefined
         },
-        appendIcon () {
+        appendIcon() {
             const icon = this.getPropertyValue('icon')
             const mdiIcon = this.makeMdiIcon(icon)
             return icon && this.iconPosition === 'right' ? mdiIcon : undefined
         },
-        label () {
+        label() {
             return this.getPropertyValue('label')
         },
-        iconPosition () {
+        iconPosition() {
             return this.getPropertyValue('iconPosition')
         },
         iconOnly () {
             return this.getPropertyValue('icon') && !this.getPropertyValue('label')
         }
     },
-    created () {
-        useDataTracker(this.id, null, null, this.onDynamicProperties)
+    created() {
+        console.log('Button Created')
+        useDataTracker(this.id, null, this.onLoad, this.onDynamicProperties)
     },
     methods: {
-        action ($evt) {
+        action($evt) {
             const evt = {
                 type: $evt.type,
                 clientX: $evt.clientX,
                 clientY: $evt.clientY,
                 bbox: $evt.target.getBoundingClientRect()
             }
+            console.log(this.props)
             const msg = this.messages[this.id] || {}
             msg._event = evt
             this.$socket.emit('widget-action', this.id, msg)
         },
-        makeMdiIcon (icon) {
+        makeMdiIcon(icon) {
             return 'mdi-' + icon.replace(/^mdi-/, '')
         },
-        onDynamicProperties (msg) {
+        onDynamicProperties(msg) {
+            console.log('Button OnDynamic')
             const updates = msg.ui_update
             if (!updates) {
                 return
@@ -83,8 +87,15 @@ export default {
             if (typeof updates.iconPosition !== 'undefined') {
                 this.dynamic.iconPosition = updates.iconPosition
             }
+            if (typeof updates.enabled !== 'undefined') {
+                this.dynamic.enabled = updates.enabled
+            }
         },
-        getPropertyValue (property) {
+        onLoad(msg) {
+            console.log('Button OnLoad')
+            console.log(msg)
+        },
+        getPropertyValue(property) {
             return this.dynamic[property] !== null ? this.dynamic[property] : this.props[property]
         }
     }


### PR DESCRIPTION
## Description

Needed a way to preserve the changes we send via `ui_update` even if the widget is hidden in another tab or after a page refresh.

As it was now, depending on the widget, it would only recuperate the last `ui_update` property sent. 
For the moment only did this for the `UI-Button` but if it is correct will make changes to at least `UI-Dropdown`, `UI-Slider` and `UI-Switch`, they are the widgets that at the moment I require this behaviour.

Changes:

- Unsubscribe from event 'widget-load:' to avoid multiple widget-Load messages, seems to solve #909
- When emitting a `widget-load` event, add to the message the `ui_update` parameters in store
- Add `ui_update.enable` as a valid parameter for `UI-Button`
- Add `onLoad` event to `UI-Button`
- Store the last message sent to  `UI-Button` to force a `widget-load` event upon refresh of page/widget.
    - This one, not quite sure about it. I needed a way for the `UI-Button` to trigger a `widget-load` event and this was the only way I could find to do that

This if applied to other widgets should also solve this issue #871



## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

