### PR TITLE
UI-Form: Allow `msg.enable`

### DIFF
--- a/nodes/widgets/ui_form.html
+++ b/nodes/widgets/ui_form.html
@@ -51,7 +51,8 @@
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
                 topicType: { value: 'msg' },
                 splitLayout: { value: '' },
-                className: { value: '' }
+                className: { value: '' },
+                passthru: { value: false }
             },
             inputs: 1,
             outputs: 1,
@@ -60,6 +61,9 @@
             label: function () { return this.name || this.label || 'form' },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },
             oneditprepare: function () {
+                // Set passthru to `false` to prevent message pass through in Form widget
+                this.passthru = false
+
                 if ($('#node-input-submit').val() === null) { $('#node-input-submit').val('submit') }
                 if ($('#node-input-cancel').val() === null) { $('#node-input-cancel').val('cancel') }
                 // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up

--- a/nodes/widgets/ui_form.html
+++ b/nodes/widgets/ui_form.html
@@ -61,9 +61,6 @@
             label: function () { return this.name || this.label || 'form' },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },
             oneditprepare: function () {
-                // Set passthru to `false` to prevent message pass through in Form widget
-                this.passthru = false
-
                 if ($('#node-input-submit').val() === null) { $('#node-input-submit').val('submit') }
                 if ($('#node-input-cancel').val() === null) { $('#node-input-cancel').val('cancel') }
                 // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up

--- a/nodes/widgets/ui_form.js
+++ b/nodes/widgets/ui_form.js
@@ -2,6 +2,7 @@ const statestore = require('../store/state.js')
 
 module.exports = function (RED) {
     function FormNode (config) {
+        config.passthru = false
         RED.nodes.createNode(this, config)
 
         const node = this

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -4,6 +4,7 @@ const { appendTopic } = require('../utils/index.js')
 module.exports = function (RED) {
     function SwitchNode (config) {
         // create node in Node-RED
+        config.passthru = false
         RED.nodes.createNode(this, config)
 
         const node = this

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -4,7 +4,6 @@ const { appendTopic } = require('../utils/index.js')
 module.exports = function (RED) {
     function SwitchNode (config) {
         // create node in Node-RED
-        config.passthru = false
         RED.nodes.createNode(this, config)
 
         const node = this

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -74,11 +74,11 @@ export default {
             const option = this.options
             option.forEach(opt => {
                 if (opt.type === 'checkbox' || opt.type === 'switch') {
-                    if (this.input[opt.key] === undefined || this.input[opt.key] === null) {
+                    if (typeof (this.input[opt.key]) === 'undefined' || this.input[opt.key] === null) {
                         this.input[opt.key] = false
                     }
                 } else if (opt.type === 'number') {
-                    if (this.input[opt.key] === undefined || this.input[opt.key] === null) {
+                    if (typeof (this.input[opt.key]) === 'undefined' || this.input[opt.key] === null) {
                         this.input[opt.key] = null
                     } else {
                         if (isNaN(this.input[opt.key])) {
@@ -88,7 +88,7 @@ export default {
                         }
                     }
                 } else {
-                    if (this.input[opt.key] === undefined || this.input[opt.key] === null) {
+                    if (typeof (this.input[opt.key]) === 'undefined' || this.input[opt.key] === null) {
                         this.input[opt.key] = ''
                     }
                 }

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -127,8 +127,7 @@ export default {
                 for (const key in payload) {
                     this.input[key] = payload[key]
                 }
-                // May not be the best way, but if we call this directly will give error on the first `input`, it seems that vue has not yet updated
-                setTimeout(() => { this.validate() }, 0)
+                this.$nextTick(() => { this.validate() })
             }
         },
         onDynamicProperties (msg) {

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -83,6 +83,9 @@ export default {
         reset () {
             this.$refs.form.reset()
         },
+        validate () {
+            this.$refs.form.validate()
+        },
         rules (row) {
             if (row.required) {
                 // is required
@@ -100,6 +103,8 @@ export default {
                 for (const key in payload) {
                     this.input[key] = payload[key]
                 }
+                // May not be the best way, but if we call this directly will give error on the first `input`, it seems that vue has not yet updated
+                setTimeout(() => { this.validate() }, 0)
             }
         },
         onDynamicProperties (msg) {

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -1,6 +1,6 @@
 <template>
     <label v-if="label" class="nrdb-ui-form-label">{{ label }}</label>
-    <v-form ref="form" v-model="isValid" validate-on="blur" @submit.prevent="onSubmit">
+    <v-form ref="form" v-model="isValid" :disabled="!state.enabled" validate-on="blur" @submit.prevent="onSubmit">
         <div class="nrdb-ui-form-rows" :class="{'nrdb-ui-form-rows--split': props.splitLayout}">
             <div v-for="row in options" :key="row.key" class="nrdb-ui-form-row" :data-form="`form-row-${row.key}`">
                 <v-checkbox v-if="row.type === 'checkbox'" v-model="input[row.key]" :label="row.label" hide-details="auto" />
@@ -20,8 +20,8 @@
             </div>
         </div>
         <div class="nrdb-ui-form-actions">
-            <v-btn data-action="form-submit" type="submit" variant="flat" size="large" :disabled="!isValid">{{ props.submit || 'submit' }}</v-btn>
-            <v-btn v-if="props.cancel" data-action="form-clear" variant="outlined" size="large" @click="clear">{{ props.cancel }}</v-btn>
+            <v-btn data-action="form-submit" type="submit" variant="flat" size="large" :disabled="submitEnabled">{{ props.submit || 'submit' }}</v-btn>
+            <v-btn v-if="props.cancel" data-action="form-clear" variant="outlined" :disabled="!state.enabled" size="large" @click="clear">{{ props.cancel }}</v-btn>
         </div>
     </v-form>
 </template>
@@ -36,7 +36,8 @@ export default {
     inject: ['$socket'],
     props: {
         id: { type: String, required: true },
-        props: { type: Object, default: () => ({}) }
+        props: { type: Object, default: () => ({}) },
+        state: { type: Object, default: () => ({}) }
     },
     data () {
         return {
@@ -55,6 +56,9 @@ export default {
         },
         options: function () {
             return this.dynamic.options !== null ? this.dynamic.options : this.props.options
+        },
+        submitEnabled: function () {
+            return !(this.isValid && !!this.state.enabled)
         }
     },
     created () {

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -1,6 +1,6 @@
 <template>
     <label v-if="label" class="nrdb-ui-form-label">{{ label }}</label>
-    <v-form ref="form" v-model="isValid" :disabled="!state.enabled" validate-on="blur" @submit.prevent="onSubmit">
+    <v-form ref="form" v-model="isValid" :disabled="!state.enabled" validate-on="input" @submit.prevent="onSubmit">
         <div class="nrdb-ui-form-rows" :class="{'nrdb-ui-form-rows--split': props.splitLayout}">
             <div v-for="row in options" :key="row.key" class="nrdb-ui-form-row" :data-form="`form-row-${row.key}`">
                 <v-checkbox v-if="row.type === 'checkbox'" v-model="input[row.key]" :label="row.label" hide-details="auto" />

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -70,6 +70,20 @@ export default {
     },
     methods: {
         onSubmit: function () {
+            // Prevent sending null for switch and combobox, and if other fields not present, send empty string
+            const option = this.options
+            option.forEach(opt => {
+                if (opt.type === 'checkbox' || opt.type === 'switch') {
+                    if (this.input[opt.key] === undefined || this.input[opt.key] === null) {
+                        this.input[opt.key] = false
+                    }
+                } else {
+                    if (this.input[opt.key] === undefined || this.input[opt.key] === null) {
+                        this.input[opt.key] = ''
+                    }
+                }
+            })
+
             this.$socket.emit('widget-action', this.id, {
                 payload: this.input
             })

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -70,12 +70,22 @@ export default {
     },
     methods: {
         onSubmit: function () {
-            // Prevent sending null for switch and combobox, and if other fields not present, send empty string
+            // Prevent sending null for switch and combobox, if type number send as Number or null if nothing present on text field and if other fields not present, send empty string
             const option = this.options
             option.forEach(opt => {
                 if (opt.type === 'checkbox' || opt.type === 'switch') {
                     if (this.input[opt.key] === undefined || this.input[opt.key] === null) {
                         this.input[opt.key] = false
+                    }
+                } else if (opt.type === 'number') {
+                    if (this.input[opt.key] === undefined || this.input[opt.key] === null) {
+                        this.input[opt.key] = null
+                    } else {
+                        if (isNaN(this.input[opt.key])) {
+                            this.input[opt.key] = null
+                        } else {
+                            this.input[opt.key] = Number(this.input[opt.key])
+                        }
                     }
                 } else {
                     if (this.input[opt.key] === undefined || this.input[opt.key] === null) {


### PR DESCRIPTION
## Description

Several changes to `UI-Form`:

- Allow `ui-form` to accept the control message `msg.enabled`
- Prevent widget to forward a input message to output
- Validate fields (to enable `submit` button) when pre-loading the form values via `msg.payload`, #1069  
- Change trigger for validation from `blur` to `input` to prevent double click for validation to occur, #935 
- Send all form properties in `msg.payload` message, if after a `clear` the user did not interact with some field it would not be sent
- Make sure that fields `switch` and `checkbox` are sent as values `true` or `false`
- If field is type `number` send value as Number or null if no number present (same behaviour as DB1), #342 

## Related Issue(s)

Fix #1069 
Fix #935 
Fix #342 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

