### PR TITLE
Fix: Ensure button is set to min-height, as to account for multi-row buttons

### DIFF
--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -481,5 +481,5 @@ NB! supresses the gridarea for messages, but those are not in use*/
 .v-btn.v-btn--density-default,
 .v-btn.v-btn--density-compact, 
 .v-btn.v-btn--density-comfortable {
-    height: var(--widget-row-height);
+    min-height: var(--widget-row-height);
 }


### PR DESCRIPTION
## Description

Problem first mentioned here: https://discourse.nodered.org/t/latest-dashboard-2-0-release-tabs-number-input-new-gauges/90506/17

We had set `height` on buttons based on the new theming size, but this should be _min_ height as multi-row buttons were then prevents from stretching their full distance.

### Before

<img width="294" alt="Screenshot 2024-08-29 at 08 42 48" src="https://github.com/user-attachments/assets/37f66ccf-661e-47df-87ff-56fb1c253958">

### After

<img width="588" alt="Screenshot 2024-08-29 at 08 42 38" src="https://github.com/user-attachments/assets/d03fe0d5-04f4-4751-948f-333744bda591">

