### PR TITLE
Reduce reconnection notification display time

### DIFF
--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -146,7 +146,7 @@ fetch('_setup')
             if (disconnected) {
                 // send a notification/alert to the user to let them know the connection is live again
                 Alerts.emit('Connected', 'Connection re-established.', '#1BC318', {
-                    displayTime: 3,
+                    displayTime: 1,
                     allowDismiss: true,
                     showCountdown: true
                 })


### PR DESCRIPTION
## Description

I hope this is a reasonable compromise solution for issue #811. It reduces the connection restored notification display time from 3 seconds to 1 second so that there is still a notification for those that want it, but it is short enough to remove the annoyance for those using a mobile device, where the notification is often shown when the device is woken up.

## Related Issue(s)

Closes #811

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

