### PR TITLE
Ensure groups in Fixed layouts are driven by the correct width property

### DIFF
--- a/ui/src/layouts/Flex.vue
+++ b/ui/src/layouts/Flex.vue
@@ -125,7 +125,6 @@ export default {
 }
 
 .nrdb-layout--flex > div {
-    width: var(--layout-card-width);
     max-width: 100%;
 }
 


### PR DESCRIPTION
## Description

Fix #1215 

Groups were rendered at a static width because of a `width` property - this should not be the case, they should be driven by their group's width.