### PR TITLE
CSS: Flex Grow the #app-bar-title by default

### DIFF
--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -49,6 +49,10 @@ main {
     gap: 6px;
 }
 
+#app-bar-title {
+    flex-grow: 1;
+}
+
 /**
 * Loading Animation
 */


### PR DESCRIPTION
## Description

Recently had a customer [raise a question](https://discourse.nodered.org/t/center-image-in-title-bar-using-teleport/90280) about centering the #app-bar-title teleport.

The solution was to add:

```css
#app-bar-title {
    flex-grow: 1;
    justify-content: center;
}
```

Whilst the `justify-content` could be argued as intuitive, the need for `flex-grow` here is not. This PR adds it in, which causes the `#app-bar-title` to spread across the full-width of the navigation header by default (still left-aligned), such that, if `justify-content` is introduced, then it centers to the full width of the screen.