### PR TITLE
UI-Dropdown: Use `v-select` option instead of `v-combox`

### DIFF
--- a/docs/nodes/widgets/ui-dropdown.md
+++ b/docs/nodes/widgets/ui-dropdown.md
@@ -18,8 +18,8 @@ props:
     Clearable:
         description: Clear selection with button.
         dynamic: false
-    Use v-select:
-        description: Use <code>v-select</code> component. Specifies that the list is displayed by clicking the down arrow and that the text portion is not editable. This means that the user cannot enter a new value. Only values already in the list can be selected. Allows typing to filter possible results.         
+    Allow Search:
+        description: Allows user to type a new value, filtering the list of possible values to choose.         
 dynamic:
     Label:
         payload: msg.ui_update.label

--- a/docs/nodes/widgets/ui-dropdown.md
+++ b/docs/nodes/widgets/ui-dropdown.md
@@ -7,7 +7,7 @@ props:
         description: The text shown to the left of the dropdown.
         dynamic: true
     Options:
-        description: A list of the options available in the dropdown. Each row defines a `label` (shown in the dropdown) and `value` (emitted on selection) property.
+        description: A list of the options available in the dropdown. Each row defines a 'label' (shown in the dropdown) and `value` (emitted on selection) property.
         dynamic: true
     Allow Multiple:
         description: Whether or not a user can select multiple options, if so, checkboxes are shown, and value is emitted in an array.
@@ -17,7 +17,9 @@ props:
         dynamic: false        
     Clearable:
         description: Clear selection with button.
-        dynamic: false        
+        dynamic: false
+    Use v-select:
+        description: Use <code>v-select</code> component. Specifies that the list is displayed by clicking the down arrow and that the text portion is not editable. This means that the user cannot enter a new value. Only values already in the list can be selected. Allows typing to filter possible results.         
 dynamic:
     Label:
         payload: msg.ui_update.label

--- a/nodes/widgets/locales/en-US/ui_dropdown.html
+++ b/nodes/widgets/locales/en-US/ui_dropdown.html
@@ -7,6 +7,10 @@
         In the case where a single option is selected, returns the object detailing that selection.
         If "Allow multiple selections" is enabled, returns an array of objects detailing the selections.
     </p>
+    <p>
+        If user want's to prevent the possibility to typing incorrect values, select the "Use v-select instead of v-combox".
+        This will make the selection box not editable / writable. This means that the user cannot enter a new value. Only values already in the list can be selected. 
+    </p>
     <h3>Selecting Options via <code>msg.</code></h3>
     <p>
         You can dynamically make selections for this dropdown by passing in the respective <code>value</code> to <code>msg.payload</code>.

--- a/nodes/widgets/locales/en-US/ui_dropdown.html
+++ b/nodes/widgets/locales/en-US/ui_dropdown.html
@@ -8,7 +8,7 @@
         If "Allow multiple selections" is enabled, returns an array of objects detailing the selections.
     </p>
     <p>
-        If user want's to prevent the possibility to typing incorrect values, select the "Use v-select instead of v-combox".
+        If user want's to prevent the possibility to typing incorrect values, unselect the "Allow Search" option.
         This will make the selection box not editable / writable. This means that the user cannot enter a new value. Only values already in the list can be selected. 
     </p>
     <h3>Selecting Options via <code>msg.</code></h3>

--- a/nodes/widgets/ui_dropdown.html
+++ b/nodes/widgets/ui_dropdown.html
@@ -39,7 +39,8 @@
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
                 topicType: { value: 'msg' },
                 className: { value: '' },
-                typeIsVselect: { value: false }
+                // This field controls if the used component is going to be a `v-combox` or a `v-select`, `v-combox` allows typing and filtering possible values
+                typeIsComboBox: { value: true }
             },
             inputs: 1,
             outputs: 1,
@@ -57,8 +58,8 @@
                 if (this.clearable === undefined) {
                     $('#node-input-clearable').prop('checked', false)
                 }  
