### PR TITLE
UI notification improvements

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -977,6 +977,10 @@ module.exports = function (RED) {
                                 if (widgetConfig.topic || widgetConfig.topicType) {
                                     msg = await appendTopic(RED, widgetConfig, wNode, msg)
                                 }
+                                if (widgetConfig.property || widgetConfig.propertyType) {
+                                    // append ui_payload to msg if property/propertyType is set
+                                    msg = await updatePayload(RED, widgetConfig, wNode, msg)
+                                }
                                 if (hasProperty(widgetConfig, 'passthru')) {
                                     if (widgetConfig.passthru) {
                                         send(msg)

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -4,7 +4,7 @@ const path = require('path')
 const v = require('../../package.json').version
 const datastore = require('../store/data.js')
 const statestore = require('../store/state.js')
-const { appendTopic, addConnectionCredentials } = require('../utils/index.js')
+const { appendTopic, addConnectionCredentials, updatePayload } = require('../utils/index.js')
 
 // from: https://stackoverflow.com/a/28592528/3016654
 function join (...paths) {

--- a/nodes/utils/index.js
+++ b/nodes/utils/index.js
@@ -30,6 +30,28 @@ async function appendTopic (RED, config, wNode, msg) {
 }
 
 /**
+ * Evaluates the property/propertyType and sets ui_payload in the message object
+ * This leaves the original payload untouched
+ * This permits an TypedInput widget to be used to set the payload
+ * @param {*} RED - The RED object
+ * @param {Object} config - The node configuration
+ * @param {Object} wNode - The node object
+ * @param {Object} msg - The message object
+ * @returns {Object} - The updated message object
+ */
+async function updatePayload (RED, config, wNode, msg) {
+    if (config.propertyType && config.property) {
+        try {
+            msg.ui_payload = await asyncEvaluateNodeProperty(RED, config.property, config.propertyType || 'msg', wNode, msg) || ''
+        } catch (_err) {
+            // do nothing
+            console.error(_err)
+        }
+    }
+    return msg
+}
+
+/**
  * Adds socket/client data to a msg payload, if enabled
  *
  */
@@ -57,5 +79,6 @@ function addConnectionCredentials (RED, msg, conn, config) {
 module.exports = {
     asyncEvaluateNodeProperty,
     appendTopic,
-    addConnectionCredentials
+    addConnectionCredentials,
+    updatePayload
 }

--- a/nodes/widgets/ui_notification.html
+++ b/nodes/widgets/ui_notification.html
@@ -27,7 +27,9 @@
                 confirmText: { value: 'Confirm' },
                 raw: { value: false },
                 className: { value: '' },
-                name: { value: '' }
+                name: { value: '' },
+                property: { value: 'payload' },
+                propertyType: { value: 'msg' }
             },
             inputs: 1,
             outputs: 1,
@@ -37,6 +39,12 @@
             label: function () { return this.name || (this.position === 'prompt' ? 'show dialog' : (this.position === 'dialog' ? 'show dialog' : 'show notification')) },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },
             oneditprepare: function () {
+                $('#node-input-property').typedInput({
+                    default: 'msg',
+                    typeField: $('#node-input-propertyType'),
+                    types: ['str', 'msg', 'jsonata']
+                })
+
                 $('#node-input-topic').typedInput({
                     default: 'str',
                     typeField: $('#node-input-topicType'),
@@ -86,6 +94,11 @@
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> Message</label>
+        <input type="hidden" id="node-input-propertyType">
+        <input type="text" id="node-input-property" placeholder="payload" style="width: 70%;">
     </div>
     <div class="form-row">
         <label for="node-input-ui"><i class="fa fa-bookmark"></i> UI</label>

--- a/nodes/widgets/ui_notification.js
+++ b/nodes/widgets/ui_notification.js
@@ -5,6 +5,7 @@ module.exports = function (RED) {
         const node = this
 
         RED.nodes.createNode(this, config)
+        config.passthru = false // prevent default passthru by setting it explicity to `false`. The notification itself will send msg on timeout, dismissal or confirmation!
 
         // Which ui are we rendering this widget.
         // In contradiction to other ui nodes (which belong to a group), the notification node belongs to a ui instead.

--- a/ui/src/widgets/ui-notification/UINotification.vue
+++ b/ui/src/widgets/ui-notification/UINotification.vue
@@ -59,7 +59,7 @@ export default {
         ...mapState('data', ['messages']),
         value: function () {
             // Get the value (i.e. the notification text content) from the last input msg
-            return this.messages[this.id]?.payload
+            return this.messages[this.id]?.ui_payload || this.messages[this.id]?.payload
         },
         allowConfirm () {
             return this.getProperty('allowConfirm')
@@ -118,15 +118,16 @@ export default {
         },
         onMsgInput (msg) {
             // Make sure the last msg (that has a payload, containing the notification content) is being stored
-            if (msg.payload) {
+            const payload = msg.ui_payload || msg.payload
+            if (typeof payload !== 'undefined') {
                 this.$store.commit('data/bind', {
                     widgetId: this.id,
                     msg
                 })
             }
 
-            if (msg.show === true || typeof msg.payload !== 'undefined') {
-                // If msg.show is true or msg.payload contains a notification title, the notification popup need to be showed (if currently hidden)
+            if (msg.show === true || typeof payload !== 'undefined') {
+                // If msg.show is true or payload contains a notification title, the notification popup need to be showed (if currently hidden)
                 if (!this.show) {
                     this.show = true
 

--- a/ui/src/widgets/ui-notification/UINotification.vue
+++ b/ui/src/widgets/ui-notification/UINotification.vue
@@ -149,7 +149,7 @@ export default {
             this.timeouts.close = setTimeout(() => {
                 // close the notification after time has elapsed
                 this.close('timeout')
-            }, time)
+            }, time + 100) // add 100ms grace before firing timeout in case user clicked a button (ui update is slow)
 
             // update the progress bar every 100ms
             this.timeouts.step = setInterval(() => {


### PR DESCRIPTION
## Description

This is not tied directly to any one ISSUE. 

This was based on recent forum feedback and my desire to support TypedInputs throughout DB2 widgets.

The changes implemented are opinionated and may not all may be welcomed but since I had some playtime, and I like where it got to, I thought I would raise a PR for feedback.

At present, this PR includes no doc updates or tests because if the changes are rejected I wont have wasted any time ;) 


### Whats changed

* **Support `TypedInput`**
  * What: This PR introduces a pattern for supporting typed inputs for the payload.
  * Why: Because is super annoying adding change nodes everywhere
  * How: It works by evaluating node config `property`/`propertyType` and adding a temporary prop `ui_payload` to the msg that is used client side as the `value`. This should work for other widgets too.
* **Inhibit default passthru**
  * Why: Currently, the notification node sends multiple messages - 1 every time it gets and input msg and 1 when it closes. 
  * What: This PR only sends the final msg upon timeout/dismiss/confirm
  * How: This is done by setting the config prop to `false` (hard coded)
* **Adds `ui_reason` to `msg`
  * `msg.ui_reason` will be added to the msg containing the relevant close reason of `timeout`, `input_msg`, `dismiss_clicked`, or `confirm_clicked`
* ** Only sends msg to Node-RED if `show` is true**
  * Why: I could quite easily get notification node to emit both "confirm" or "dismiss" AND "timeout" (when clicking a button near the end of progress bar)
 

### Demo
![chrome_zRLbx6gi7J](https://github.com/user-attachments/assets/3975debc-8646-413e-91be-d29c9b1aa308)




## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

