### PR TITLE
UI-ButtonGroup: Add `msg.enabled` support, validate `msg.payload` before apply to selection

### DIFF
--- a/docs/nodes/widgets/ui-button-group.md
+++ b/docs/nodes/widgets/ui-button-group.md
@@ -18,6 +18,9 @@ controls:
         example: true | false
         description: Allow control over whether or not the button is clickable.
 dynamic:
+    Disabled State:
+        payload: msg.enabled
+        structure: ["Boolean"]
     Label:
         payload: msg.ui_update.label
         structure: ["String"]

--- a/nodes/widgets/locales/en-US/ui_button_group.html
+++ b/nodes/widgets/locales/en-US/ui_button_group.html
@@ -2,6 +2,7 @@
 <script type="text/html" data-help-name="ui-button-group">
     <p>A Node-RED node to show a switch with multiple buttons in the Node-RED Dashboard.</p>
     <p>The active selection can be dynamically set by sending a <code>msg.payload</code> which matches a respective option's value.</p>
+    <p>To clear any selection, pass an empty array <code>[]</code> as <code>msg.payload</code>.</p>
     <h3>Properties</h3>
     <p><strong>Label:</strong><br/>
     The label that will be displayed on the left side of the button group.</p>

--- a/nodes/widgets/ui_button_group.js
+++ b/nodes/widgets/ui_button_group.js
@@ -14,7 +14,6 @@ module.exports = function (RED) {
             beforeSend: function (msg) {
                 if (msg.ui_update) {
                     const update = msg.ui_update
-                    console.log(update)
                     if (typeof update.options !== 'undefined') {
                         // dynamically set "options" property
                         statestore.set(group.getBase(), node, msg, 'options', update.options)

--- a/ui/src/widgets/ui-button-group/UIButtonGroup.vue
+++ b/ui/src/widgets/ui-button-group/UIButtonGroup.vue
@@ -3,7 +3,7 @@
         <label v-if="label" class="v-label">
             {{ label }}
         </label>
-        <v-btn-toggle v-model="selection" mandatory divided :rounded="props.rounded ? 'xl' : ''" :color="selectedColor" @update:model-value="onChange(selection)">
+        <v-btn-toggle v-model="selection" mandatory divided :rounded="props.rounded ? 'xl' : ''" :color="selectedColor" :disabled="!state.enabled" @update:model-value="onChange(selection)">
             <v-btn v-for="option in options" :key="option.value" :value="option.value">
                 <template v-if="option.icon && option.label !== undefined && option.label !== ''" #prepend>
                     <v-icon size="x-large" :icon="`mdi-${option.icon.replace(/^mdi-/, '')}`" />
@@ -81,7 +81,9 @@ export default {
                 msg
             })
             // make sure our v-model is updated to reflect the value from Node-RED
-            this.selection = msg.payload
+            if (msg.payload !== undefined) {
+                this.selection = msg.payload
+            }
         },
         onLoad (msg) {
             // update vuex store to reflect server-state
@@ -90,7 +92,9 @@ export default {
                 msg
             })
             // make sure we've got the relevant option selected on load of the page
-            this.selection = msg.payload
+            if (msg.payload !== undefined) {
+                this.selection = msg.payload
+            }
         },
         onDynamicProperty (msg) {
             const updates = msg.ui_update

--- a/ui/src/widgets/ui-button-group/UIButtonGroup.vue
+++ b/ui/src/widgets/ui-button-group/UIButtonGroup.vue
@@ -141,7 +141,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .nrdb-ui-button-group-wrapper {
     display: flex;
     flex-direction: row;
@@ -171,5 +171,13 @@ export default {
 
 .nrdb-ui-button-group-wrapper .icon-only .v-btn__prepend {
     margin-inline: 0;
+}
+
+.nrdb-ui-button-group-wrapper .v-btn.v-btn--disabled .v-btn__overlay {
+    opacity: 0.1;
+}
+
+.nrdb-ui-button-group-wrapper .v-btn-group .v-btn--disabled .v-btn__content {
+    color: rgb(var(--v-theme-on-group-background), var(--v-disabled-opacity));
 }
 </style>

--- a/ui/src/widgets/ui-button-group/UIButtonGroup.vue
+++ b/ui/src/widgets/ui-button-group/UIButtonGroup.vue
@@ -80,9 +80,12 @@ export default {
                 widgetId: this.id,
                 msg
             })
+
             // make sure our v-model is updated to reflect the value from Node-RED
             if (msg.payload !== undefined) {
-                this.selection = msg.payload
+                if (this.findOptionByValue(msg.payload) !== null) {
+                    this.selection = msg.payload
+                }
             }
         },
         onLoad (msg) {
@@ -93,7 +96,9 @@ export default {
             })
             // make sure we've got the relevant option selected on load of the page
             if (msg.payload !== undefined) {
-                this.selection = msg.payload
+                if (this.findOptionByValue(msg.payload) !== null) {
+                    this.selection = msg.payload
+                }
             }
         },
         onDynamicProperty (msg) {

--- a/ui/src/widgets/ui-button-group/UIButtonGroup.vue
+++ b/ui/src/widgets/ui-button-group/UIButtonGroup.vue
@@ -83,8 +83,12 @@ export default {
 
             // make sure our v-model is updated to reflect the value from Node-RED
             if (msg.payload !== undefined) {
-                if (this.findOptionByValue(msg.payload) !== null) {
-                    this.selection = msg.payload
+                if (Array.isArray(msg.payload) && msg.payload.length === 0) {
+                    this.selection = null
+                } else {
+                    if (this.findOptionByValue(msg.payload) !== null) {
+                        this.selection = msg.payload
+                    }
                 }
             }
         },
@@ -96,8 +100,12 @@ export default {
             })
             // make sure we've got the relevant option selected on load of the page
             if (msg.payload !== undefined) {
-                if (this.findOptionByValue(msg.payload) !== null) {
-                    this.selection = msg.payload
+                if (Array.isArray(msg.payload) && msg.payload.length === 0) {
+                    this.selection = null
+                } else {
+                    if (this.findOptionByValue(msg.payload) !== null) {
+                        this.selection = msg.payload
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Description

- Add support for the `msg.enabled` property to allow enable/disable widget
- Validate that `msg.payload` exists and it is valid to apply to selection
- Add option to clear selection by sending an empty array

## Related Issue(s)

Fixes #721

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