-                if (this.typeIsVselect === undefined) {
-                    $('#node-input-typeIsVselect').prop('checked', false)
+                if (this.typeIsComboBox === undefined) {
+                    $('#node-input-typeIsComboBox').prop('checked', true)
                 }                            
                 // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
                 // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
@@ -234,15 +235,8 @@
         <input type="checkbox" checked id="node-input-clearable" style="display: inline-block; width: auto; margin: 0px 0px 0px 4px;">
     </div>   
     <div class="form-row">
-        <label style="width:auto" for="node-input-typeIsVselect"><i class="fa fa-pencil-square"></i> Use <code>v-select</code> instead of <code>v-combobox</code> </label>
-        <input type="checkbox" checked id="node-input-typeIsVselect" style="display: inline-block; width: auto; margin: 0px 0px 0px 4px;">
-       <a
-        data-html="true"
-        title="Option 'v-combobox' component supports write (typing) new values and 'v-select' does not. Booth allow typing to filter possible result match."
-        class="red-ui-button ui-node-popover-title"
-        style="margin-left: 4px; cursor: help; font-size: 0.625rem; border-radius: 50%; width: 24px; height: 24px; display: inline-flex; justify-content: center; align-items: center;">
-        <i style="font-family: ui-serif;">fx</i>
-        </a>
+        <label style="width:auto" for="node-input-typeIsComboBox"><i class="fa fa-pencil-square"></i> Allow Search </label>
+        <input type="checkbox" checked id="node-input-typeIsComboBox" style="display: inline-block; width: auto; margin: 0px 0px 0px 4px;">
         </div>
     </div>  
     <div class="form-row">

--- a/nodes/widgets/ui_dropdown.html
+++ b/nodes/widgets/ui_dropdown.html
@@ -38,7 +38,8 @@
                 payload: { value: '' },
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
                 topicType: { value: 'msg' },
-                className: { value: '' }
+                className: { value: '' },
+                typeIsVselect: { value: false }
             },
             inputs: 1,
             outputs: 1,
