### PR TITLE
UI-Text-Input: Prevent text delete when no msg.payload is present

### DIFF
--- a/docs/nodes/widgets/ui-text-input.md
+++ b/docs/nodes/widgets/ui-text-input.md
@@ -16,6 +16,10 @@ props:
     Send On "Focus Leave": Sends a msg when the text input loses focus. Will always send, even if the value has not changed.
     Send On "Press Enter": Sends a msg when the user presses the enter key. Will always send, even if the value has not changed.
     Send On "Clear Button": Send a msg when the user clear the text input using the clear button, the "Clear Selection" button must be enabled.
+controls:
+    enabled:
+        example: true | false
+        description: Allow control over whether or not the text-input is enabled
 dynamic:
     Class:
         payload: msg.class
@@ -36,6 +40,10 @@ Adds a single text input row to your dashboard, with a configurable "type" (text
 ## Dynamic Properties
 
 <DynamicPropsTable/>
+
+## Controls
+
+<ControlsTable/>
 
 ## Example
 

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -112,9 +112,6 @@ export default {
     created () {
         // can't do this in setup as we are using custom onInput function that needs access to 'this'
         useDataTracker(this.id, this.onInput, this.onLoad, null)
-
-        // let Node-RED know that this widget has loaded
-        this.$socket.emit('widget-load', this.id)
     },
     methods: {
         onInput (msg) {

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -35,12 +35,10 @@ export default {
         props: { type: Object, default: () => ({}) },
         state: { type: Object, default: () => ({}) }
     },
-    setup (props) {
-        useDataTracker(props.id)
-    },
     data () {
         return {
-            delayTimer: null
+            delayTimer: null,
+            textValue: null
         }
     },
     computed: {
@@ -91,13 +89,14 @@ export default {
         },
         value: {
             get () {
-                return this.messages[this.id]?.payload
+                return this.textValue
             },
             set (val) {
                 if (this.value === val) {
                     return // no change
                 }
                 const msg = this.messages[this.id] || {}
+                this.textValue = val
                 msg.payload = val
                 this.messages[this.id] = msg
             }
@@ -110,7 +109,36 @@ export default {
             }
         }
     },
+    created () {
+        // can't do this in setup as we are using custom onInput function that needs access to 'this'
+        useDataTracker(this.id, this.onInput, this.onLoad, null)
+
+        // let Node-RED know that this widget has loaded
+        this.$socket.emit('widget-load', this.id)
+    },
     methods: {
+        onInput (msg) {
+            // update our vuex store with the value retrieved from Node-RED
+            this.$store.commit('data/bind', {
+                widgetId: this.id,
+                msg
+            })
+            // make sure our v-model is updated to reflect the value from Node-RED
+            if (msg.payload !== undefined) {
+                this.textValue = msg.payload
+            }
+        },
+        onLoad (msg) {
+            // update vuex store to reflect server-state
+            this.$store.commit('data/bind', {
+                widgetId: this.id,
+                msg
+            })
+            // make sure we've got the relevant option selected on load of the page
+            if (msg.payload !== undefined) {
+                this.textValue = msg.payload
+            }
+        },
         send: function () {
             this.$socket.emit('widget-change', this.id, this.value)
         },


### PR DESCRIPTION
## Description

- Prevents that a message without `msg.payload` can delete the text, specifically if the message only has `msg.enabled` for example.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

