### PR TITLE
State store access for third-party nodes

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -736,7 +736,8 @@ module.exports = function (RED) {
         }
 
         node.stores = {
-            data: datastore
+            data: datastore,
+            state: statestore
         }
 
         /**


### PR DESCRIPTION
## Description

Currently the data store is available in third-party ui nodes, but not the state store.  
This PR makes our most populare store available for our nodes ;-)

## Related Issue(s)

See [1067](https://github.com/FlowFuse/node-red-dashboard/issues/1067)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

