### PR TITLE
UI Switch - Add "Indicator" mode

### DIFF
--- a/docs/nodes/widgets/ui-switch.md
+++ b/docs/nodes/widgets/ui-switch.md
@@ -4,12 +4,14 @@ props:
     Group: Defines which group of the UI Dashboard this widget will render in.
     Size: Controls the width of the button with respect to the parent group. Maximum value is the width of the group.
     Label: The text shown within the button.
-    On Payload: The type & value to output in <code>msg.payload</code> when the switch is turned on.
-    Off Payload: The type & value to output in <code>msg.payload</code> when the switch is turned off.
     On Icon: If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "on" state. No need to include the <code>mdi</code> prefix.
     Off Icon: If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "off" state. No need to include the <code>mdi</code> prefix.
     On Color: If provided with a icons, this colour is used for the icon when in "on" state
     Off Color: If provided with a icons, this colour is used for the icon when in "off" state
+    Passthrough: If enabled, the widget will pass through the input message to the output.
+    Indicator: Only available when "Passthrough" is set to <code>false</code>. Defines whether the switch shows the status of the output, or any provided input via <code>msg.payload</code>.
+    On Payload: The type & value to output in <code>msg.payload</code> when the switch is turned on.
+    Off Payload: The type & value to output in <code>msg.payload</code> when the switch is turned off.
 controls:
     enabled:
         example: true | false

--- a/docs/user/migration/ui_switch.json
+++ b/docs/user/migration/ui_switch.json
@@ -64,8 +64,8 @@
         },
         {
             "property": "indicator",
-            "changes": -1,
-            "notes": "<a href='https://github.com/FlowFuse/node-red-dashboard/issues/210' target='_blank'>Issue #210</a>"
+            "changes": null,
+            "notes": null
         },
         {
             "property": "'on' payload",

--- a/nodes/widgets/locales/en-US/ui_switch.html
+++ b/nodes/widgets/locales/en-US/ui_switch.html
@@ -16,17 +16,35 @@
     </p>
     <p>
         The switch state can be updated by an incoming <code>msg.payload</code>. The values must either be <code>true</code>/<code>false</code>
-        or match the specified type (number, string, etc) in the node's configuration.</p>
-    <!-- <p>
-        The label can also be set by a message property by setting
-    the field to the name of the property, for example <code>{{msg.topic}}</code>.</p>
-    <p>If a <b>Topic</b> is specified, it will be added to the output as <code>msg.topic</code>.</p> -->
-    <!-- <p>Setting <code>msg.enabled</code> to <code>false</code> will disable the switch widget.</p> -->
-    <!-- <p>
-        If a <b>Class</b> is specified, it will be added to the parent card. This way you can style the card
-        and the elements inside it with custom CSS. The Class can be set at runtime by setting a
-        <code>msg.className</code> string property.
-    </p> -->
+        or match the specified type (number, string, etc) in the node's configuration.
+    </p>
+    <h3>Properties</h3>
+    <dl class="message-properties">
+        <dt>Icon Position<span class="property-type">left | right</span></dt>
+        <dd>If "Icon" is defined, this property controls which side of the "Label" the icon will render on</dd>
+        <dt>Label <span class="property-type">string</span></dt>
+        <dd>The text shown within the button. If not provided, then the button will only render the icon. It supports HTML content</dd>
+        <dt>Icon <span class="property-type">default | custom</span></dt>
+        <dd>Either use the "default" switch appearance, or define your own custom icons.</dd>
+        <dt>On Icon <span class="property-type">string</span></dt>
+        <dd>If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "on" state. No need to include the mdi prefix.</dd>
+        <dt>Off Icon <span class="property-type">string</span></dt>
+        <dd>If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "off" state. No need to include the mdi prefix.</dd>
+        <dt>On Color <span class="property-type">string</span></dt>
+        <dd>If provided with icons, this color is used for the icon when in "on" state</dd>
+        <dt>Off Color <span class="property-type">string</span></dt>
+        <dd>If provided with icons, this color is used for the icon when in "off" state</dd>
+        <dt>Passthrough <span class="property-type">boolean</span></dt>
+        <dd>When a message is received into this node, should it be passed through to any connected output.</dd>
+        <dt>Indicator <span class="property-type">boolean</span></dt>
+        <dd>Only available when "Passthrough" is set to <code>false</code>. Defines whether the switch shows the status of the output, or instead, the input provided through <code>msg.payload</code>.</dd>
+        <dt>Off Payload <span class="property-type">any</span></dt>
+        <dd>The type & value to output in msg.payload when the switch is turned off.</dd>
+        <dt>On Payload <span class="property-type">any</span></dt>
+        <dd>The type & value to output in msg.payload when the switch is turned on.</dd>
+        <dt>Off Payload <span class="property-type">any</span></dt>
+        <dd>The type & value to output in msg.payload when the switch is turned off.</dd>
+    </dl>
     <h3>Dynamic Properties (Inputs)</h3>
     <p>Any of the following can be appended to a <code>msg.</code> in order to override or set properties on this node at runtime.</p>
     <dl class="message-properties">

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -25,6 +25,7 @@
                 },
                 height: { value: 0 },
                 passthru: { value: false },
+                decouple: { value: false },
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
                 topicType: { value: 'msg' },
                 style: { value: '' },
@@ -100,12 +101,19 @@
 
                 $('#node-input-passthru').on('change', function () {
                     if (this.checked) {
+                        $('#node-field-decouple').val('false')
                         $('.form-row-decouple').hide()
-                        $('#node-input-decouple').val('false')
                     } else {
                         $('.form-row-decouple').show()
                     }
                 })
