### PR TITLE
Switch - adjustable clickable area

### DIFF
--- a/docs/nodes/widgets/ui-switch.md
+++ b/docs/nodes/widgets/ui-switch.md
@@ -4,6 +4,7 @@ props:
     Group: Defines which group of the UI Dashboard this widget will render in.
     Size: Controls the width of the button with respect to the parent group. Maximum value is the width of the group.
     Label: The text shown within the button.
+    Clickable: The clickable area (which will result in the switch toggling).
     On Icon: If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "on" state. No need to include the <code>mdi</code> prefix.
     Off Icon: If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "off" state. No need to include the <code>mdi</code> prefix.
     On Color: If provided with a icons, this colour is used for the icon when in "on" state
@@ -23,6 +24,9 @@ dynamic:
     Label:
         payload: msg.ui_update.label
         structure: ["Boolean"]
+    Clickable:
+        payload: msg.ui_update.clickableArea
+        structure: ["String"]
     Passthrough:
         payload: msg.ui_update.passthru
         structure: ["Boolean"]

--- a/nodes/widgets/locales/en-US/ui_switch.html
+++ b/nodes/widgets/locales/en-US/ui_switch.html
@@ -24,6 +24,8 @@
         <dd>If "Icon" is defined, this property controls which side of the "Label" the icon will render on</dd>
         <dt>Label <span class="property-type">string</span></dt>
         <dd>The text shown within the button. If not provided, then the button will only render the icon. It supports HTML content</dd>
+        <dt>Clickable <span class="property-type">string</span></dt>
+        <dd>The part of the horizontal line that is clickable.  By default only the switch icon will be clickable.</dd>
         <dt>Icon <span class="property-type">default | custom</span></dt>
         <dd>Either use the "default" switch appearance, or define your own custom icons.</dd>
         <dt>On Icon <span class="property-type">string</span></dt>
@@ -54,6 +56,17 @@
     <dl class="message-properties">
         <dt class="optional">label <span class="property-type">string</span></dt>
         <dd>Change the switch label at runtime.</dd>
+    </dl>
+    <dl class="message-properties">
+        <dt class="optional">clickableArea <span class="property-type">string</span></dt>
+        <dd>
+            Change the clickable area at runtime:
+            <ul>
+                <li><code>switch</code>: only the switch icon is clickable</li>
+                <li><code>label</code>: both the label text and the switch icon are clickable</li>
+                <li><code>line</code>: the entire line is clickable</li>
+            </ul>
+        </dd>
     </dl>
     <dl class="message-properties">
         <dt class="optional">passthru <span class="property-type">boolean</span></dt>

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -30,6 +30,7 @@
                 topicType: { value: 'msg' },
                 style: { value: '' },
                 className: { value: '' },
+                clickableArea: { value: 'switch' },
                 // on state
                 onvalue: { value: true, validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('onvalueType') : function (v) { return true }) },
                 onvalueType: { value: 'bool' },
