### PR TITLE
chore: Add `needs-triage` to story and task issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,6 +1,6 @@
 name: 📖 Story
 description: Create a story
-labels: [story]
+labels: [needs-triage, story]
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,6 +1,6 @@
 name: 📄 Task
 description: Create a task
-labels: [task]
+labels: [needs-triage, task]
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
## Description

This pull request adds a `needs-triage` label to story and task issue templates.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