@@ -55,7 +56,10 @@
                 }    
                 if (this.clearable === undefined) {
                     $('#node-input-clearable').prop('checked', false)
-                }                              
+                }  
+                if (this.typeIsVselect === undefined) {
+                    $('#node-input-typeIsVselect').prop('checked', false)
+                }                            
                 // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
                 // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
                 if (RED.nodes.subflow(this.z)) {
@@ -228,7 +232,19 @@
     <div class="form-row">
         <label style="width:auto" for="node-input-clearable"><i class="fa fa-times"></i> Clear selection with button </label>
         <input type="checkbox" checked id="node-input-clearable" style="display: inline-block; width: auto; margin: 0px 0px 0px 4px;">
-    </div>    
+    </div>   
+    <div class="form-row">
+        <label style="width:auto" for="node-input-typeIsVselect"><i class="fa fa-pencil-square"></i> Use <code>v-select</code> instead of <code>v-combobox</code> </label>
+        <input type="checkbox" checked id="node-input-typeIsVselect" style="display: inline-block; width: auto; margin: 0px 0px 0px 4px;">
+       <a
+        data-html="true"
+        title="Option 'v-combobox' component supports write (typing) new values and 'v-select' does not. Booth allow typing to filter possible result match."
+        class="red-ui-button ui-node-popover-title"
+        style="margin-left: 4px; cursor: help; font-size: 0.625rem; border-radius: 50%; width: 24px; height: 24px; display: inline-flex; justify-content: center; align-items: center;">
+        <i style="font-family: ui-serif;">fx</i>
+        </a>
+        </div>
+    </div>  
     <div class="form-row">
         <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
         <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">

--- a/ui/src/widgets/ui-dropdown/UIDropdown.vue
+++ b/ui/src/widgets/ui-dropdown/UIDropdown.vue
@@ -1,8 +1,8 @@
 <template>
     <v-combobox
-        v-if="isvSelect !== true" v-model="value" :disabled="!state.enabled" :class="className" :label="label"
+        v-if="typeIsComboBox === true" v-model="value" :disabled="!state.enabled" :class="className" :label="label"
         :multiple="multiple" :chips="chips" :clearable="clearable" :items="options" item-title="label"
-        item-value="value" variant="outlined" hide-details="auto"
+        item-value="value" variant="outlined" hide-details="auto" auto-select-first
         :error-messages="options?.length ? '' : 'No options available'" @update:model-value="onChange"
     />
     <v-select
@@ -75,8 +75,8 @@ export default {
         label: function () {
             return this.dynamic.label !== null ? this.dynamic.label : this.props.label
         },
-        isvSelect: function () {
-            return this.props.typeIsVselect || false
+        typeIsComboBox: function () {
+            return this.props.typeIsComboBox ?? true
         }
     },
     created () {
@@ -135,14 +135,14 @@ export default {
             if (this.multiple) {
                 // return an array
                 msg.payload = this.value.map((option) => {
-                    if (this.props.typeIsVselect) {
+                    if (this.props.typeIsComboBox === false) {
                         return option
                     }
                     return option.value
                 })
             } else if (this.value) {
                 // return a single value
-                if (this.props.typeIsVselect) {
+                if (this.props.typeIsComboBox === false) {
                     msg.payload = this.value
                 } else {
                     msg.payload = this.value.value

--- a/ui/src/widgets/ui-dropdown/UIDropdown.vue
+++ b/ui/src/widgets/ui-dropdown/UIDropdown.vue
@@ -1,12 +1,16 @@
 <template>
-    <v-combobox v-if="isvSelect !== true" v-model="value" :disabled="!state.enabled" :class="className" :label="label"
+    <v-combobox
+        v-if="isvSelect !== true" v-model="value" :disabled="!state.enabled" :class="className" :label="label"
         :multiple="multiple" :chips="chips" :clearable="clearable" :items="options" item-title="label"
         item-value="value" variant="outlined" hide-details="auto"
-        :error-messages="options?.length ? '' : 'No options available'" @update:model-value="onChange" />
-    <v-select v-else v-model="value" :disabled="!state.enabled" :class="className" :label="label" :multiple="multiple"
+        :error-messages="options?.length ? '' : 'No options available'" @update:model-value="onChange"
+    />
+    <v-select
+        v-else v-model="value" :disabled="!state.enabled" :class="className" :label="label" :multiple="multiple"
         :chips="chips" :clearable="clearable" :items="options" item-title="label" item-value="value" variant="outlined"
         hide-details="auto" :error-messages="options?.length ? '' : 'No options available'"
-        @update:model-value="onChange" />
+        @update:model-value="onChange"
+    />
 </template>
 
 <script>
@@ -22,7 +26,7 @@ export default {
         props: { type: Object, default: () => ({}) },
         state: { type: Object, default: () => ({}) }
     },
-    data() {
+    data () {
         return {
             value: null,
             items: null,
@@ -37,7 +41,7 @@ export default {
     computed: {
         ...mapState('data', ['messages']),
         options: {
-            get() {
+            get () {
                 const items = this.items || this.props.options
                 return items.map((item) => {
                     if (typeof item !== 'object') {
@@ -55,7 +59,7 @@ export default {
                     }
                 })
             },
-            set(value) {
+            set (value) {
                 this.items = value
             }
         },
@@ -75,7 +79,7 @@ export default {
             return this.props.typeIsVselect || false
         }
     },
-    created() {
+    created () {
         // can't do this in setup as we are using custom onInput function that needs access to 'this'
         useDataTracker(this.id, null, this.onLoad, this.onDynamicProperties)
 
@@ -84,7 +88,7 @@ export default {
     },
     methods: {
         // given the last received msg into this node, load the state
-        onLoad(msg) {
+        onLoad (msg) {
             // update vuex store to reflect server-state
             this.$store.commit('data/bind', {
                 widgetId: this.id,
@@ -92,7 +96,7 @@ export default {
             })
             this.select(this.messages[this.id]?.payload)
         },
-        onDynamicProperties(msg) {
+        onDynamicProperties (msg) {
             // When a msg comes in from Node-RED, we need support 2 operations:
             // 1. add/replace the dropdown options (to support dynamic options e.g: nested dropdowns populated from a database)
             // 2. update the selected value(s)
@@ -125,7 +129,7 @@ export default {
                 }
             }
         },
-        onChange() {
+        onChange () {
             // ensure our data binding with vuex store is updated
             const msg = this.messages[this.id] || {}
             if (this.multiple) {
@@ -153,7 +157,7 @@ export default {
             })
             this.$socket.emit('widget-change', this.id, msg.payload)
         },
-        select(value) {
+        select (value) {
             if (value !== undefined) {
                 // first, if we have a single value, we need to convert it to an array
                 if (!Array.isArray(value)) {


### PR DESCRIPTION
## Description

This allows the user to use the vue component `v-select` instead of `v-combox`.

The main difference is that `v-select` is not "writable". Specifies that the list is displayed by clicking the down arrow and that the text portion is not editable. This means that the user cannot enter a new value. Only values already in the list can be selected

This prevents that the user can type an invalid value (that do not exist on the list and sending payload as null as result). It allows typing for filtering values.

The text description in the config menu could be better, but having no ideia how. Other option is to use the v-select instead of v-combox, but this could be tricky for legacy reasons.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

