### PR TITLE
Alter alert subscription causing the vue application to silently crash

### DIFF
--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -55,6 +55,7 @@
                 <ui-notification
                     id="ui-inline-alert" ref="alert"
                     :props="{position: 'top right', showCountdown: alert.showCountdown, displayTime: alert.displayTime, raw: true, allowDismiss: alert.allowDismiss}"
+                    @mounted="subscribeAlerts"
                 />
             </div>
         </v-main>
@@ -187,18 +188,20 @@ export default {
     },
     mounted () {
         this.updateTheme()
-        Alerts.subscribe((title, description, color, alertOptions) => {
-            this.$refs.alert.close()
-            this.alert = alertOptions
-            this.$nextTick(() => {
-                this.$refs.alert.onMsgInput({
-                    payload: `<h3>${title}</h3><p>${description}</p>`,
-                    color
-                })
-            })
-        })
     },
     methods: {
+        subscribeAlerts (context) {
+            Alerts.subscribe((title, description, color, alertOptions) => {
+                context.close()
+                this.alert = alertOptions
+                this.$nextTick(() => {
+                    context.onMsgInput({
+                        payload: `<h3>${title}</h3><p>${description}</p>`,
+                        color
+                    })
+                })
+            })
+        },
         go: function (name) {
             this.$router.push({
                 name

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -136,7 +136,7 @@ fetch('_setup')
             }
             // tell the user we're trying to connect
             Alerts.emit('Connection Lost', 'Attempting to reconnect to server...', 'red', {
-                displayTime: 0,
+                displayTime: 0, // displayTime 0 persists notifications until another notification closes it
                 allowDismiss: false,
                 showCountdown: false
             })

--- a/ui/src/widgets/ui-notification/UINotification.vue
+++ b/ui/src/widgets/ui-notification/UINotification.vue
@@ -44,6 +44,7 @@ export default {
         props: { type: Object, default: () => ({}) },
         state: { type: Object, default: () => ({}) }
     },
+    emits: ['mounted'],
     data () {
         return {
             show: false,
@@ -99,6 +100,9 @@ export default {
     created () {
         // can't do this in setup as we have custom onInput function
         this.$dataTracker(this.id, this.onMsgInput, null, this.onDynamicProperties)
+    },
+    mounted () {
+        this.$emit('mounted', this)
     },
     methods: {
         onDynamicProperties (msg) {


### PR DESCRIPTION
## Description

The alerts service was subscribing in on the mounted lifecycle method in the Baseline.vue component (which is inherited by all existing layouts) before the UiNotification child component which it acted upot managed to properly mount.

Updated the lifecycle flow in order to preserve lifecycle consistency between parent/child components by forcing the alerts service to subscribe only after the UiNotification components get's mounted properly.

## Related Issue(s)

closes https://github.com/FlowFuse/node-red-dashboard/issues/747#

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