@@ -48,6 +49,11 @@
             label: function () { return this.name || (~this.label.indexOf('{' + '{') ? null : this.label) || 'switch' },
             labelStyle: function () { return this.name ? 'node_label_italic' : '' },
             oneditprepare: function () {
+                // Migration of older nodes without clickableArea
+                if (!this.clickableArea) {
+                    $('#node-input-clickableArea').val('switch')
+                }
+
                 // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
                 // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
                 if (RED.nodes.subflow(this.z)) {
@@ -168,6 +174,14 @@
         <input type="text" id="node-input-label">
     </div>
     <div class="form-row">
+        <label for="node-input-clickableArea"><i class="fa fa-hand-pointer-o"></i> Clickable</label>
+        <select id="node-input-clickableArea" style="width:70%">
+            <option value="switch">Only switch</option>
+            <option value="label">Label and switch</option>
+            <option value="line">Entire line</option>
+        </select>
+    </div>
+    <div class="form-row">
         <label for="node-input-className"><i class="fa fa-code"></i> Class</label>
         <div style="display: inline;">
             <input style="width: 70%;" type="text" id="node-input-className" placeholder="Optional CSS class name(s)" style="flex-grow: 1;">
@@ -186,7 +200,7 @@
     </div>-->
     <div class="form-row">
         <label for="node-input-custom-icons"><i class="fa fa-picture-o"></i> Icon</label>
-        <select id="node-input-custom-icons" style="width:35%">
+        <select id="node-input-custom-icons" style="width:70%">
             <option value="default">Default</option>
             <option value="custom">Custom</option>
         </select>

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -104,6 +104,10 @@ module.exports = function (RED) {
                         // dynamically set "label" property
                         statestore.set(group.getBase(), node, msg, 'label', updates.label)
                     }
+                    if (typeof updates.clickableArea !== 'undefined') {
+                        // dynamically set "clickableArea" property
+                        statestore.set(group.getBase(), node, msg, 'clickableArea', updates.clickableArea)
+                    }
                     if (typeof updates.passthru !== 'undefined') {
                         // dynamically set "passthru" property
                         statestore.set(group.getBase(), node, msg, 'passthru', updates.passthru)

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -1,6 +1,19 @@
 <template>
     <div class="nrdb-switch" :class="{'nrdb-nolabel': !label, [className]: !!className}">
-        <label v-if="label" class="v-label">{{ label }}</label>
+        <label
+            v-if="label"
+            class="v-label"
+            :style="{cursor: lineClickable ? 'pointer' : 'default'}"
+            @click="lineClickable ? toggle() : null"
+        >
+            <span
+                class="clickable-label"
+                :style="{cursor: textClickable ? 'pointer' : 'default'}"
+                @click.stop="textClickable ? toggle() : null"
+            >
+                {{ props.label }}
+            </span>
+        </label>
         <v-switch
             v-if="!icon" v-model="status"
             :disabled="!state.enabled"
@@ -57,6 +70,12 @@ export default {
             }
             return null
         },
+        lineClickable: function () {
+            return this.getProperty('clickableArea') === 'line'
+        },
+        textClickable: function () {
+            return this.getProperty('clickableArea') === 'label' || this.getProperty('clickableArea') === 'line'
+        },
         value () {
             return this.selection
         },
@@ -102,6 +121,7 @@ export default {
                 return
             }
             this.updateDynamicProperty('label', updates.label)
+            this.updateDynamicProperty('clickableArea', updates.clickableArea)
             this.updateDynamicProperty('decouple', updates.decouple)
             this.updateDynamicProperty('oncolor', updates.oncolor)
             this.updateDynamicProperty('offcolor', updates.offcolor)


### PR DESCRIPTION
## Description

As requested [here](https://discourse.nodered.org/t/db2-switch-node-doesnt-response-when-clicking-on-the-label/90770/10) by Joe, a PR to allow users to specify the clickable area of a ui switch:

![image](https://github.com/user-attachments/assets/ee8d25b4-9363-41d0-8227-1fbbfeed3e9f)

Depending on the use case, a user can change it to fits his needs:

![image](https://github.com/user-attachments/assets/fb0177e0-decd-41d6-b80d-3b2bce619694)

P.S. I find my md file a bit limited to be honest.  But not sure how to add more info to it in a decent way.  Currently my info panel contains more info compared to the md file, which is the opposite what I would expect.  And info like my screenshot above of the 3 areas will get lost here in this pull request and never end up in the documentation.  Not sure if that is the way to go...

The property can adjusted dynamically via `msg.ui_update.clickableArea`.  The following demo shows what happens when I hover across the 3 areas (e.g. mouse cursor) and if I click on every area:

![clickable switch](https://github.com/user-attachments/assets/601e34c0-9810-402e-aede-4bcc974d7436)
```
[{"id":"bc5ab21a6466fac2","type":"ui-switch","z":"4aad778b57d4f47b","name":"","label":"Test switch","group":"c2bf863890b3eab0","order":1,"width":0,"height":0,"passthru":false,"decouple":false,"topic":"topic","topicType":"msg","style":"","className":"","clickableArea":"line","onvalue":"true","onvalueType":"bool","onicon":"","oncolor":"","offvalue":"false","offvalueType":"bool","officon":"","offcolor":"","x":1070,"y":340,"wires":[["f659839079aa4ede"]]},{"id":"f659839079aa4ede","type":"debug","z":"4aad778b57d4f47b","name":"output","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"payload","targetType":"msg","statusVal":"","statusType":"auto","x":1230,"y":340,"wires":[]},{"id":"a2531ab733fe5e4a","type":"inject","z":"4aad778b57d4f47b","name":"Clickable label and switch","props":[{"p":"ui_update.clickableArea","v":"label","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":830,"y":380,"wires":[["bc5ab21a6466fac2"]]},{"id":"b2de1e7349ab1e13","type":"inject","z":"4aad778b57d4f47b","name":"Clickable entire line","props":[{"p":"ui_update.clickableArea","v":"line","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":850,"y":420,"wires":[["bc5ab21a6466fac2"]]},{"id":"bd9e697c7636125f","type":"inject","z":"4aad778b57d4f47b","name":"Clickable switch","props":[{"p":"ui_update.clickableArea","v":"switch","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":860,"y":340,"wires":[["bc5ab21a6466fac2"]]},{"id":"c2bf863890b3eab0","type":"ui-group","name":"Ui switch demo","page":"2e8fc9a730774265","width":"6","height":"1","order":2,"showTitle":true,"className":"","visible":"true","disabled":"false"},{"id":"2e8fc9a730774265","type":"ui-page","name":"Demo","ui":"be29745a6e568f30","path":"/page11","icon":"home","layout":"grid","theme":"a965ccfef139317a","order":1,"className":"","visible":"true","disabled":"false"},{"id":"be29745a6e568f30","type":"ui-base","name":"UI Name","path":"/dashboard","includeClientData":true,"acceptsClientConfig":["ui-notification","ui-control","ui-chart","ui-text-input","ui-dropdown"],"showPathInSidebar":false,"titleBarStyle":"default"},{"id":"a965ccfef139317a","type":"ui-theme","name":"Default","colors":{"surface":"#404040","primary":"#109fbc","bgPage":"#e8e8e8","groupBg":"#d6d6d6","groupOutline":"#6fbc10"},"sizes":{"pagePadding":"12px","groupGap":"12px","groupBorderRadius":"4px","widgetGap":"12px"}}]
```

Two remarks about the code:
+ Just for clarification:  I have used a `@click.stop` which is to avoid event propagation.  Because when *'entire line'* has been selected, both the `<label>` and `<tag>` elements will get a click event handler.  So when you click on the tag, a switch toggle will be triggered.  But the event bubbles up to the label element and trigger its click event handler also, resulting in a second switch toggle.  Which is not what we want.

+ Something that might be a bit confusing: for a user the *"label"* is the visible text.  But for the ui developer, that *"label"* option corresponds to the `<tag>` element.  While the `<label>` element will be clickable when "*entire line"* has been selected.  It might be useful to add this as a comment in the code?

## Related Issue(s)

None I think

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [X] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

