### PR TITLE
[fix]: Font-size supporting issue in ui-text node

### DIFF
--- a/ui/src/widgets/ui-text/UIText.vue
+++ b/ui/src/widgets/ui-text/UIText.vue
@@ -35,7 +35,7 @@ export default {
         style () {
             return {
                 'font-family': this.getProperty('font'),
-                'font-size': this.getProperty('fontSize'),
+                'font-size': `${this.getProperty('fontSize')}px`,
                 color: this.getProperty('color')
             }
         }


### PR DESCRIPTION
## Description

As the per the reported issue says "styling no longer applying" [1193](https://github.com/FlowFuse/node-red-dashboard/issues/1193).

I noticed that the only issue was with the `font size` as it was just passed as a string without setting the unit as suffix.
At moment the Dashboard 2.0 uses only pixel unit for font sizes I concatenated `px` unit in this fix 

<img width="863" alt="Screenshot 2024-08-12 at 12 58 30" src="https://github.com/user-attachments/assets/976d896b-5c30-49a8-8985-bf857f6d7c7b">

<!-- Describe your changes in detail -->

## Related Issue(s)

[https://github.com/FlowFuse/node-red-dashboard/issues/1193](https://github.com/FlowFuse/node-red-dashboard/issues/1193)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

