### PR TITLE
Fix: Defaults set before Vuetify loading

### DIFF
--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -228,7 +228,7 @@ export default {
                 sizes['--group-border-radius'] = this.theme.sizes.groupBorderRadius
                 sizes['--widget-gap'] = this.theme.sizes.widgetGap
 
-                this.$vuetify.defaults.global.density = this.density
+                this.$vuetify.defaults?.global.density = this.density
             }
         },
         getPageLabel (page) {

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -228,7 +228,7 @@ export default {
                 sizes['--group-border-radius'] = this.theme.sizes.groupBorderRadius
                 sizes['--widget-gap'] = this.theme.sizes.widgetGap
 
-                this.$vuetify.defaults?.global.density = this.density
+                this.$vuetify.defaults.global.density = this.density
             }
         },
         getPageLabel (page) {

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -55,6 +55,11 @@ const vuetify = createVuetify({
         themes: {
             nrdb: theme
         }
+    },
+    defaults: {
+        global: {
+            density: 'default'
+        }
     }
 })
 


### PR DESCRIPTION
## Description

Noticed this error starting to appear:

<img width="487" alt="Screenshot 2024-08-08 at 16 49 39" src="https://github.com/user-attachments/assets/2f837486-93f6-4abd-84f2-7c969d9eb69a">

Seems to have been introduced in https://github.com/FlowFuse/node-red-dashboard/pull/1166 whereby the defaults are trying to be set, before Vuetify has fully loaded them, wbhich also meant #1166 never fully worked when delivered too.