### PR TITLE
Add CSS to ensure there is a drop target for empty group

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -239,15 +239,21 @@
         min-height: 20px; /* IMPORTANT! So that user when last element is dragged out it doesnt collapse. */
     }
     div.nrdb2-sb-widget-list-container ol.nrdb2-sb-widget-list.red-ui-editableList-list.ui-sortable:empty {
-        border: 2px dashed lightgrey;
+        border: 1px dashed #c4c4c4;
         padding: 7px; /* should be 9px to match the other entries but border width is 2px */
         height: 20px; /* To make it visible */
         text-align: center;
+        border-left-width: 0;
+        border-right-width: 0;
+        background-color: #f9f9f9;
     }
     div.nrdb2-sb-widget-list-container ol.nrdb2-sb-widget-list.red-ui-editableList-list.ui-sortable:empty::before {
         content: "empty";
-        color: lightgrey;
+        color: #d2d2d2;
         font-style: italic;
+    }
+    ol.nrdb2-sb-group-list li:last-child ol.nrdb2-sb-widget-list.red-ui-editableList-list.ui-sortable:empty {
+        border-bottom-width: 0px;
     }
 </style>
 

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -235,6 +235,20 @@
         display: flex;
         flex-direction: column;
     }
+    div.nrdb2-sb-widget-list-container ol.nrdb2-sb-widget-list.red-ui-editableList-list.ui-sortable {
+        min-height: 20px; /* IMPORTANT! So that user when last element is dragged out it doesnt collapse. */
+    }
+    div.nrdb2-sb-widget-list-container ol.nrdb2-sb-widget-list.red-ui-editableList-list.ui-sortable:empty {
+        border: 2px dashed lightgrey;
+        padding: 7px; /* should be 9px to match the other entries but border width is 2px */
+        height: 20px; /* To make it visible */
+        text-align: center;
+    }
+    div.nrdb2-sb-widget-list-container ol.nrdb2-sb-widget-list.red-ui-editableList-list.ui-sortable:empty::before {
+        content: "empty";
+        color: lightgrey;
+        font-style: italic;
+    }
 </style>
 
 
@@ -1043,7 +1057,7 @@
             addItem: function (container, i, /** @type {DashboardItem} */ widget) {
                 const titleRow = $('<div>', { class: 'nrdb2-sb-list-header nrdb2-sb-widgets-list-header' }).appendTo(container)
                 $('<i class="nrdb2-sb-list-handle nrdb2-sb-widget-list-handle fa fa-bars"></i>').appendTo(titleRow)
-                
+
                 // Set the icon
                 const ico = $('<i>', { class: 'nrdb2-sb-icon nrdb2-sb-widget-icon' }).appendTo(titleRow)
                 let widgetIcon = RED.utils.getNodeIcon(widget.node?._def, widget.node) || 'fa-question'

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -240,7 +240,7 @@
     }
     div.nrdb2-sb-widget-list-container ol.nrdb2-sb-widget-list.red-ui-editableList-list.ui-sortable:empty {
         border: 1px dashed #c4c4c4;
-        padding: 7px; /* should be 9px to match the other entries but border width is 2px */
+        padding: 8px; /* should be 9px to match the other entries but border width is 2px */
         height: 20px; /* To make it visible */
         text-align: center;
         border-left-width: 0;


### PR DESCRIPTION
closes #1228

## Description

Simple to fix, stupid hard to find!

Adds CSS to pseudo classes `:empty` and `:empty::before` to generate an "empty state" that is essentially a drop target

### Demo
![chrome_WUjSsXVCPm](https://github.com/user-attachments/assets/80be4f8b-1518-40e6-aa53-abf68d1f7459)


## Related Issue(s)
#1228 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

