### PR TITLE
DRAFT - Node icons in sidebar

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1038,7 +1038,12 @@
             addItem: function (container, i, /** @type {DashboardItem} */ widget) {
                 const titleRow = $('<div>', { class: 'nrdb2-sb-list-header nrdb2-sb-widgets-list-header' }).appendTo(container)
                 $('<i class="nrdb2-sb-list-handle nrdb2-sb-widget-list-handle fa fa-bars"></i>').appendTo(titleRow)
-                let widgetIcon = 'fa fa-image'
+
+                let widgetIcon = widget.node._def.icon || 'fa fa-question'
+                if (widget.node._def.icon.startsWith('font-awesome/')) {
+                    widgetIcon = 'fa ' + widget.node._def.icon.replace('font-awesome/', '')
+                }
+
                 if (widget.isSubflowInstance) {
                     // In this MVP, subflow instances are constrained to stay within own group.
                     container.parent().addClass('red-ui-editableList-item-constrained')
@@ -1047,7 +1052,17 @@
                     // apply a tooltip to further clarify this is a subflow
                     titleRow.attr('title', widget.subflowName || 'Subflow instance')
                 }
-                $('<i>', { class: 'nrdb2-sb-icon nrdb2-sb-widget-icon ' + widgetIcon }).appendTo(titleRow)
+
+                if (widgetIcon == 'nrdb2-sb-subflow-icon' || widgetIcon.startsWith('fa fa-')) {
+                    // Some ui nodes require a FontAwesome icon
+                    $('<i>', { class: 'nrdb2-sb-icon nrdb2-sb-widget-icon ' + widgetIcon }).appendTo(titleRow)
+                }
+                else {
+                    // Some ui nodes require a custom icon (png, svg, ...)
+                    const href = 'icons/' + widget.node._def.set.module + '/' + widgetIcon
+                    $('<image>', { class: 'nrdb2-sb-icon nrdb2-sb-widget-icon', href: href }).appendTo(titleRow)
+                }
+
                 $('<span>', { class: 'nrdb2-sb-title' }).text(widget.label?.trim() || widget.id).appendTo(titleRow)
                 const actions = $('<div>', { class: 'nrdb2-sb-list-header-actions' }).appendTo(titleRow)
                 addRowActions(actions, widget)

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -172,6 +172,10 @@
     /* indent the widgets */
     .nrdb2-sb-widgets-list-header .nrdb2-sb-widget-icon {
         margin-left: 3.5rem;
+        display: inline-block;
+        height: 14px;
+        width: 14px;
+        text-align: center;
     }
     /* apply subflow icon */
     .nrdb2-sb-widgets-list-header .nrdb2-sb-widget-icon.nrdb2-sb-subflow-icon {
@@ -1056,11 +1060,10 @@
                 if (widgetIcon == 'nrdb2-sb-subflow-icon' || widgetIcon.startsWith('fa fa-')) {
                     // Some ui nodes require a FontAwesome icon
                     $('<i>', { class: 'nrdb2-sb-icon nrdb2-sb-widget-icon ' + widgetIcon }).appendTo(titleRow)
-                }
-                else {
+                } else {
                     // Some ui nodes require a custom icon (png, svg, ...)
                     const href = 'icons/' + widget.node._def.set.module + '/' + widgetIcon
-                    $('<image>', { class: 'nrdb2-sb-icon nrdb2-sb-widget-icon', href: href }).appendTo(titleRow)
+                    $('<image>', { class: 'nrdb2-sb-icon nrdb2-sb-widget-icon', href, width: 14, height: 14 }).appendTo(titleRow)
                 }
 
                 $('<span>', { class: 'nrdb2-sb-title' }).text(widget.label?.trim() || widget.id).appendTo(titleRow)

--- a/nodes/widgets/icons/ui-markdown.svg
+++ b/nodes/widgets/icons/ui-markdown.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg xmlns="http://www.w3.org/2000/svg"
+aria-label="Markdown" role="img"
+viewBox="0 0 512 512"><path fill="white" d="M410 366H102C88 366 76 354 76 340V170c0-14 12 -26 26 -26h307c14 0 26 12 26 26v170c0 14-11 26 -25 26zM102 162c-4 0-9 4 -9 9v170c0 5 4 9 9 9h307c5 0 9-4 9 -9V170c0-5 -4 -9 -9 -9c1 0-307 0 -307 0zm26 153V196h34l34 43l34-43H265V314h-34v-68l-34 43l-34-43v68zm216 0l-52-57h34v-61h34v60h34z"/></svg>


### PR DESCRIPTION
## Description

Fix for [pull request](https://github.com/FlowFuse/node-red-dashboard/pull/1151).
The other PR assumed that all ui nodes use a FontAwesome icon, however some nodes have a custom (png, svg, ...) icon.

I had a look in the Network tab of the developer tools, and seems that all node icons are being loaded like this:
`.../icons/<node_module_name>/<icon_resource_name>`.  So I use the same mechanism, and my png test icon seems to be loaded correctly.

**_Known issue_**: the icons of nodes are always white on a transparant background, so they are nicely visible on top of their node in the flow editor.  However since the dashboard sidebar (with my current theme) is white, you won't see the icon although it is available:

![image](https://github.com/user-attachments/assets/a764b92d-2c0b-41db-81cd-4effe28beaa1)

Not sure how to solve this.  CSS isn't my best friend...

## Related Issue(s)

None

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

