### PR TITLE
Set UI Notification min-width to auto for mobile responsiveness

### DIFF
--- a/ui/src/widgets/ui-notification/UINotification.vue
+++ b/ui/src/widgets/ui-notification/UINotification.vue
@@ -187,6 +187,7 @@ export default {
     background-color: rgb(var(--v-theme-group-background));
     color: rgb(var(--v-theme-on-group-background));
     border-left: 6px solid var(--nrdb-ui-notification-color);
+    min-width: auto;
 }
 .nrdb-ui-notification .v-snackbar__content {
     padding: 8px 12px;


### PR DESCRIPTION
## Description

Override Vuetify's snackbar min with value with auto to support mobile responsiveness

https://github.com/user-attachments/assets/60aac614-1c20-4877-9825-0f4820353c5e

_Note that this doesn't need E2E tests to be written as this contains only one line css change_

## Related Issue(s)

https://github.com/FlowFuse/node-red-dashboard/issues/1230

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

