### PR TITLE
Fix code example in option 2 (bad arrow function)

### DIFF
--- a/docs/nodes/widgets/ui-template.md
+++ b/docs/nodes/widgets/ui-template.md
@@ -126,8 +126,10 @@ Option 2:
 We can alternatively add a custom socket listener to the `msg-input:<id>` event. This is useful if you want to listen to messages _only_ when they are received, and not when the widget first loads.
 
 ```js
-// runs only onInput
-this.$socket.on('msg-input:' + this.id, (msg) = { ... })
+this.$socket.on('msg-input:' + this.id, (msg) => {
+    // do stuff with msg
+    // runs only when messages are received
+})
 ```
 
 This can be added into the widget's `mounted () { }` handler


### PR DESCRIPTION
## Description

copy paste code results in error due to missing `>` in example.

this PR provides a copy+pasteable example for option 2

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

