### PR TITLE
UI-Button: Add Background, text and icon color option

### DIFF
--- a/docs/nodes/widgets/ui-button.md
+++ b/docs/nodes/widgets/ui-button.md
@@ -12,6 +12,15 @@ props:
     Label:
         description: The text shown within the button. If not provided, then the button will only render the icon.
         dynamic: true
+    Button Color:
+        description: Button Color. If not provided, default theme color will be used.
+        dynamic: true
+    Text Color:
+        description: Text (Label) color. If not provided calculated automatically based on Button color to be Black or White.
+        dynamic: true
+    Icon Color:
+        description: Icon color. If not provided, will have the same color as text / label.
+        dynamic: true
     Emulate Button Click: If enabled, any received message will trigger a button click, emitting the relevant payload and topic.
 controls:
     enabled:
@@ -26,6 +35,15 @@ dynamic:
         structure: ["String"]
     Label:
         payload: msg.ui_update.label
+        structure: ["String"]
+    Button Color:
+        payload: msg.ui_update.buttonColor
+        structure: ["String"]
+    Text Color:
+        payload: msg.ui_update.textColor
+        structure: ["String"]
+    Icon Color:
+        payload: msg.ui_update.iconColor
         structure: ["String"]
     Class:
         payload: msg.ui_update.class

