### PR TITLE
Layouts: Ensure we're parsing float on the "px" row height

### DIFF
--- a/ui/src/layouts/Flex.vue
+++ b/ui/src/layouts/Flex.vue
@@ -49,7 +49,7 @@ export default {
     data () {
         const rowHeight = getComputedStyle(document.body).getPropertyValue('--widget-row-height')
         return {
-            rowHeight
+            rowHeight: parseFloat(rowHeight)
         }
     },
     computed: {

--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -48,11 +48,6 @@ export default {
         BaselineLayout,
         WidgetGroup
     },
-    data () {
-        return {
-            rowHeight: 48
-        }
-    },
     computed: {
         ...mapState('ui', ['groups', 'widgets', 'pages']),
         ...mapState('data', ['properties']),

--- a/ui/src/layouts/Group.vue
+++ b/ui/src/layouts/Group.vue
@@ -30,7 +30,6 @@ export default {
     },
     computed: {
         columns () {
-            console.log(this.group.width)
             return this.group.width
         }
     },

--- a/ui/src/layouts/Group.vue
+++ b/ui/src/layouts/Group.vue
@@ -30,6 +30,7 @@ export default {
     },
     computed: {
         columns () {
+            console.log(this.group.width)
             return this.group.width
         }
     },

--- a/ui/src/layouts/Notebook.vue
+++ b/ui/src/layouts/Notebook.vue
@@ -48,7 +48,7 @@ export default {
     data () {
         const rowHeight = getComputedStyle(document.body).getPropertyValue('--widget-row-height')
         return {
-            rowHeight
+            rowHeight: parseFloat(rowHeight)
         }
     },
     computed: {


### PR DESCRIPTION
## Description

When reconciling the `rowHeight` into the CSS vars, made an error on Fixed layouts which meant that the `48px` was then included ins a JS calculation for the width, failing (because of the inclusion of `px`) and then not setting the width properly.

This PR ensures that `rowHeight` is a number, before injecting it into the width calculations.

## Related Issue(s)

Fixes #1215 