### PR TITLE
UI-Switch: Prevent change state when no `msg.payload` is present, fix `topic` not present at restart

### DIFF
--- a/docs/nodes/widgets/ui-switch.md
+++ b/docs/nodes/widgets/ui-switch.md
@@ -10,6 +10,10 @@ props:
     Off Icon: If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "off" state. No need to include the <code>mdi</code> prefix.
     On Color: If provided with a icons, this colour is used for the icon when in "on" state
     Off Color: If provided with a icons, this colour is used for the icon when in "off" state
+controls:
+    enabled:
+        example: true | false
+        description: Allow control over whether or not the switch can be toggled via the UI.
 dynamic:
     Class:
         payload: msg.class
@@ -30,6 +34,10 @@ Adds a toggle switch to the user interface.
 ## Dynamic Properties
 
 <DynamicPropsTable/>
+
+## Controls
+
+<ControlsTable/>
 
 ## Example
 

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -32,6 +32,10 @@ module.exports = function (RED) {
                 const off = RED.util.evaluateNodeProperty(config.offvalue, config.offvalueType, wNode)
                 msg.payload = value ? on : off
 
+                if (config.topic || config.topicType) {
+                    msg = await appendTopic(RED, config, node, msg)
+                }
+
                 datastore.save(group.getBase(), node, msg)
 
                 // simulate Node-RED node receiving an input


### PR DESCRIPTION
## Description

- Prevents that a message without `msg.payload` can change the switch state, specifically if the message only has `msg.enabled` for example.
- Make sure that `topic` is added to message in case a message is sent by switch toggle before a message was sent to the switch by Node-Red (#456)

## Related Issue(s)

Partial Fix #622 , regarding the topic issue (when is configured to be `msg.topic`), it happens with other widgets, the best option I can think at the moment for this widget is that in the `onInput` handler if the current message does not has a ` topic` to get the `topic` from the last message and add it to this new message, or in this case the `topic` should be handled as a `ui_update` property and saved/restored from `statestore`.

Closes #366 (It was already supported, just to close the issue)

Fix #456 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

