### PR TITLE
UI-Slider: Add missing properties to msg.`ui_update`

### DIFF
--- a/docs/nodes/widgets/ui-slider.md
+++ b/docs/nodes/widgets/ui-slider.md
@@ -17,9 +17,9 @@ props:
         dynamic: true
     Color:
         description: main - color of the slider and thumb; track - color of the slider track; thumb - color of the handle. It could be the name of a color (red, green, blue, ...) or a Hex color code (#b5b5b5).
-        dynamic: false
+        dynamic: true
     Icons:
-        description: Add <a href="https://pictogrammers.com/library/mdi/">mdi icon</a> before and after the slider. For example, "mdi-minus". Click option make icons clickable to change the value by step.
+        description: Add <a href="https://pictogrammers.com/library/mdi/">mdi icon</a> before and after the slider. For example, "minus". There is no need to include the "mdi-" prefix, just the name of the icon.
         dynamic: true    
     Output: Defines when a msg is emitted, either as the slider is moved, or as the slider is released.        
 dynamic:
@@ -41,6 +41,21 @@ dynamic:
     Range (max):
         payload: msg.ui_update.max
         structure: ["Number"]
+    Icon Prepend:
+        payload: msg.ui_update.iconPrepend
+        structure: ["String"]
+    Icon Append:
+        payload: msg.ui_update.iconAppend
+        structure: ["String"]
+    Color:
+        payload: msg.ui_update.color
+        structure: ["String"]
+    Color Track:
+        payload: msg.ui_update.colorTrack
+        structure: ["String"]
+    Color Thumb:
+        payload: msg.ui_update.colorThumb
+        structure: ["String"]
     Class:
         payload: msg.ui_update.class
         structure: ["String"]

--- a/nodes/widgets/locales/en-US/ui_slider.html
+++ b/nodes/widgets/locales/en-US/ui_slider.html
@@ -15,20 +15,20 @@
         <dd>Defined when the thumb of the slider will show. Defaults to 'On Drag'.</dd>
         <dt>Show Ticks <span class="property-type">'never' | 'on drag' | 'always'</span></dt>
         <dd>Defined when the ticks will be visible on the track. Defaults to 'Always'.</dd>
-        <dt>Range</dt>
+        <dt>Range <span class="property-type">number</span></dt>
         <dd>
             min - the minimum value the slider can be changed to; max - the maximum value the
             slider can be changed to; step - the increment/decrement value when the slider is moved.
         </dd>
-        <dt>Colors</dt>
+        <dt>Colors <span class="property-type">string</dt>
         <dd>
             main - color of the slider and thumb; track - color of the slider track; thumb - color of the handle.
             It could be the name of a color (red, green, blue, ...) or a Hex color code (#b5b5b5).
         </dd>
-        <dt>Icons</dt>
+        <dt>Icons <span class="property-type">string</dt>
         <dd>
             Add <a href="https://pictogrammers.com/library/mdi/">mdi icon</a> before and after the slider.
-            For example, "mdi-minus". Click option make icons clickable to change the value by step.
+            For example, "minus". There is no need to include the "mdi-" prefix, just the name of the icon.
         </dd>
     </dl>
     <h3>Dynamic Properties (Inputs)</h3>
@@ -56,6 +56,26 @@
     <dl class="message-properties">
         <dt class="optional">max <span class="property-type">number</span></dt>
         <dd>The maximum value available on the slider.</dd>
+    </dl>
+    <dl class="message-properties">
+        <dt class="optional">iconPrepend <span class="property-type">string</span></dt>
+        <dd>Add icon to the left side of slider.</dd>
+    </dl>
+    <dl class="message-properties">
+        <dt class="optional">iconAppend <span class="property-type">string</span></dt>
+        <dd>Add icon to the right side of slider.</dd>
+    </dl>
+    <dl class="message-properties">
+        <dt class="optional">color <span class="property-type">string</span></dt>
+        <dd>Define slider color, see <a href="https://vuetifyjs.com/en/components/sliders/#colors">vuetify documentation</a> </dd>
+    </dl>
+    <dl class="message-properties">
+        <dt class="optional">colorTrack <span class="property-type">string</span></dt>
+        <dd>Define slider track color, see <a href="https://vuetifyjs.com/en/components/sliders/#colors">vuetify documentation</a> </dd>
+    </dl>
+    <dl class="message-properties">
+        <dt class="optional">colorThumb <span class="property-type">string</span></dt>
+        <dd>Define thumb color, see <a href="https://vuetifyjs.com/en/components/sliders/#colors">vuetify documentation</a> </dd>
     </dl>
     <dl class="message-properties">
         <dt class="optional">class <span class="property-type">string</span></dt>

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -189,11 +189,11 @@
             <div style="display: grid; grid-template-columns: repeat(3, 1fr); width: 70%">
                 <div>
                     <span for="node-input-iconPrepend">before</span>
-                    <input type="text" id="node-input-iconPrepend" placeholder="mdi-minus" style="width:60px">
+                    <input type="text" id="node-input-iconPrepend" placeholder="minus" style="width:60px">
                 </div>
                 <div>
                     <span for="node-input-iconAppend">after</span>
-                    <input type="text" id="node-input-iconAppend" placeholder="mdi-plus" style="width:60px">
+                    <input type="text" id="node-input-iconAppend" placeholder="plus" style="width:60px">
                 </div>
             </div>
         </div>

--- a/nodes/widgets/ui_slider.js
+++ b/nodes/widgets/ui_slider.js
@@ -74,10 +74,10 @@ module.exports = function (RED) {
                         statestore.set(group.getBase(), node, msg, 'color', updates.color)
                     }
                     if (typeof (updates.colorTrack) !== 'undefined') {
-                        statestore.set(group.getBase(), node, msg, 'color-track', updates.colorTrack)
+                        statestore.set(group.getBase(), node, msg, 'colorTrack', updates.colorTrack)
                     }
                     if (typeof (updates.colorThumb) !== 'undefined') {
-                        statestore.set(group.getBase(), node, msg, 'color-thumb', updates.colorThumb)
+                        statestore.set(group.getBase(), node, msg, 'colorThumb', updates.colorThumb)
                     }
                 }
                 return msg

--- a/ui/src/widgets/ui-slider/UISlider.vue
+++ b/ui/src/widgets/ui-slider/UISlider.vue
@@ -9,7 +9,7 @@
         :min="min" :direction="direction"
         :tick-size="4" :track-size="4"
         :color="color" :track-color="colorTrack" :thumb-color="colorThumb"
-        :max="max" :step="props.step || 1" :show-ticks="showTicks"
+        :max="max" :step="step || 1" :show-ticks="showTicks"
         @update:model-value="onChange" @end="onBlur"
     />
 </template>

--- a/ui/src/widgets/ui-slider/UISlider.vue
+++ b/ui/src/widgets/ui-slider/UISlider.vue
@@ -168,6 +168,15 @@ export default {
             if (typeof updates.iconPrepend !== 'undefined') {
                 this.dynamic.iconPrepend = updates.iconPrepend
             }
+            if (typeof updates.color !== 'undefined') {
+                this.dynamic.color = updates.color
+            }
+            if (typeof updates.colorTrack !== 'undefined') {
+                this.dynamic.colorTrack = updates.colorTrack
+            }
+            if (typeof updates.colorThumb !== 'undefined') {
+                this.dynamic.colorThumb = updates.colorThumb
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

- Property `step` was not being used from dynamic properties in the vue template definition (was `props.step`)
- Properties `color`, `colorTrack` and `colorThumb` where not being update in `onDynamicProperties` function
- Properties `colorTrack` and `colorThumb` where not being correctly stored on `statestore`
- Fix / Add Properties to docs and help page

## Related Issue(s)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