--- a/docs/user/migration/ui_button.json
+++ b/docs/user/migration/ui_button.json
@@ -33,13 +33,13 @@
         },
         {
             "property": "color",
-            "changes": -1,
-            "notes": "<a href='https://github.com/FlowFuse/node-red-dashboard/issues/375' target='_blank'>Issue #375</a>"
+            "changes": "improved",
+            "notes": "Separeted property for text color and icon color"
         },
         {
             "property": "background",
-            "changes": -1,
-            "notes": "<a href='https://github.com/FlowFuse/node-red-dashboard/issues/375' target='_blank'>Issue #375</a>"
+            "changes": null,
+            "notes": null
         },
         {
             "property": "payload",

--- a/docs/user/migration/ui_button.json
+++ b/docs/user/migration/ui_button.json
@@ -34,7 +34,7 @@
         {
             "property": "color",
             "changes": "improved",
-            "notes": "Separeted property for text color and icon color"
+            "notes": "Separated property for text color and icon color"
         },
         {
             "property": "background",

--- a/nodes/widgets/locales/en-US/ui_button.html
+++ b/nodes/widgets/locales/en-US/ui_button.html
@@ -4,6 +4,16 @@
         Clicking the button generates a message with <code>msg.payload</code>
         set to the <b>Payload</b> field, and <code>msg.topic</code> to the <b>Topic</b> field.
     </p>
+    <h3>HTML Content</h3>
+    <p>
+        The text field can also be used to set HTML content in the user interface.
+        This can be done by setting the <code>msg.ui_update.label</code> to a string of HTML.
+        This can be useful for displaying images, links, or other HTML elements.
+    </p>
+    <p>
+        You can also use Node-RED's built-in "template" node to generate the HTML you want to display if
+        you want to render <code>msg</code>, <code>flow</code> or <code>global</code> content.
+    </p>
     <h3>Properties</h3>
     <dl class="message-properties">
         <dt>Icon <span class="property-type">string</span></dt>
@@ -13,12 +23,11 @@
         <dt>Button Color<span class="property-type">string</span></dt>
         <dd>Background color for the button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
         <dt>Text Color<span class="property-type">string</span></dt>
-        <dd>Color the text on the Button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color.
-        <br>Possible to also add parameter to specify text font height and style <a href="https://vuetifyjs.com/en/styles/text-and-typography/#text-and-typography">Vuetify Text Helper Class</a>, this extra property must be separated by a <b>space</b> from color, or if no color to be defined the string text must start with a <b>space</b>. </dd>
+        <dd>Color the text on the Button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>, send empty string to use default theme color.
         <dt>ICon Color<span class="property-type">string</span></dt>
         <dd>Color for the Icon on the Button (if Icon configured), valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
         <dt>Label <span class="property-type">string</span></dt>
-        <dd>The text shown within the button. If not provided, then the button will only render the icon</dd>
+        <dd>The text shown within the button. If not provided, then the button will only render the icon. It supports HTML content</dd>
         <dt>Emulate Button Click <span class="property-type">bool</span></dt>
         <dd>If enabled, any received message will trigger a button click, emitting the relevant payload and topic</dd>
     </dl>

--- a/nodes/widgets/locales/en-US/ui_button.html
+++ b/nodes/widgets/locales/en-US/ui_button.html
@@ -13,7 +13,8 @@
         <dt>Button Color<span class="property-type">string</span></dt>
         <dd>Background color for the button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
         <dt>Text Color<span class="property-type">string</span></dt>
-        <dd>Color the text on the Button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
+        <dd>Color the text on the Button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color.
+        <br>Possible to also add parameter to specify text font height and style <a href="https://vuetifyjs.com/en/styles/text-and-typography/#text-and-typography">Vuetify Text Helper Class</a>, this extra property must be separated by a <b>space</b> from color, or if no color to be defined the string text must start with a <b>space</b>. </dd>
         <dt>ICon Color<span class="property-type">string</span></dt>
         <dd>Color for the Icon on the Button (if Icon configured), valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
         <dt>Label <span class="property-type">string</span></dt>

--- a/nodes/widgets/locales/en-US/ui_button.html
+++ b/nodes/widgets/locales/en-US/ui_button.html
@@ -20,16 +20,16 @@
         <dd>Renders a Material Design icon within the button. We use the Material Design Icons, you can see a full list of the available icons <a href="https://pictogrammers.com/library/mdi/">here</a>. There is no need to include the "mdi-" prefix, just the name of the icon.</dd>
         <dt>Icon Position<span class="property-type">left | right</span></dt>
         <dd>If "Icon" is defined, this property controls which side of the "Label" the icon will render on</dd>
-        <dt>Button Color<span class="property-type">string</span></dt>
-        <dd>Background color for the button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
-        <dt>Text Color<span class="property-type">string</span></dt>
-        <dd>Color the text on the Button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>, send empty string to use default theme color.
-        <dt>ICon Color<span class="property-type">string</span></dt>
-        <dd>Color for the Icon on the Button (if Icon configured), valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
         <dt>Label <span class="property-type">string</span></dt>
         <dd>The text shown within the button. If not provided, then the button will only render the icon. It supports HTML content</dd>
         <dt>Emulate Button Click <span class="property-type">bool</span></dt>
         <dd>If enabled, any received message will trigger a button click, emitting the relevant payload and topic</dd>
+        <dt>Background Color<span class="property-type">string</span></dt>
+        <dd>Background color for the button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
+        <dt>Text Color<span class="property-type">string</span></dt>
+        <dd>Color the text on the Button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>, send empty string to use default theme color.
+        <dt>Icon Color<span class="property-type">string</span></dt>
+        <dd>Color for the Icon on the Button (if Icon configured), valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
     </dl>
     <h3>Dynamic Properties (Inputs)</h3>
     <p>Any of the following can be appended to a <code>msg.ui_update</code> in order to override or set properties on this node at runtime.</p>

--- a/nodes/widgets/locales/en-US/ui_button.html
+++ b/nodes/widgets/locales/en-US/ui_button.html
@@ -10,6 +10,12 @@
         <dd>Renders a Material Design icon within the button. We use the Material Design Icons, you can see a full list of the available icons <a href="https://pictogrammers.com/library/mdi/">here</a>. There is no need to include the "mdi-" prefix, just the name of the icon.</dd>
         <dt>Icon Position<span class="property-type">left | right</span></dt>
         <dd>If "Icon" is defined, this property controls which side of the "Label" the icon will render on</dd>
+        <dt>Button Color<span class="property-type">string</span></dt>
+        <dd>Background color for the button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
+        <dt>Text Color<span class="property-type">string</span></dt>
+        <dd>Color the text on the Button, valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
+        <dt>ICon Color<span class="property-type">string</span></dt>
+        <dd>Color for the Icon on the Button (if Icon configured), valid values as <b>green</b>/<b>#a5a5a5</b>/<b>rgb(165,165,165)</b>/<b>green-darken-2</b>, check <a href="https://vuetifyjs.com/en/styles/colors/#material-colors"> Vuetify Colors</a> for help, send empty string to use default theme color</dd>
         <dt>Label <span class="property-type">string</span></dt>
         <dd>The text shown within the button. If not provided, then the button will only render the icon</dd>
         <dt>Emulate Button Click <span class="property-type">bool</span></dt>
@@ -24,6 +30,12 @@
         <dd>Override the icon defined in the initial configuration</dd>
         <dt class="optional">iconPosition <span class="property-type">'left' | 'right'</span></dt>
         <dd>Change which side of the label the icon renders</dd>
+        <dt class="optional">buttonColor <span class="property-type">string</span></dt>
+        <dd>Override the default button color</dd>
+        <dt class="optional">textColor <span class="property-type">string</span></dt>
+        <dd>Override the button text default color</dd>
+        <dt class="optional">iconColor <span class="property-type">string</span></dt>
+        <dd>Override the icon (if present) default color</dd>
         <dt class="optional">class <span class="property-type">string</span></dt>
         <dd>Add a CSS class, or more, to the Button at runtime.</dd>
     </dl>

--- a/nodes/widgets/locales/en-US/ui_button.json
+++ b/nodes/widgets/locales/en-US/ui_button.json
@@ -22,7 +22,13 @@
             "whenClicked": "When clicked, send:",
             "payload": "Payload",
             "topic": "Topic",
-            "emulateClick": "If msg arrives on input, emulate a button click:"
+            "emulateClick": "If msg arrives on input, emulate a button click:",
+            "buttonColor": "Button Color",
+            "optionalbuttonColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'/'green-darken-2'",
+            "textColor": "Text Color",
+            "optionaltextColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'/'green-darken-2'",
+            "iconColor": "Icon Color",
+            "optionaliconColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'/'green-darken-2'"
         }
     }
 }

