### PR TITLE
[fix]: docs: broken URL in ui_page.html

### DIFF
--- a/nodes/config/locales/en-US/ui_page.html
+++ b/nodes/config/locales/en-US/ui_page.html
@@ -40,7 +40,7 @@
         </dt>
         <dd>
             Choose form one of the available Dashboard Layouts.
-            You can read more about our layouts <a href="https://dashboard.flowfuse.com/layouts/grid.html">here</a>.
+            You can read more about our layouts <a href="https://dashboard.flowfuse.com/layouts/types/grid.html">here</a>.
         </dd>
         <dt>
             Class


### PR DESCRIPTION
## Description

The URL of the help page under the ui_page.html has been broken. fixed it.

## Related Issue(s)

https://github.com/FlowFuse/node-red-dashboard/issues/1049

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

