### PR TITLE
UI-Button: Fix eslint warning

### DIFF
--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -10,6 +10,7 @@
         <template v-if="appendIcon" #append>
             <v-icon :color="iconColor" />
         </template>
+        <!-- eslint-disable-next-line vue/no-v-html -->
         <span v-if="label" :style="{'color': textColor}" v-html="label" />
     </v-btn>
 </template>


### PR DESCRIPTION
## Description

On PR #1087  when was added the possibility of the `ui-button` label to use `html` a warning start appearing when running `eslint`.

This add the eslint rule to disable eslint for that line for this specific warning.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