--- a/nodes/widgets/locales/en-US/ui_button.json
+++ b/nodes/widgets/locales/en-US/ui_button.json
@@ -26,7 +26,7 @@
             "buttonColor": "Button Color",
             "optionalbuttonColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'/'green-darken-2'",
             "textColor": "Text Color",
-            "optionaltextColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'/'green-darken-2'",
+            "optionaltextColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'",
             "iconColor": "Icon Color",
             "optionaliconColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'/'green-darken-2'"
         }

--- a/nodes/widgets/locales/en-US/ui_button.json
+++ b/nodes/widgets/locales/en-US/ui_button.json
@@ -23,12 +23,12 @@
             "payload": "Payload",
             "topic": "Topic",
             "emulateClick": "If msg arrives on input, emulate a button click:",
-            "buttonColor": "Button Color",
-            "optionalbuttonColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'/'green-darken-2'",
-            "textColor": "Text Color",
-            "optionaltextColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'",
-            "iconColor": "Icon Color",
-            "optionaliconColor": "(Optional) e.g. 'green'/'#a5a5a5'/'rgb(165,165,165)'/'green-darken-2'"
+            "buttonColor": "Background",
+            "optionalButtonColor": "(Optional) e.g. 'green'/'#a5a5a5'",
+            "textColor": "Text",
+            "optionalTextColor": "(Optional) e.g. 'green'/'#a5a5a5'",
+            "iconColor": "Icon",
+            "optionalIconColor": "(Optional) e.g. 'green'/'#a5a5a5'"
         }
     }
 }

--- a/nodes/widgets/ui_button.html
+++ b/nodes/widgets/ui_button.html
@@ -33,7 +33,10 @@
                 payload: { value: '', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('payloadType') : function (v) { return true }) },
                 payloadType: { value: 'str' },
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
-                topicType: { value: 'msg' }
+                topicType: { value: 'msg' },
+                buttonColor: { value: '' },
+                textColor: { value: '' },
+                iconColor: { value: '' }
             },
             inputs: 1,
             outputs: 1,
@@ -126,6 +129,18 @@
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-button.label.label"></label>
         <input type="text" id="node-input-label" data-i18n="[placeholder]ui-button.label.optionalLabel">
