### PR TITLE
Alter UITemplate dataTracker bind to anonymous component

### DIFF
--- a/ui/src/widgets/ui-template/UITemplate.vue
+++ b/ui/src/widgets/ui-template/UITemplate.vue
@@ -164,6 +164,8 @@ export default {
                 ...component?.methods
             },
             created () {
+                useDataTracker(props.id)
+
                 if (component?.beforeCreate) {
                     // run any generic JS code user has defined outisde of a VueJS component
                     // eslint-disable-next-line no-eval

--- a/ui/src/widgets/ui-template/UITemplate.vue
+++ b/ui/src/widgets/ui-template/UITemplate.vue
@@ -164,7 +164,7 @@ export default {
                 ...component?.methods
             },
             created () {
-                useDataTracker(props.id)
+                this.$dataTracker(props.id)
 
                 if (component?.beforeCreate) {
                     // run any generic JS code user has defined outisde of a VueJS component
@@ -189,9 +189,6 @@ export default {
             id: props.id,
             props: props.props
         })
-    },
-    created () {
-        this.$dataTracker(this.id)
     },
     errorCaptured: (err, vm, info) => {
         console.error('errorCaptured', err, vm, info)


### PR DESCRIPTION
## Description

bind the dataTracker with the mounted component instead of the parent to preserve reactivity after socket disconnect/reconnect
 
## Related Issue(s)

closes #747

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

