### PR TITLE
UI Template - Run generic JS onMounted

### DIFF
--- a/ui/src/util/vue.acorn.js
+++ b/ui/src/util/vue.acorn.js
@@ -115,7 +115,7 @@ function parseSFC (js) {
     } if (tree.type === 'Program' && tree.body.length > 0) {
         // we have raw JavaScript.
         // - this is fine, but we need to wrap it in a Vue Component to render in Dashboard
-        // assusming this runs straight away, let's add it to the beforeCreate of the component
+        // assuming this runs straight away, let's document this in a "beforeCreate" lifecycle hook
         const component = {}
         component.beforeCreate = ''
         tree.body.forEach((block) => {

--- a/ui/src/util/vue.acorn.js
+++ b/ui/src/util/vue.acorn.js
@@ -117,9 +117,9 @@ function parseSFC (js) {
         // - this is fine, but we need to wrap it in a Vue Component to render in Dashboard
         // assuming this runs straight away, let's document this in a "beforeCreate" lifecycle hook
         const component = {}
-        component.beforeCreate = ''
+        component.js = ''
         tree.body.forEach((block) => {
-            component.beforeCreate += processProperty('', block)
+            component.js += processProperty('', block)
         })
         return component
     } else {

--- a/ui/src/util/vue.acorn.js
+++ b/ui/src/util/vue.acorn.js
@@ -115,7 +115,7 @@ function parseSFC (js) {
     } if (tree.type === 'Program' && tree.body.length > 0) {
         // we have raw JavaScript.
         // - this is fine, but we need to wrap it in a Vue Component to render in Dashboard
-        // assuming this runs straight away, let's document this in a "beforeCreate" lifecycle hook
+        // assuming this runs straight away, let's add this to a new lifecycle hook named "js" that is executed on the "mounted" hook
         const component = {}
         component.js = ''
         tree.body.forEach((block) => {

--- a/ui/src/widgets/ui-template/UITemplate.vue
+++ b/ui/src/widgets/ui-template/UITemplate.vue
@@ -165,14 +165,13 @@ export default {
             },
             created () {
                 this.$dataTracker(props.id)
-
+            },
+            mounted () {
                 if (component?.beforeCreate) {
-                    // run any generic JS code user has defined outisde of a VueJS component
+                    // run any generic JS code user has defined outside of a VueJS component
                     // eslint-disable-next-line no-eval
                     eval(component.beforeCreate)
                 }
-            },
-            mounted () {
                 if (component?.mounted) {
                     component.mounted.call(this)
                 }

--- a/ui/src/widgets/ui-template/UITemplate.vue
+++ b/ui/src/widgets/ui-template/UITemplate.vue
@@ -61,10 +61,10 @@ export default {
                     })
                 } else {
                     const parsed = VueParser.parse(script.innerHTML)
-                    if (parsed.beforeCreate) {
+                    if (parsed.js) {
                         component = {
                             ...component,
-                            beforeCreate: parsed.beforeCreate
+                            js: parsed.js
                         }
                     } else {
                         component = {
@@ -167,10 +167,10 @@ export default {
                 this.$dataTracker(props.id)
             },
             mounted () {
-                if (component?.beforeCreate) {
+                if (component?.js) {
                     // run any generic JS code user has defined outside of a VueJS component
                     // eslint-disable-next-line no-eval
-                    eval(component.beforeCreate)
+                    eval(component.js)
                 }
                 if (component?.mounted) {
                     component.mounted.call(this)


### PR DESCRIPTION
## Description

- We group any generic JS we find into a `beforeCreate` function, which was then run in the `beforeCreate` lifecycle hook of VueJS. This was causing problems though if a user was trying to reference HTML elements in their component e.g. https://discourse.nodered.org/t/graph-shapes-and-single-point/90041/4 as the component hadn't yet been mounted.
- This PR moves the `beforeCreate` content (i.e. generic JS) into a new hok called `js`, and runs this code in `mounted()` instead so that the code _can_ reference HTML content