+    </div>
+    <div class="form-row">
+        <label for="node-input-buttonColor"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.buttonColor"></label>
+        <input type="text" id="node-input-buttonColor" data-i18n="[placeholder]ui-button.label.optionalbuttonColor">
+    </div>
+    <div class="form-row">
+        <label for="node-input-textColor"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.textColor"></label>
+        <input type="text" id="node-input-textColor" data-i18n="[placeholder]ui-button.label.optionaltextColor">
+    </div>
+    <div class="form-row">
+        <label for="node-input-iconColor"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.iconColor"></label>
+        <input type="text" id="node-input-iconColor" data-i18n="[placeholder]ui-button.label.optionaliconColor">
     </div>
     <div class="form-row">
         <label for="node-input-className"><i class="fa fa-code"></i> <span data-i18n="ui-button.label.className"></label>

--- a/nodes/widgets/ui_button.html
+++ b/nodes/widgets/ui_button.html
@@ -101,6 +101,10 @@
 
 <script type="text/html" data-template-name="ui-button">
     <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-row">
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-button.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
@@ -131,18 +135,6 @@
         <input type="text" id="node-input-label" data-i18n="[placeholder]ui-button.label.optionalLabel">
     </div>
     <div class="form-row">
-        <label for="node-input-buttonColor"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.buttonColor"></label>
-        <input type="text" id="node-input-buttonColor" data-i18n="[placeholder]ui-button.label.optionalbuttonColor">
-    </div>
-    <div class="form-row">
-        <label for="node-input-textColor"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.textColor"></label>
-        <input type="text" id="node-input-textColor" data-i18n="[placeholder]ui-button.label.optionaltextColor">
-    </div>
-    <div class="form-row">
-        <label for="node-input-iconColor"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.iconColor"></label>
-        <input type="text" id="node-input-iconColor" data-i18n="[placeholder]ui-button.label.optionaliconColor">
-    </div>
-    <div class="form-row">
         <label for="node-input-className"><i class="fa fa-code"></i> <span data-i18n="ui-button.label.className"></label>
         <div style="display: inline;">
             <input style="width: 70%;" type="text" id="node-input-className" data-i18n="[placeholder]ui-button.label.classNamePlaceholder" style="flex-grow: 1;">
@@ -158,14 +150,6 @@
     <!--<div class="form-row">
         <label for="node-input-tooltip"><i class="fa fa-info-circle"></i> <span data-i18n="ui-button.label.tooltip"></label>
         <input type="text" id="node-input-tooltip" data-i18n="[placeholder]ui-button.label.optionalTooltip">
-    </div>
-    <div class="form-row">
-        <label for="node-input-color"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.color"></label>
-        <input type="text" id="node-input-color" data-i18n="[placeholder]ui-button.label.optionalColor">
-    </div>
-    <div class="form-row">
-        <label for="node-input-bgcolor"><i class="fa fa-tint"></i>  <span data-i18n="ui-button.label.background"></label>
-        <input type="text" id="node-input-bgcolor" data-i18n="[placeholder]ui-button.label.optionalBackgroundColor">
     </div>-->
     <div class="form-row">
         <label style="width:auto" for="node-input-payload"><i class="fa fa-envelope-o"></i> <span data-i18n="ui-button.label.whenClicked"></label>
@@ -185,7 +169,18 @@
         <input type="checkbox" id="node-input-emulateClick" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+        <h4>Custom Styling</h4>
+    </div>
+    <div class="form-row">
+        <label for="node-input-buttonColor"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.buttonColor"></label>
+        <input type="text" id="node-input-buttonColor" data-i18n="[placeholder]ui-button.label.optionalButtonColor">
+    </div>
+    <div class="form-row">
+        <label for="node-input-textColor"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.textColor"></label>
+        <input type="text" id="node-input-textColor" data-i18n="[placeholder]ui-button.label.optionalTextColor">
+    </div>
+    <div class="form-row">
+        <label for="node-input-iconColor"><i class="fa fa-tint"></i> <span data-i18n="ui-button.label.iconColor"></label>
+        <input type="text" id="node-input-iconColor" data-i18n="[placeholder]ui-button.label.optionalIconColor">
     </div>
 </script>

