### PR TITLE
UI Gauge - Improve font-size in smaller tiles

### DIFF
--- a/ui/src/widgets/ui-gauge/types/UIGaugeBattery.vue
+++ b/ui/src/widgets/ui-gauge/types/UIGaugeBattery.vue
@@ -155,7 +155,7 @@ export default {
 .nrdb-ui-gauge-battery label {
     font-weight: bold;
     resize: both;
-    font-size: min(2.5rem,max(30cqmin, .5rem));
+    font-size: min(2.5rem,max(25cqmin, .5rem));
     position: relative;
     z-index: 2;
     width: 100%;

--- a/ui/src/widgets/ui-gauge/types/UIGaugeTile.vue
+++ b/ui/src/widgets/ui-gauge/types/UIGaugeTile.vue
@@ -34,6 +34,7 @@ export default {
     border: 1px solid rgb(var(--v-theme-group-outline));
     label {
         font-size: min(2.5rem, max(40cqmin, .5rem));
+        text-align: center;
     }
 }
 </style>

--- a/ui/src/widgets/ui-gauge/types/UIGaugeTile.vue
+++ b/ui/src/widgets/ui-gauge/types/UIGaugeTile.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="nrdb-ui-gauge-tile" :style="{'background-color': valueToColor(props.segments, value), 'color': getTextColor(props.segments, value)}">
-        {{ props.title }}
+        <label>{{ props.title }}</label>
     </div>
 </template>
 
@@ -23,14 +23,17 @@ export default {
 }
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .nrdb-ui-gauge-tile {
     display: flex;
     justify-content: center;
     align-items: center;
-    font-size: 2.5rem;
+    container-type: size;
     font-weight: bold;
     transition: 0.15s background-color;
     border: 1px solid rgb(var(--v-theme-group-outline));
+    label {
+        font-size: min(2.5rem, max(40cqmin, .5rem));
+    }
 }
 </style>


### PR DESCRIPTION
## Description

On a customer call and they mention that the tile's didn't render well at small scale, so this addresses that.

### Before:

<img width="886" alt="Screenshot 2024-08-28 at 14 39 50" src="https://github.com/user-attachments/assets/8470bf74-398b-4efd-a784-4c4786aaa66d">

### After:

<img width="895" alt="Screenshot 2024-08-28 at 14 37 34" src="https://github.com/user-attachments/assets/49d86831-504f-4d80-bde0-f3cf638b84ba">
