### PR TITLE
DRAFT - Table send clicked column

### DIFF
--- a/ui/src/widgets/ui-table/UITable.vue
+++ b/ui/src/widgets/ui-table/UITable.vue
@@ -21,12 +21,12 @@
         <template #item="{ item, index, internalItem, isSelected, toggleSelect }">
             <tr
                 :class="{'nrdb-table-row-selectable': props.selectionType === 'click', 'nrdb-table-row-selected': selected === item}"
-                @click="props.selectionType === 'click' ? onRowClick(item) : {}"
+                @click="props.selectionType === 'click' ? onRowClick($event, item) : {}"
             >
                 <td v-if="props.selectionType === 'checkbox'" class="v-data-table__td v-data-table-column--no-padding v-data-table-column--align-start">
                     <v-checkbox-btn :modelValue="isSelected(internalItem)" @click="toggleSelect(internalItem)" />
                 </td>
-                <td v-for="col in headers" :key="col.key">
+                <td v-for="col in headers" :key="col.key" :data-column-key="col.key">
                     <div class="nrdb-table-cell-align" :style="{'justify-content': col.align || 'start'}">
                         <UITableCell :row="index + 1" :item="item" :property="col.key" :type="col.type" />
                     </div>
@@ -159,11 +159,15 @@ export default {
                 this.pagination.rows = this.rows
             }
         },
-        onRowClick (row) {
+        onRowClick (event, row) {
             this.selected = this.selected === row ? null : row
-
+    
+            const cell = event.target.closest('td')
+            const columnKey = cell ? cell.getAttribute('data-column-key') : null
+    
             const msg = {
-                payload: row
+                payload: row,
+                column: columnKey
             }
             this.$socket.emit('widget-action', this.id, msg)
         },


### PR DESCRIPTION
## Description

Hi guys,
When you select a row in a ui-table widget, the clicked column will be send by this PR in the `msg.column` property:

![table_column](https://github.com/user-attachments/assets/606579af-c91b-49a0-852d-b140d35f6479)

I have this PR marked as ***draft*** because I wasn't sure whether the `msg.column` property is ok?  Therefore I also haven't yet adapted any documentation...

## Related Issue(s)

None

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

