### PR TITLE
UI Chart: Fix missing entry for first of series (after 1st)

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -351,6 +351,8 @@ export default {
             }
 
             const sIndex = sLabels?.indexOf(label)
+            // are we adding a new datapoint to an existing x-value
+            const xIndex = xLabels.indexOf(datapoint.x)
 
             // the chart is empty, we're adding a new series
             if (sIndex === -1) {
@@ -360,8 +362,11 @@ export default {
 
                 // ensure we have a datapoint for the relevant series
                 const data = Array(sLabels.length + 1).fill({})
-                // define the data point for this series
-                data[sLabels.length] = datapoint
+                if (xIndex === -1) {
+                    data[xLabels.length] = datapoint
+                } else {
+                    data[xIndex] = datapoint
+                }
                 // add the new dataset to the chart
                 const d = {
                     backgroundColor: colorByIndex ? this.props.colors : this.props.colors[sLabels.length],
@@ -378,9 +383,7 @@ export default {
 
                 this.chart.data.datasets.push(d)
             } else {
-                // we're adding a new datapoint to an existing series
                 // have we seen this x-value before?
-                const xIndex = xLabels.indexOf(datapoint.x)
                 if (xIndex >= 0 && (this.props.xAxisType === 'category' || this.props.xAxisType === 'radial')) {
                     // yes, so we need to update the data at this index
                     this.chart.data.datasets[sIndex].data[xIndex] = datapoint


### PR DESCRIPTION
## Description

- When a data point came in for a new "Series", but we'd seen the x-value before, we were not assigning the index of the data point correctly.

## Related Issue(s)

Closes #1130 