### PR TITLE
Show node icons in sidebar

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1038,7 +1038,7 @@
             addItem: function (container, i, /** @type {DashboardItem} */ widget) {
                 const titleRow = $('<div>', { class: 'nrdb2-sb-list-header nrdb2-sb-widgets-list-header' }).appendTo(container)
                 $('<i class="nrdb2-sb-list-handle nrdb2-sb-widget-list-handle fa fa-bars"></i>').appendTo(titleRow)
-                let widgetIcon = 'fa fa-image'
+                let widgetIcon = 'fa ' + (widget.node._def.icon || 'fa-question').replace('font-awesome/', '')
                 if (widget.isSubflowInstance) {
                     // In this MVP, subflow instances are constrained to stay within own group.
                     container.parent().addClass('red-ui-editableList-item-constrained')


### PR DESCRIPTION
## Description

Hi guys,

I wanted to continue with the migration of my old dashboard, but I now noticed that all widgets in the sidebar have the same icon:

![image](https://github.com/user-attachments/assets/43487e93-a642-4fb1-ba3e-cf23ca245882)

I find this rather unclear.  Because it is hard to find fast some specific node and they all look like svg nodes (because I already use the fa-image icon for the svg node).

Via this pull request the icon of the (core or third-party) node is being used:

![image](https://github.com/user-attachments/assets/1c2e9aa0-8864-4956-94b5-8706ef3cc22d)

When - for some reason - the icon has no node (or we cannot find it), then the [question](https://fontawesome.com/v4/icon/question) fontawesome node will be displayed.

## Related Issue(s)

I don't see at first sight that an issue has been reported yet.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