--- a/nodes/widgets/ui_button.js
+++ b/nodes/widgets/ui_button.js
@@ -55,12 +55,24 @@ module.exports = function (RED) {
                     statestore.set(group.getBase(), node, msg, 'label', updates.label)
                 }
                 if (typeof updates.icon !== 'undefined') {
-                    // dynamically set "label" property
+                    // dynamically set "icon" property
                     statestore.set(group.getBase(), node, msg, 'icon', updates.icon)
                 }
                 if (typeof updates.iconPosition !== 'undefined') {
-                    // dynamically set "label" property
+                    // dynamically set "iconPosition" property
                     statestore.set(group.getBase(), node, msg, 'iconPosition', updates.iconPosition)
+                }
+                if (typeof updates.buttonColor !== 'undefined') {
+                    // dynamically set "buttonColor" property
+                    statestore.set(group.getBase(), node, msg, 'buttonColor', updates.buttonColor)
+                }
+                if (typeof updates.textColor !== 'undefined') {
+                    // dynamically set "textColor" property
+                    statestore.set(group.getBase(), node, msg, 'textColor', updates.textColor)
+                }
+                if (typeof updates.iconColor !== 'undefined') {
+                    // dynamically set "iconColor" property
+                    statestore.set(group.getBase(), node, msg, 'iconColor', updates.iconColor)
                 }
             }
 

--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -1,7 +1,9 @@
 <template>
-    <v-btn block variant="flat" :disabled="!state.enabled" :prepend-icon="prependIcon" :append-icon="appendIcon"
+    <v-btn
+        block variant="flat" :disabled="!state.enabled" :prepend-icon="prependIcon" :append-icon="appendIcon"
         :class="{ 'nrdb-ui-button--icon': iconOnly }" :color="buttonColor" :style="{ 'min-width': icon ?? 'auto' }"
-        @click="action">
+        @click="action"
+    >
         <template #append>
             <v-icon :color="iconColor" />
         </template>
@@ -24,7 +26,7 @@ export default {
         props: { type: Object, default: () => ({}) },
         state: { type: Object, default: () => ({}) }
     },