+
+                if (typeof this.decouple === 'undefined') {
+                    // backward compatibility
+                    this.decouple = false
+                }
+                // set decouple option correctly
+                $('#node-field-decouple').val(this.decouple.toString()).change()
 
                 // use jQuery UI tooltip to convert the plain old title attribute to a nice tooltip
                 $('.ui-node-popover-title').tooltip({
@@ -121,6 +129,13 @@
                     $('#node-input-officon').val('')
                     $('#node-input-oncolor').val('')
                     $('#node-input-offcolor').val('')
+                }
+
+                const decouple = $('#node-field-decouple').val()
+                if (decouple === 'true') {
+                    this.decouple = true
+                } else {
+                    this.decouple = false
                 }
             }
         })
@@ -191,6 +206,14 @@
     <div class="form-row">
         <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
         <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
+    <div class="form-row form-row-decouple">
+        <!-- do not us node-input-<property> so we can enforce boolean types -->
+        <label for="node-field-decouple"><i class="fa fa-toggle-on"></i> Indicator</label>
+        <select id="node-field-decouple" style="display: inline-block; vertical-align: middle; width:70%;">
+            <option value="false">Switch icon shows state of the output</option>
+            <option value="true">Switch icon shows state of the input</option>
+        </select>
     </div>
     <div class="form-row">
         <label style="width:auto" for="node-input-onvalue"><i class="fa fa-envelope-o"></i> When clicked, send:</label>

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -110,11 +110,13 @@ export default {
             }
         },
         toggle () {
-            if (this.props.decouple) {
-                this.loading = true
-            } else {
-                this.status = !this.status
-                this.$socket.emit('widget-change', this.id, this.status)
+            if (this.state.enabled) {
+                if (this.props.decouple) {
+                    this.loading = true
+                } else {
+                    this.status = !this.status
+                    this.$socket.emit('widget-change', this.id, this.status)
+                }
             }
         }
     }

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -1,8 +1,16 @@
 <template>
     <div class="nrdb-switch" :class="{'nrdb-nolabel': !props.label, [className]: !!className}">
         <label v-if="props.label" class="v-label">{{ props.label }}</label>
-        <v-switch v-if="!icon" v-model="status" :disabled="!state.enabled" :class="{'active': status}" hide-details="auto" color="primary" @update:model-value="onChange" />
-        <v-btn v-else variant="text" :disabled="!state.enabled" :icon="icon" :color="color" @click="toggle" />
+        <v-switch
+            v-if="!icon" v-model="status"
+            :disabled="!state.enabled" :class="{'active': status}"
+            hide-details="auto" color="primary"
+            :loading="loading ? (status === true ? 'secondary' : 'primary') : null"
+            readonly
+            @click="toggle"
+        />
+        <v-btn v-else-if="!loading" variant="text" :disabled="!state.enabled" :icon="icon" :color="color" @click="toggle" />
+        <v-progress-circular v-else indeterminate color="primary" />
     </div>
 </template>
 
@@ -19,7 +27,8 @@ export default {
     },
     data () {
         return {
-            selection: null
+            selection: null,
+            loading: false
         }
     },
     computed: {
@@ -63,6 +72,9 @@ export default {
                 msg.payload = val
                 this.selection = val
                 this.messages[this.id] = msg
+                if (this.decouple) {
+                    this.loading = true
+                }
             }
         }
     },
@@ -83,6 +95,7 @@ export default {
             // make sure our v-model is updated to reflect the value from Node-RED
             if (msg.payload !== undefined) {
                 this.selection = msg.payload
+                this.loading = false
             }
         },
         onLoad (msg) {
@@ -92,7 +105,7 @@ export default {
                 msg
             })
             // make sure we've got the relevant option selected on load of the page
-            if (msg.payload !== undefined) {
+            if (msg?.payload !== undefined) {
                 this.selection = msg.payload
             }
         },
@@ -102,14 +115,18 @@ export default {
             this.$socket.emit('widget-change', this.id, val)
         },
         toggle () {
-            this.status = !this.status
-            this.$socket.emit('widget-change', this.id, this.status)
+            if (this.props.decouple) {
+                this.loading = true
+            } else {
+                this.status = !this.status
+                this.$socket.emit('widget-change', this.id, this.status)
+            }
         }
     }
 }
 </script>
 
-<style scoped>
+<style>
 .nrdb-switch {
     display: flex;
     align-items: center;
@@ -126,5 +143,9 @@ export default {
 }
 .nrdb-switch.nrdb-nolabel .v-selection-control {
     justify-content: center;
+}
+.nrdb-switch > .v-progress-circular > svg {
+    width: 24px;
+    height: 24px;
 }
 </style>

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -109,11 +109,6 @@ export default {
                 this.selection = msg.payload
             }
         },
-        onChange (val) {
-            // only runs when clicked/changed in UI.
-            // inverted as the store doesn't quite update quick enough, but this is reliable method
-            this.$socket.emit('widget-change', this.id, val)
-        },
         toggle () {
             if (this.props.decouple) {
                 this.loading = true


### PR DESCRIPTION
## Description

- Adds in the "show input value" option that existed in Dashboard 1.0
- If active, then the switch will not auto-toggle when clicked, instead it will output a message, and only respond when a new message is received into the switch.
- Puts switch into "loading" state if decouple and user interacts
    - User can still click over and over, even whilst in "loading" and an event will still be broadcast

## Related Issue(s)

Closes #210 