### PR TITLE
fix failing form e2e test due to multiple submit buttons present on page

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,6 +6,8 @@ module.exports = defineConfig({
         specPattern: 'cypress/tests/**/*.spec.{js,jsx,ts,tsx}',
         setupNodeEvents (on, config) {
             // implement node event listeners here
-        }
+        },
+        defaultCommandTimeout: 10000,
+        retries: { runMode: 3, openMode: 1 }
     }
 })

--- a/cypress/tests/widgets/form.spec.js
+++ b/cypress/tests/widgets/form.spec.js
@@ -30,7 +30,9 @@ describe('Node-RED Dashboard 2.0 - Forms', () => {
         cy.get('[data-form="form-row-name"]').find('input[type="text"]').type('John Smith', { force: true })
         cy.focused().blur()
 
-        cy.get('[data-action="form-submit"]').should('not.be.disabled')
+        cy.get('#nrdb-ui-group-dashboard-ui-group').within(() => {
+            cy.get('[data-action="form-submit"]').should('not.be.disabled')
+        })
     })
 })
 


### PR DESCRIPTION
## Description

fixes constantly failing form test due to multiple selectors being present on the dashboard

## Related Issue(s)
https://github.com/FlowFuse/node-red-dashboard/issues/882

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