-    data() {
+    data () {
         return {
             dynamic: {
                 label: null,
@@ -38,32 +40,32 @@ export default {
     },
     computed: {
         ...mapState('data', ['messages']),
-        prependIcon() {
+        prependIcon () {
             const icon = this.getPropertyValue('icon')
             const mdiIcon = this.makeMdiIcon(icon)
             return icon && this.iconPosition === 'left' ? mdiIcon : undefined
         },
-        appendIcon() {
+        appendIcon () {
             const icon = this.getPropertyValue('icon')
             const mdiIcon = this.makeMdiIcon(icon)
             return icon && this.iconPosition === 'right' ? mdiIcon : undefined
         },
-        label() {
+        label () {
             return this.getPropertyValue('label')
         },
-        iconPosition() {
+        iconPosition () {
             return this.getPropertyValue('iconPosition')
         },
-        iconOnly() {
+        iconOnly () {
             return this.getPropertyValue('icon') && !this.getPropertyValue('label')
         },
-        buttonColor() {
+        buttonColor () {
             return this.getPropertyValue('buttonColor')
         },
-        iconColor() {
+        iconColor () {
             return this.getPropertyValue('iconColor')
         },
-        textColor() {
+        textColor () {
             const textColor = this.getPropertyValue('textColor')
             if (typeof textColor === 'string') {
                 return 'text-' + textColor
@@ -71,11 +73,11 @@ export default {
             return undefined
         }
     },
-    created() {
+    created () {
         useDataTracker(this.id, null, null, this.onDynamicProperties)
     },
     methods: {
-        action($evt) {
+        action ($evt) {
             const evt = {
                 type: $evt.type,
                 clientX: $evt.clientX,
@@ -86,10 +88,10 @@ export default {
             msg._event = evt
             this.$socket.emit('widget-action', this.id, msg)
         },
-        makeMdiIcon(icon) {
+        makeMdiIcon (icon) {
             return 'mdi-' + icon.replace(/^mdi-/, '')
         },
-        onDynamicProperties(msg) {
+        onDynamicProperties (msg) {
             const updates = msg.ui_update
             if (!updates) {
                 return
@@ -113,7 +115,7 @@ export default {
                 this.dynamic.iconColor = updates.iconColor
             }
         },
-        getPropertyValue(property) {
+        getPropertyValue (property) {
             return this.dynamic[property] !== null ? this.dynamic[property] : this.props[property]
         }
     }

--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -1,16 +1,16 @@
 <template>
     <v-btn
         block variant="flat" :disabled="!state.enabled" :prepend-icon="prependIcon" :append-icon="appendIcon"
-        :class="{ 'nrdb-ui-button--icon': iconOnly }" :color="buttonColor" :style="{ 'min-width': icon ?? 'auto' }"
+        :class="{ 'nrdb-ui-button--icon': iconOnly }" :color="buttonColor" :style="{ 'min-width': iconOnly ?? 'auto' }"
         @click="action"
     >
-        <template #append>
+        <template v-if="prependIcon" #prepend>
             <v-icon :color="iconColor" />
         </template>
-        <template #prepend>
+        <template v-if="appendIcon" #append>
             <v-icon :color="iconColor" />
         </template>
-        <span :style="{'color': textColor}" v-html="label" />
+        <span v-if="label" :style="{'color': textColor}" v-html="label" />
     </v-btn>
 </template>
 
@@ -121,10 +121,12 @@ export default {
 <style>
 .nrdb-ui-button--icon .v-btn__append {
     margin-left: 0;
+    margin-inline: initial;
 }
 
 .nrdb-ui-button--icon .v-btn__prepend {
     margin-right: 0;
+    margin-inline: initial;
 }
 
 .nrdb-ui-button .v-btn .v-icon {

--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -8,7 +8,7 @@
         <template #prepend>
             <v-icon :color="iconColor" />
         </template>
-        <span :class="textClass"> {{ label }} </span>
+        <span :class="textColor"> {{ label }} </span>
     </v-btn>
 </template>
 
@@ -63,7 +63,7 @@ export default {
         iconColor() {
             return this.getPropertyValue('iconColor')
         },
-        textClass() {
+        textColor() {
             const textColor = this.getPropertyValue('textColor')
             if (typeof textColor === 'string') {
                 return 'text-' + textColor

--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -10,7 +10,7 @@
         <template #prepend>
             <v-icon :color="iconColor" />
         </template>
-        <span :class="textColor"> {{ label }} </span>
+        <span :style="{'color': textColor}" v-html="label" />
     </v-btn>
 </template>
 
@@ -66,11 +66,7 @@ export default {
             return this.getPropertyValue('iconColor')
         },
         textColor () {
-            const textColor = this.getPropertyValue('textColor')
-            if (typeof textColor === 'string') {
-                return 'text-' + textColor
-            }
-            return undefined
+            return this.getPropertyValue('textColor')
         }
     },
     created () {

--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -1,10 +1,14 @@
 <template>
-    <v-btn
-        block variant="flat" :disabled="!state.enabled" :prepend-icon="prependIcon"
-        :append-icon="appendIcon" :class="{'nrdb-ui-button--icon': iconOnly}"
-        :style="{'min-width': icon ?? 'auto'}" @click="action"
-    >
-        {{ label }}
+    <v-btn block variant="flat" :disabled="!state.enabled" :prepend-icon="prependIcon" :append-icon="appendIcon"
+        :class="{ 'nrdb-ui-button--icon': iconOnly }" :color="buttonColor" :style="{ 'min-width': icon ?? 'auto' }"
+        @click="action">
+        <template #append>
+            <v-icon :color="iconColor" />
+        </template>
+        <template #prepend>
+            <v-icon :color="iconColor" />
+        </template>
+        <span :class="textClass"> {{ label }} </span>
     </v-btn>
 </template>
 
@@ -20,42 +24,58 @@ export default {
         props: { type: Object, default: () => ({}) },
         state: { type: Object, default: () => ({}) }
     },
-    data () {
+    data() {
         return {
             dynamic: {
                 label: null,
                 icon: null,
+                buttonColor: null,
+                textColor: null,
+                iconColor: null,
                 iconPosition: null
             }
         }
     },
     computed: {
         ...mapState('data', ['messages']),
-        prependIcon () {
+        prependIcon() {
             const icon = this.getPropertyValue('icon')
             const mdiIcon = this.makeMdiIcon(icon)
             return icon && this.iconPosition === 'left' ? mdiIcon : undefined
         },
-        appendIcon () {
+        appendIcon() {
             const icon = this.getPropertyValue('icon')
             const mdiIcon = this.makeMdiIcon(icon)
             return icon && this.iconPosition === 'right' ? mdiIcon : undefined
         },
-        label () {
+        label() {
             return this.getPropertyValue('label')
         },
-        iconPosition () {
+        iconPosition() {
             return this.getPropertyValue('iconPosition')
         },
-        iconOnly () {
+        iconOnly() {
             return this.getPropertyValue('icon') && !this.getPropertyValue('label')
+        },
+        buttonColor() {
+            return this.getPropertyValue('buttonColor')
+        },
+        iconColor() {
+            return this.getPropertyValue('iconColor')
+        },
+        textClass() {
+            const textColor = this.getPropertyValue('textColor')
+            if (typeof textColor === 'string') {
+                return 'text-' + textColor
+            }
+            return undefined
         }
     },
-    created () {
+    created() {
         useDataTracker(this.id, null, null, this.onDynamicProperties)
     },
     methods: {
-        action ($evt) {
+        action($evt) {
             const evt = {
                 type: $evt.type,
                 clientX: $evt.clientX,
@@ -66,10 +86,10 @@ export default {
             msg._event = evt
             this.$socket.emit('widget-action', this.id, msg)
         },
-        makeMdiIcon (icon) {
+        makeMdiIcon(icon) {
             return 'mdi-' + icon.replace(/^mdi-/, '')
         },
-        onDynamicProperties (msg) {
+        onDynamicProperties(msg) {
             const updates = msg.ui_update
             if (!updates) {
                 return
@@ -83,8 +103,17 @@ export default {
             if (typeof updates.iconPosition !== 'undefined') {
                 this.dynamic.iconPosition = updates.iconPosition
             }
+            if (typeof updates.buttonColor !== 'undefined') {
+                this.dynamic.buttonColor = updates.buttonColor
+            }
+            if (typeof updates.textColor !== 'undefined') {
+                this.dynamic.textColor = updates.textColor
+            }
+            if (typeof updates.iconColor !== 'undefined') {
+                this.dynamic.iconColor = updates.iconColor
+            }
         },
-        getPropertyValue (property) {
+        getPropertyValue(property) {
             return this.dynamic[property] !== null ? this.dynamic[property] : this.props[property]
         }
     }
@@ -95,6 +124,7 @@ export default {
 .nrdb-ui-button--icon .v-btn__append {
     margin-left: 0;
 }
+
 .nrdb-ui-button--icon .v-btn__prepend {
     margin-right: 0;
 }
@@ -102,6 +132,7 @@ export default {
 .nrdb-ui-button .v-btn .v-icon {
     --v-icon-size-multiplier: 1;
 }
+
 .nrdb-ui-button .nrdb-ui-button--icon .v-icon {
     --v-icon-size-multiplier: 1.1;
 }


### PR DESCRIPTION
## Description

Add properties to allow the user to set the color to be used for:
- Button Background Color
- Text Color
- Icon Color

If empty string in any of these properties, the default theme color will be used.

The text color allows the use of [Helper Class](https://vuetifyjs.com/en/styles/text-and-typography/#text-and-typography), for example having the field defined as `red text-decoration-underline text-h3 font-weight-black` results in:

![Button Example](https://github.com/user-attachments/assets/d00ef132-412a-4799-b64c-dacc09c0c9dd)

Alternatively, for the text part we could allow html injection like it was done to `ui-text`. 

Most if not all of these are possible to be done via `class` using CSS, this is a more "direct"/"user friendly" way of doing it.

## Related Issue(s)

Close #375 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

