### PR TITLE
Fix: Ensure we check for existence of msg before using msg.payload

### DIFF
--- a/ui/src/widgets/ui-button-group/UIButtonGroup.vue
+++ b/ui/src/widgets/ui-button-group/UIButtonGroup.vue
@@ -97,7 +97,7 @@ export default {
                 msg
             })
             // make sure we've got the relevant option selected on load of the page
-            if (msg.payload !== undefined) {
+            if (msg?.payload !== undefined) {
                 if (Array.isArray(msg.payload) && msg.payload.length === 0) {
                     this.selection = null
                 } else {

--- a/ui/src/widgets/ui-event/UIEvent.vue
+++ b/ui/src/widgets/ui-event/UIEvent.vue
@@ -37,7 +37,7 @@ export default {
     },
     created () {
         // can't do this in setup as we have custom onInput function
-        this.$dataTracker(this.id, null, this.onLoad)
+        this.$dataTracker(this.id)
         this.page = this.pages[this.$route.meta.id]
         this.pageview()
     },

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -26,7 +26,7 @@
 import { mapState } from 'vuex' // eslint-disable-line import/order
 
 export default {
-    name: 'DBUIText',
+    name: 'DBUITextInput',
     inject: ['$socket', '$dataTracker'],
     props: {
         id: { type: String, required: true },
@@ -130,7 +130,7 @@ export default {
                 msg
             })
             // make sure we've got the relevant option selected on load of the page
-            if (msg.payload !== undefined) {
+            if (msg?.payload !== undefined) {
                 this.textValue = msg.payload
             }
         },


### PR DESCRIPTION
## Description

- Removes `null` pointer in UI Event
- Ensure we check for existence of `msg` onLoad for Button Group
    - Introduced in: https://github.com/FlowFuse/node-red-dashboard/pull/1089
- Ensure we check for existence of `msg` onLoad for UI Text
    - Introduced in: https://github.com/FlowFuse/node-red-dashboard/pull/1091