### PR TITLE
Clear unused keys when receiving `msg.ui_update.options`, to prevent sending old keys on next submit

### DIFF
--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -71,6 +71,16 @@ export default {
     methods: {
         onSubmit: function () {
             const option = this.options
+            // Clear unused keys from `input`, to prevent sending old keys on next submit
+            const allowed = option.map(opt => opt.key)
+            this.input = Object.keys(this.input)
+                .filter(key => allowed.includes(key))
+                .reduce((obj, key) => {
+                    return {
+                        ...obj,
+                        [key]: this.input[key]
+                    }
+                }, {})
             // Prevent sending null for switch and combobox, if type number send as Number or null if nothing present on text field and if other fields not present, send empty string
             option.forEach(opt => {
                 if (opt.type === 'checkbox' || opt.type === 'switch') {
@@ -137,16 +147,6 @@ export default {
             }
             if (typeof updates?.options !== 'undefined') {
                 this.dynamic.options = updates.options
-                // Clear unused keys from `input`, to prevent sending old keys on next submit
-                const allowed = this.options.map(opt => opt.key)
-                this.input = Object.keys(this.input)
-                    .filter(key => allowed.includes(key))
-                    .reduce((obj, key) => {
-                        return {
-                            ...obj,
-                            [key]: this.input[key]
-                        }
-                    }, {})
             }
         }
     }

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -70,9 +70,9 @@ export default {
     },
     methods: {
         onSubmit: function () {
-            const option = this.options
+            const options = this.options
             // Clear unused keys from `input`, to prevent sending old keys on next submit
-            const allowed = option.map(opt => opt.key)
+            const allowed = options.map(opt => opt.key)
             this.input = Object.keys(this.input)
                 .filter(key => allowed.includes(key))
                 .reduce((obj, key) => {
@@ -82,7 +82,7 @@ export default {
                     }
                 }, {})
             // Prevent sending null for switch and combobox, if type number send as Number or null if nothing present on text field and if other fields not present, send empty string
-            option.forEach(opt => {
+            options.forEach(opt => {
                 if (opt.type === 'checkbox' || opt.type === 'switch') {
                     if (typeof (this.input[opt.key]) === 'undefined' || this.input[opt.key] === null) {
                         this.input[opt.key] = false

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -70,8 +70,8 @@ export default {
     },
     methods: {
         onSubmit: function () {
-            // Prevent sending null for switch and combobox, if type number send as Number or null if nothing present on text field and if other fields not present, send empty string
             const option = this.options
+            // Prevent sending null for switch and combobox, if type number send as Number or null if nothing present on text field and if other fields not present, send empty string
             option.forEach(opt => {
                 if (opt.type === 'checkbox' || opt.type === 'switch') {
                     if (typeof (this.input[opt.key]) === 'undefined' || this.input[opt.key] === null) {
@@ -137,6 +137,16 @@ export default {
             }
             if (typeof updates?.options !== 'undefined') {
                 this.dynamic.options = updates.options
+                // Clear unused keys from `input`, to prevent sending old keys on next submit
+                const allowed = this.options.map(opt => opt.key)
+                this.input = Object.keys(this.input)
+                    .filter(key => allowed.includes(key))
+                    .reduce((obj, key) => {
+                        return {
+                            ...obj,
+                            [key]: this.input[key]
+                        }
+                    }, {})
             }
         }
     }


### PR DESCRIPTION
## Description

When receiving a new message with new form elements to update in the form, delete old/unused values to prevent sending them on the next form `submit`

## Related Issue(s)

Closes #343

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

