### PR TITLE
Preserve Range and Segments on Field Value Changes + Added Reset to Default Button

### DIFF
--- a/nodes/widgets/locales/en-US/ui_gauge.html
+++ b/nodes/widgets/locales/en-US/ui_gauge.html
@@ -12,6 +12,8 @@
         <dd>Collection of objects that define the relevant color for a given value</dd>
         <dt>Label <span class="property-type">list</span></dt>
         <dd>The title text shown above the gauge</dd>
+        <dt>Defaults <span class="property-type">list</span></dt>
+        <dd>Reset to default min/max and segments based on the selected gauge type</dd>
     </dl>
     <h3>Properties (Half &amp; 3/4 Gauges Only)</h3>
     <dl class="message-properties">

--- a/nodes/widgets/locales/en-US/ui_gauge.json
+++ b/nodes/widgets/locales/en-US/ui_gauge.json
@@ -28,7 +28,8 @@
             "styling": "Styling",
             "class": "Class",
             "units": "Units",
-            "icon": "Icon"
+            "icon": "Icon",
+            "defaults": "Defaults"
         },
         "errors": {
             "unique": "All 'from' values must be unique."

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -143,20 +143,11 @@
                 prefix: { value: '' },
                 suffix: { value: '' },
                 segments: {
-                    value: [{
-                        color: '#5CD65C',
-                        from: 0
-                    }, {
-                        color: '#FFC800',
-                        from: 4
-                    }, {
-                        color: '#EA5353',
-                        from: 7
-                    }],
+                    value: [...DEFAULTS['gauge-half'].segments],
                     validate: validateGaugeSegments
                 },
-                min: { value: 0, required: true, validate: RED.validators.number() },
-                max: { value: 10, required: true, validate: RED.validators.number() },
+                min: { value: DEFAULTS['gauge-half'].min, required: true, validate: RED.validators.number() },
+                max: { value: DEFAULTS['gauge-half'].max, required: true, validate: RED.validators.number() },
                 // sizes
                 sizeThickness: { value: 16, validate: RED.validators.number() },
                 sizeGap: { value: 4, validate: RED.validators.number() },

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -38,7 +38,7 @@
         }
         return minCovered && !extras
     }
-    let isInitialised = false
+    let isDirty = false
     RED.nodes.registerType('ui-gauge', {
         category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
         color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
@@ -99,7 +99,7 @@
         label: function () { return this.name || this.title || this.gtype },
         labelStyle: function () { return this.name ? 'node_label_italic' : '' },
         oneditprepare: function () {
-            let isDirty = false
+            let isInitialised = false
 
             // store reference to initial gtype so we can check if it's changed
             const initGType = this.gtype
@@ -253,13 +253,6 @@
             // only show relevant options
             function showTypeOptions (type) {
                 currentGaugeType = type
-                const newSegments = []
-                $('#node-input-segments-container > li').each(function () {
-                    newSegments.push({
-                        color: $(this).find('.node-input-segment-color').val(),
-                        from: $(this).find('.node-input-segment-from').val()
-                    })
-                })
 
                 if (type === 'gauge-tile' || type === 'gauge-battery' || type === 'gauge-tank') {
                     $('#node-input-container-sizes').hide()

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -9,64 +9,75 @@
 </style>
 
 <script type="text/javascript">
-    function validateGaugeSegments (segments) {
-        $('#node-input-validation-segments').hide()
-        const min = parseFloat(this.min)
-        const max = parseFloat(this.max)
-    
-        // check we havea  segment covering the smallest values of the gauge
-        let minCovered = false
-        for (let i = 0; i < segments.length; i++) {
-            const from = parseFloat(segments[i].from)
-            if (from <= min) {
-                minCovered = true
-            }
-        }
-        if (!minCovered) {
-            $('#node-input-validation-segments').text("It's advised to make sure your first segment's 'from' value and the gauge's 'min' value are the same.").show()
-        }
-        // check if we have any extra, unneccessary, segments
-        let extras = false
-        for (let i = 0; i < segments.length; i++) {
-            const from = parseFloat(segments[i].from)
-            if (from > max) {
-                extras = true
-            }
-        }
-        if (extras) {
-            $('#node-input-validation-segments').text('You have segments defined outside of the min/max range of your gauge').show()
-        }
-        return minCovered && !extras
-    }
-    let isDirty = false
-    RED.nodes.registerType('ui-gauge', {
-        category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
-        color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
-        defaults: {
-            name: { value: '' },
-            group: { type: 'ui-group', required: true },
-            order: { value: 0 },
-            width: {
-                value: 3,
-                validate: function (v) {
-                    const width = v || 0
-                    const currentGroup = $('#node-input-group').val() || this.group
-                    const groupNode = RED.nodes.node(currentGroup)
-                    const valid = !groupNode || +width <= +groupNode.width
-                    $('#node-input-size').toggleClass('input-error', !valid)
-                    return valid
+    (function () {
+        function validateGaugeSegments (segments) {
+            $('#node-input-validation-segments').hide()
+            const min = parseFloat(this.min)
+            const max = parseFloat(this.max)
+
+            // check we have a  segment covering the smallest values of the gauge
+            let minCovered = false
+            for (let i = 0; i < segments.length; i++) {
+                const from = parseFloat(segments[i].from)
+                if (from <= min) {
+                    minCovered = true
                 }
+            }
+            if (!minCovered) {
+                $('#node-input-validation-segments').text("It's advised to make sure your first segment's 'from' value and the gauge's 'min' value are the same.").show()
+            }
+            // check if we have any extra, unneccessary, segments
+            let extras = false
+            for (let i = 0; i < segments.length; i++) {
+                const from = parseFloat(segments[i].from)
+                if (from > max) {
+                    extras = true
+                }
+            }
+            if (extras) {
+                $('#node-input-validation-segments').text('You have segments defined outside of the min/max range of your gauge').show()
+            }
+            const unique = new Set(this.segments.map(function (o) { return o.from }))
+            if (this.segments.length === unique.size) { $('#valWarning').hide() } else { $('#valWarning').show() }
+            return minCovered && !extras && this.segments.length === unique.size
+        }
+
+        const DEFAULTS = {
+            'gauge-tank': {
+                min: 0,
+                max: 100,
+                segments: [{
+                    color: '#A8F5FF',
+                    from: 0
+                }, {
+                    color: '#55DBEC',
+                    from: 15
+                }, {
+                    color: '#53B4FD',
+                    from: 35
+                }, {
+                    color: '#2397D1',
+                    from: 50
+                }]
             },
-            height: { value: 3 },
-            gtype: { value: 'gauge-half' },
-            gstyle: { value: 'needle' },
-            title: { value: 'gauge' },
-            units: { value: 'units' },
-            icon: { value: '' },
-            prefix: { value: '' },
-            suffix: { value: '' },
-            segments: {
-                value: [{
+            'gauge-battery': {
+                min: 0,
+                max: 100,
+                segments: [{
+                    color: '#EA5353',
+                    from: 0
+                }, {
+                    color: '#FFC800',
+                    from: 40
+                }, {
+                    color: '#5CD65C',
+                    from: 70
+                }]
+            },
+            'gauge-tile': {
+                min: 0,
+                max: 10,
+                segments: [{
                     color: '#5CD65C',
                     from: 0
                 }, {
@@ -75,270 +86,224 @@
                 }, {
                     color: '#EA5353',
                     from: 7
-                }],
-                validate: validateGaugeSegments
-            },
-            min: { value: 0, required: true, validate: RED.validators.number() },
-            max: { value: 10, required: true, validate: RED.validators.number() },
-            // sizes
-            sizeThickness: { value: 16, validate: RED.validators.number() },
-            sizeGap: { value: 4, validate: RED.validators.number() },
-            sizeKeyThickness: { value: 8, validate: RED.validators.number() },
-            // style
-            styleRounded: { value: true },
-            styleGlow: { value: false },
-            // CSS
-            className: { value: '' }
-        },
-        inputs: 1,
-        outputs: 0,
-        inputLabels: function () { return this.min + ' - ' + this.max },
-        align: 'right',
-        icon: 'ui-gauge.svg',
-        paletteLabel: 'gauge',
-        label: function () { return this.name || this.title || this.gtype },
-        labelStyle: function () { return this.name ? 'node_label_italic' : '' },
-        oneditprepare: function () {
-            let isInitialised = false
-
-            // store reference to initial gtype so we can check if it's changed
-            const initGType = this.gtype
-    
-            // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
-            // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
-            if (RED.nodes.subflow(this.z)) {
-                // change inputs from hidden to text & display them
-                $('#node-input-width').attr('type', 'text')
-                $('#node-input-height').attr('type', 'text')
-                $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                $('div.form-row.nr-db-ui-manual-size-row').show()
-            } else {
-                // not in a subflow, use the elementSizer
-                $('div.form-row.nr-db-ui-element-sizer-row').show()
-                $('div.form-row.nr-db-ui-manual-size-row').hide()
-                $('#node-input-size').elementSizer({
-                    width: '#node-input-width',
-                    height: '#node-input-height',
-                    group: '#node-input-group'
-                })
+                }]
             }
-
-            // check for duplicate values
-            const unique = new Set(this.segments.map(function (o) { return o.from }))
-            if (this.segments.length === unique.size) { $('#valWarning').hide() } else { $('#valWarning').show() }
-
-            validateGaugeSegments.call(this, this.segments)
-
-            function generateSegment (i, segment) {
-                const container = $('<li/>', { style: 'background: var(--red-ui-secondary-background, #fff); margin:0; padding:8px 0px 0px; border-bottom: 1px solid var(--red-ui-form-input-border-color, #ccc);' })
-                const row = $('<div/>').appendTo(container)
-                $('<div/>', { style: 'padding-top:5px; padding-left:175px;' }).appendTo(container)
-                $('<div/>', { style: 'padding-top:5px; padding-left:120px;' }).appendTo(container)
-
-                $('<i style="color: var(--red-ui-form-text-color, #eee); cursor:move; margin-left:3px;" class="node-input-segment-handle fa fa-bars"></i>').appendTo(row)
-
-                $('<input/>', { class: 'node-input-segment-color', type: 'color', style: 'margin-left:7px; width: 50px;', placeholder: 'Color', value: segment.color }).appendTo(row)
-                $('<input/>', { class: 'node-input-segment-from', type: 'text', style: 'margin-left:7px; width:calc(100% - 175px);', placeholder: 'From', value: segment.from }).appendTo(row)
-
-                const finalSpan = $('<span/>', { style: 'float:right; margin-right:8px;' }).appendTo(row)
-                const deleteButton = $('<a/>', { href: '#', class: 'editor-button editor-button-small', style: 'margin-top:7px; margin-left:5px;' }).appendTo(finalSpan)
-                $('<i/>', { class: 'fa fa-remove' }).appendTo(deleteButton)
-
-                deleteButton.click(function () {
-                    container.css({ background: 'var(--red-ui-secondary-background-inactive, #fee)' })
-                    container.fadeOut(300, function () {
-                        $(this).remove()
-                    })
-                    isDirty = true // make dirty on delete segments
-                })
-
-                $('#node-input-segments-container').append(container)
-            }
-
-            $('#node-input-add-segment').click(function () {
-                generateSegment($('#node-input-segments-container').children().length + 1, {})
-                $('#node-input-segments-container-div').scrollTop($('#node-input-segments-container-div').get(0).scrollHeight)
-                isDirty = true // make dirty on add segments
-            })
-
-            $('#node-input-segments-container').sortable({
-                axis: 'y',
-                handle: '.node-input-segment-handle',
-                cursor: 'move'
-            })
-
-            for (let i = 0; i < this.segments.length; i++) {
-                const segment = this.segments[i]
-                generateSegment(i + 1, segment)
-            }
-
-            let currentGaugeType
-
-            const segmentsTank = [{
-                color: '#A8F5FF',
-                from: 0
-            }, {
-                color: '#55DBEC',
-                from: 15
-            }, {
-                color: '#53B4FD',
-                from: 35
-            }, {
-                color: '#2397D1',
-                from: 50
-            }]
-            const segmentsBattery = [{
-                color: '#EA5353',
-                from: 0
-            }, {
-                color: '#FFC800',
-                from: 40
-            }, {
-                color: '#5CD65C',
-                from: 70
-            }]
-            const segmentsTileHalfand34 = [{
-                color: '#5CD65C',
-                from: 0
-            }, {
-                color: '#FFC800',
-                from: 4
-            }, {
-                color: '#EA5353',
-                from: 7
-            }]
-
-            // set default segments based on the current gauge type
-            $('#node-input-get-defaults').click(function () {
-                if (currentGaugeType === 'gauge-tank') {
-                    const segments = segmentsTank
-                    // clear existing segments
-                    $('#node-input-segments-container').empty()
-                    // add the new "defaults" for this gType
-                    for (let i = 0; i < segments.length; i++) {
-                        const segment = segments[i]
-                        generateSegment(i + 1, segment)
-                    }
-                    // set new min/max
-                    $('#node-input-min').val(0)
-                    $('#node-input-max').val(100)
-                } else if (currentGaugeType === 'gauge-battery') {
-                    const segments = segmentsBattery
-                    // clear existing segments
-                    $('#node-input-segments-container').empty()
-                    // add the new "defaults" for this gType
-                    for (let i = 0; i < segments.length; i++) {
-                        const segment = segments[i]
-                        generateSegment(i + 1, segment)
-                    }
-                    // set new min/max
-                    $('#node-input-min').val(0)
-                    $('#node-input-max').val(100)
-                } else {
-                    const segments = segmentsTileHalfand34
-                    // clear existing segments
-                    $('#node-input-segments-container').empty()
-                    // add the new "defaults" for this gType
-                    for (let i = 0; i < segments.length; i++) {
-                        const segment = segments[i]
-                        generateSegment(i + 1, segment)
-                    }
-                    // set new min/max
-                    $('#node-input-min').val(0)
-                    $('#node-input-max').val(10)
-                }
-                isDirty = false // make dirty false on defaults
-            })
-
-            // only show relevant options
-            function showTypeOptions (type) {
-                currentGaugeType = type
-
-                if (type === 'gauge-tile' || type === 'gauge-battery' || type === 'gauge-tank') {
-                    $('#node-input-container-sizes').hide()
-                    $('#node-input-container-gstyle').hide()
-                    $('#node-input-container-label-extras').hide()
-                } else {
-                    $('#node-input-container-sizes').show()
-                    $('#node-input-container-gstyle').show()
-                    $('#node-input-container-label-extras').show()
-                }
-
-                if (type === 'gauge-tank' && initGType !== 'gauge-tank') {
-                    // set some sensible segments
-                    const segments = segmentsTank
-                    if (!isDirty) {
-                        // clear existing segments
-                        $('#node-input-segments-container').empty()
-                        // add the new "defaults" for this gType
-                        for (let i = 0; i < segments.length; i++) {
-                            const segment = segments[i]
-                            generateSegment(i + 1, segment)
-                        }
-                        // set new min/max
-                        $('#node-input-min').val(0)
-                        $('#node-input-max').val(100)
-                    }
-                } else if (type === 'gauge-battery' && initGType !== 'gauge-battery') {
-                    // set some sensible segments
-                    const segments = segmentsBattery
-                    if (!isDirty) {
-                        // clear existing segments
-                        $('#node-input-segments-container').empty()
-                        // add the new "defaults" for this gType
-                        for (let i = 0; i < segments.length; i++) {
-                            const segment = segments[i]
-                            generateSegment(i + 1, segment)
-                        }
-                        // set new min/max
-                        $('#node-input-min').val(0)
-                        $('#node-input-max').val(100)
-                    }
-                } else if (isInitialised) {
-                    // we've actually changed type, not just being triggered by the initial NR load of palette
-
-                    // set some sensible segments
-                    const segments = segmentsTileHalfand34
-
-                    if (!isDirty) {
-                        // clear existing segments
-                        $('#node-input-segments-container').empty()
-                        // add the new "defaults" for this gType
-                        for (let i = 0; i < segments.length; i++) {
-                            const segment = segments[i]
-                            generateSegment(i + 1, segment)
-                        }
-                        // set new min/max
-                        $('#node-input-min').val(0)
-                        $('#node-input-max').val(10)
-                    }
-                }
-                $('.node-input-segment-color, .node-input-segment-from, #node-input-min, #node-input-max').on('input', function () {
-                    isDirty = true // make dirty on input change
-                })
-                isInitialised = true
-            }
-
-            $('#node-input-gtype').change((data) => {
-                const gType = $('#node-input-gtype').val()
-                showTypeOptions(gType)
-            })
-        },
-        oneditsave: function () {
-            const segments = $('#node-input-segments-container').children()
-
-            const node = this
-            node.segments = []
-            segments.each(function (i) {
-                const segment = $(this)
-                const s = {
-                    from: segment.find('.node-input-segment-from').val(),
-                    color: segment.find('.node-input-segment-color').val()
-                }
-                node.segments.push(s)
-            })
         }
-    })
+        DEFAULTS['gauge-34'] = DEFAULTS['gauge-tile']
+        DEFAULTS['gauge-half'] = DEFAULTS['gauge-tile']
+
+        function isDefault (gtype) {
+            // get min, max and segments from UI and check if they are different from the defaults
+            const min = +$('#node-input-min').val()
+            const max = +$('#node-input-max').val()
+            const segments = $('#node-input-segments-container').children()
+            gtype = gtype || $('#node-input-gtype').val()
+            const defaults = DEFAULTS[gtype]
+            if (!defaults) {
+                return false
+            }
+            if (min !== defaults.min || max !== defaults.max || segments.length !== defaults.segments.length) {
+                return false
+            }
+            for (let i = 0; i < segments.length; i++) {
+                const segment = $(segments[i])
+                const from = +segment.find('.node-input-segment-from').val()
+                const color = segment.find('.node-input-segment-color').val()
+                if (from !== defaults.segments[i].from || (color + '').toLowerCase() !== defaults.segments[i].color.toLowerCase()) {
+                    return false
+                }
+            }
+            return true
+        }
+
+        RED.nodes.registerType('ui-gauge', {
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
+            defaults: {
+                name: { value: '' },
+                group: { type: 'ui-group', required: true },
+                order: { value: 0 },
+                width: {
+                    value: 3,
+                    validate: function (v) {
+                        const width = v || 0
+                        const currentGroup = $('#node-input-group').val() || this.group
+                        const groupNode = RED.nodes.node(currentGroup)
+                        const valid = !groupNode || +width <= +groupNode.width
+                        $('#node-input-size').toggleClass('input-error', !valid)
+                        return valid
+                    }
+                },
+                height: { value: 3 },
+                gtype: { value: 'gauge-half' },
+                gstyle: { value: 'needle' },
+                title: { value: 'gauge' },
+                units: { value: 'units' },
+                icon: { value: '' },
+                prefix: { value: '' },
+                suffix: { value: '' },
+                segments: {
+                    value: [{
+                        color: '#5CD65C',
+                        from: 0
+                    }, {
+                        color: '#FFC800',
+                        from: 4
+                    }, {
+                        color: '#EA5353',
+                        from: 7
+                    }],
+                    validate: validateGaugeSegments
+                },
+                min: { value: 0, required: true, validate: RED.validators.number() },
+                max: { value: 10, required: true, validate: RED.validators.number() },
+                // sizes
+                sizeThickness: { value: 16, validate: RED.validators.number() },
+                sizeGap: { value: 4, validate: RED.validators.number() },
+                sizeKeyThickness: { value: 8, validate: RED.validators.number() },
+                // style
+                styleRounded: { value: true },
+                styleGlow: { value: false },
+                // CSS
+                className: { value: '' }
+            },
+            inputs: 1,
+            outputs: 0,
+            inputLabels: function () { return this.min + ' - ' + this.max },
+            align: 'right',
+            icon: 'ui-gauge.svg',
+            paletteLabel: 'gauge',
+            label: function () { return this.name || this.title || this.gtype },
+            labelStyle: function () { return this.name ? 'node_label_italic' : '' },
+            oneditprepare: function () {
+                let isInitialised = false
+                let currentType = this.gtype
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
+
+                function generateSegment (i, segment) {
+                    const container = $('<li/>', { style: 'background: var(--red-ui-secondary-background, #fff); margin:0; padding:8px 0px 0px; border-bottom: 1px solid var(--red-ui-form-input-border-color, #ccc);' })
+                    const row = $('<div/>').appendTo(container)
+                    $('<div/>', { style: 'padding-top:5px; padding-left:175px;' }).appendTo(container)
+                    $('<div/>', { style: 'padding-top:5px; padding-left:120px;' }).appendTo(container)
+
+                    $('<i style="color: var(--red-ui-form-text-color, #eee); cursor:move; margin-left:3px;" class="node-input-segment-handle fa fa-bars"></i>').appendTo(row)
+
+                    $('<input/>', { class: 'node-input-segment-color', type: 'color', style: 'margin-left:7px; width: 50px;', placeholder: 'Color', value: segment.color }).appendTo(row)
+                    $('<input/>', { class: 'node-input-segment-from', type: 'text', style: 'margin-left:7px; width:calc(100% - 175px);', placeholder: 'From', value: segment.from }).appendTo(row)
+
+                    const finalSpan = $('<span/>', { style: 'float:right; margin-right:8px;' }).appendTo(row)
+                    const deleteButton = $('<a/>', { href: '#', class: 'editor-button editor-button-small', style: 'margin-top:7px; margin-left:5px;' }).appendTo(finalSpan)
+                    $('<i/>', { class: 'fa fa-remove' }).appendTo(deleteButton)
+
+                    deleteButton.click(function () {
+                        container.css({ background: 'var(--red-ui-secondary-background-inactive, #fee)' })
+                        container.fadeOut(300, function () {
+                            $(this).remove()
+                        })
+                    })
+
+                    $('#node-input-segments-container').append(container)
+                }
+
+                function showTypeOptions (type) {
+                    const isChanging = currentType !== type
+                    const oldType = currentType
+                    currentType = type
+                    if (type === 'gauge-tile' || type === 'gauge-battery' || type === 'gauge-tank') {
+                        $('#node-input-container-sizes').hide()
+                        $('#node-input-container-gstyle').hide()
+                        $('#node-input-container-label-extras').hide()
+                    } else {
+                        $('#node-input-container-sizes').show()
+                        $('#node-input-container-gstyle').show()
+                        $('#node-input-container-label-extras').show()
+                    }
+
+                    if (isInitialised && isChanging && isDefault(oldType)) {
+                        const defaults = DEFAULTS[currentType]
+                        setup(defaults?.segments, defaults?.min, defaults?.max)
+                    }
+                }
+
+                function setup (segments, min, max) {
+                    $('#node-input-min').val(min)
+                    $('#node-input-max').val(max)
+                    $('#node-input-segments-container').empty()
+                    for (let i = 0; i < segments.length; i++) {
+                        const segment = segments[i]
+                        generateSegment(i + 1, segment)
+                    }
+                }
+
+                $('#node-input-add-segment').click(function () {
+                    generateSegment($('#node-input-segments-container').children().length + 1, {})
+                    $('#node-input-segments-container-div').scrollTop($('#node-input-segments-container-div').get(0).scrollHeight)
+                })
+
+                $('#node-input-segments-container').sortable({
+                    axis: 'y',
+                    handle: '.node-input-segment-handle',
+                    cursor: 'move'
+                })
+
+                // set default segments based on the current gauge type
+                $('#node-input-get-defaults').click(function () {
+                    const selectedType = $('#node-input-gtype').val()
+                    const defaults = DEFAULTS[selectedType]
+                    if (defaults) {
+                        setup(defaults.segments, defaults.min, defaults.max)
+                    }
+                })
+
+                $('#node-input-gtype').change((data) => {
+                    const gType = $('#node-input-gtype').val()
+                    showTypeOptions(gType)
+                })
+
+                // now event handlers are set up, set the initial state of the form
+                setup(this.segments, this.min, this.max)
+
+                // trigger the change event to show the correct options
+                $('#node-input-gtype').change()
+
+                // validate the segments
+                validateGaugeSegments.call(this, this.segments)
+
+                isInitialised = true
+            },
+            oneditsave: function () {
+                const segments = $('#node-input-segments-container').children()
+
+                const node = this
+                node.segments = []
+                segments.each(function (i) {
+                    const segment = $(this)
+                    const s = {
+                        from: segment.find('.node-input-segment-from').val(),
+                        color: segment.find('.node-input-segment-color').val()
+                    }
+                    node.segments.push(s)
+                })
+            }
+        })
+    })()
 </script>
 
 <script type="text/html" data-template-name="ui-gauge">

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -232,7 +232,6 @@
             // only show relevant options
 
             function showTypeOptions (type) {
-                debugger;
                 if (type === 'gauge-tile' || type === 'gauge-battery' || type === 'gauge-tank') {
                     $('#node-input-container-sizes').hide()
                     $('#node-input-container-gstyle').hide()

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -9,7 +9,6 @@
 </style>
 
 <script type="text/javascript">
-    let nodeState
     function validateGaugeSegments (segments) {
         $('#node-input-validation-segments').hide()
         const min = parseFloat(this.min)
@@ -39,6 +38,7 @@
         }
         return minCovered && !extras
     }
+    let isInitialised = false
     RED.nodes.registerType('ui-gauge', {
         category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
         color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
@@ -99,66 +99,7 @@
         label: function () { return this.name || this.title || this.gtype },
         labelStyle: function () { return this.name ? 'node_label_italic' : '' },
         oneditprepare: function () {
-            // Node state for later comparison
-            nodeState = this
-
-            function isDifferent (originalValue, newValue) {
-                // Normalize values (e.g., for strings and numbers)
-                function normalize (value) {
-                    if (typeof value === 'string') {
-                        // Convert string numbers to actual numbers and normalize string case
-                        return isNaN(value) ? value.toLowerCase() : parseFloat(value)
-                    }
-                    return value
-                }
-
-                // Check if both are of the same type after normalization
-                originalValue = normalize(originalValue)
-                newValue = normalize(newValue)
-
-                if (typeof originalValue !== typeof newValue) {
-                    return true // Different types
-                }
-
-                // Handle primitive values (numbers, strings, booleans, etc.)
-                if (typeof originalValue !== 'object' || originalValue === null || newValue === null) {
-                    return originalValue !== newValue
-                }
-
-                // Handle arrays
-                if (Array.isArray(originalValue) && Array.isArray(newValue)) {
-                    if (originalValue.length !== newValue.length) {
-                        return true // Different array lengths
-                    }
-                    for (let i = 0; i < originalValue.length; i++) {
-                        if (isDifferent(originalValue[i], newValue[i])) {
-                            return true // Difference found in array element
-                        }
-                    }
-                    return false // Arrays are the same
-                }
-
-                // Handle objects
-                if (typeof originalValue === 'object' && typeof newValue === 'object') {
-                    const keys1 = Object.keys(originalValue).sort()
-                    const keys2 = Object.keys(newValue).sort()
-
-                    // Check if object keys are different
-                    if (keys1.length !== keys2.length) {
-                        return true // Different number of keys
-                    }
-
-                    // Check if values for each key are different
-                    for (const key of keys1) {
-                        if (!keys2.includes(key) || isDifferent(originalValue[key], newValue[key])) {
-                            return true // Difference found in object property
-                        }
-                    }
-                    return false // Objects are the same
-                }
-
-                return false // Default case if nothing above matched
-            }
+            let isDirty = false
 
             // store reference to initial gtype so we can check if it's changed
             const initGType = this.gtype
@@ -208,6 +149,7 @@
                     container.fadeOut(300, function () {
                         $(this).remove()
                     })
+                    isDirty = true // make dirty on delete segments
                 })
 
                 $('#node-input-segments-container').append(container)
@@ -216,6 +158,7 @@
             $('#node-input-add-segment').click(function () {
                 generateSegment($('#node-input-segments-container').children().length + 1, {})
                 $('#node-input-segments-container-div').scrollTop($('#node-input-segments-container-div').get(0).scrollHeight)
+                isDirty = true // make dirty on add segments
             })
 
             $('#node-input-segments-container').sortable({
@@ -229,9 +172,95 @@
                 generateSegment(i + 1, segment)
             }
 
-            // only show relevant options
+            let currentGaugeType
 
+            const segmentsTank = [{
+                color: '#A8F5FF',
+                from: 0
+            }, {
+                color: '#55DBEC',
+                from: 15
+            }, {
+                color: '#53B4FD',
+                from: 35
+            }, {
+                color: '#2397D1',
+                from: 50
+            }]
+            const segmentsBattery = [{
+                color: '#EA5353',
+                from: 0
+            }, {
+                color: '#FFC800',
+                from: 40
+            }, {
+                color: '#5CD65C',
+                from: 70
+            }]
+            const segmentsTileHalfand34 = [{
+                color: '#5CD65C',
+                from: 0
+            }, {
+                color: '#FFC800',
+                from: 4
+            }, {
+                color: '#EA5353',
+                from: 7
+            }]
+
+            // set default segments based on the current gauge type
+            $('#node-input-get-defaults').click(function () {
+                if (currentGaugeType === 'gauge-tank') {
+                    const segments = segmentsTank
+                    // clear existing segments
+                    $('#node-input-segments-container').empty()
+                    // add the new "defaults" for this gType
+                    for (let i = 0; i < segments.length; i++) {
+                        const segment = segments[i]
+                        generateSegment(i + 1, segment)
+                    }
+                    // set new min/max
+                    $('#node-input-min').val(0)
+                    $('#node-input-max').val(100)
+                } else if (currentGaugeType === 'gauge-battery') {
+                    const segments = segmentsBattery
+                    // clear existing segments
+                    $('#node-input-segments-container').empty()
+                    // add the new "defaults" for this gType
+                    for (let i = 0; i < segments.length; i++) {
+                        const segment = segments[i]
+                        generateSegment(i + 1, segment)
+                    }
+                    // set new min/max
+                    $('#node-input-min').val(0)
+                    $('#node-input-max').val(100)
+                } else {
+                    const segments = segmentsTileHalfand34
+                    // clear existing segments
+                    $('#node-input-segments-container').empty()
+                    // add the new "defaults" for this gType
+                    for (let i = 0; i < segments.length; i++) {
+                        const segment = segments[i]
+                        generateSegment(i + 1, segment)
+                    }
+                    // set new min/max
+                    $('#node-input-min').val(0)
+                    $('#node-input-max').val(10)
+                }
+                isDirty = false // make dirty false on defaults
+            })
+
+            // only show relevant options
             function showTypeOptions (type) {
+                currentGaugeType = type
+                const newSegments = []
+                $('#node-input-segments-container > li').each(function () {
+                    newSegments.push({
+                        color: $(this).find('.node-input-segment-color').val(),
+                        from: $(this).find('.node-input-segment-from').val()
+                    })
+                })
+
                 if (type === 'gauge-tile' || type === 'gauge-battery' || type === 'gauge-tank') {
                     $('#node-input-container-sizes').hide()
                     $('#node-input-container-gstyle').hide()
@@ -242,75 +271,10 @@
                     $('#node-input-container-label-extras').show()
                 }
 
-                const otherGuages = ['gauge-battery', 'gauge-tank']
-
                 if (type === 'gauge-tank' && initGType !== 'gauge-tank') {
-                    // set new min/max
-                    $('#node-input-min').val(0)
-                    $('#node-input-max').val(100)
-
                     // set some sensible segments
-                    const segments = [{
-                        color: '#A8F5FF',
-                        from: 0
-                    }, {
-                        color: '#55DBEC',
-                        from: 15
-                    }, {
-                        color: '#53B4FD',
-                        from: 35
-                    }, {
-                        color: '#2397D1',
-                        from: 50
-                    }]
-                    // clear existing segments
-                    $('#node-input-segments-container').empty()
-                    // add the new "defaults" for this gType
-                    for (let i = 0; i < segments.length; i++) {
-                        const segment = segments[i]
-                        generateSegment(i + 1, segment)
-                    }
-                } else if (type === 'gauge-battery' && initGType !== 'gauge-battery') {
-                    // set new min/max
-                    $('#node-input-min').val(0)
-                    $('#node-input-max').val(100)
-
-                    // set some sensible segments
-                    const segments = [{
-                        color: '#EA5353',
-                        from: 0
-                    }, {
-                        color: '#FFC800',
-                        from: 40
-                    }, {
-                        color: '#5CD65C',
-                        from: 70
-                    }]
-                    // clear existing segments
-                    $('#node-input-segments-container').empty()
-                    // add the new "defaults" for this gType
-                    for (let i = 0; i < segments.length; i++) {
-                        const segment = segments[i]
-                        generateSegment(i + 1, segment)
-                    }
-                } else if (initGType !== type) {
-                    // we've actually changed type, not just being triggered by the initial NR load of palette
-                    const inputMin = 0
-                    const inputMax = 10
-
-                    // set some sensible segments
-                    const segments = [{
-                        color: '#5CD65C',
-                        from: 0
-                    }, {
-                        color: '#FFC800',
-                        from: 4
-                    }, {
-                        color: '#EA5353',
-                        from: 7
-                    }]
-
-                    if (!isDifferent(segments, nodeState.segments) || otherGuages.includes(initGType)) {
+                    const segments = segmentsTank
+                    if (!isDirty) {
                         // clear existing segments
                         $('#node-input-segments-container').empty()
                         // add the new "defaults" for this gType
@@ -318,18 +282,50 @@
                             const segment = segments[i]
                             generateSegment(i + 1, segment)
                         }
-                    }
-                    if (!isDifferent(inputMin, nodeState.min) || otherGuages.includes(initGType)) {
-                        // set new min
+                        // set new min/max
                         $('#node-input-min').val(0)
+                        $('#node-input-max').val(100)
                     }
-                    if (!isDifferent(inputMax, nodeState.max) || otherGuages.includes(initGType)) {
-                        // set new max
+                } else if (type === 'gauge-battery' && initGType !== 'gauge-battery') {
+                    // set some sensible segments
+                    const segments = segmentsBattery
+                    if (!isDirty) {
+                        // clear existing segments
+                        $('#node-input-segments-container').empty()
+                        // add the new "defaults" for this gType
+                        for (let i = 0; i < segments.length; i++) {
+                            const segment = segments[i]
+                            generateSegment(i + 1, segment)
+                        }
+                        // set new min/max
+                        $('#node-input-min').val(0)
+                        $('#node-input-max').val(100)
+                    }
+                } else if (isInitialised) {
+                    // we've actually changed type, not just being triggered by the initial NR load of palette
+
+                    // set some sensible segments
+                    const segments = segmentsTileHalfand34
+
+                    if (!isDirty) {
+                        // clear existing segments
+                        $('#node-input-segments-container').empty()
+                        // add the new "defaults" for this gType
+                        for (let i = 0; i < segments.length; i++) {
+                            const segment = segments[i]
+                            generateSegment(i + 1, segment)
+                        }
+                        // set new min/max
+                        $('#node-input-min').val(0)
                         $('#node-input-max').val(10)
                     }
                 }
+                $('.node-input-segment-color, .node-input-segment-from, #node-input-min, #node-input-max').on('input', function () {
+                    isDirty = true // make dirty on input change
+                })
+                isInitialised = true
             }
-    
+
             $('#node-input-gtype').change((data) => {
                 const gType = $('#node-input-gtype').val()
                 showTypeOptions(gType)
@@ -421,6 +417,7 @@
     </div>
     <div class="form-row">
         <a href="#" class="editor-button editor-button-small" id="node-input-add-segment" style="margin-top:4px; margin-left:103px;"><i class="fa fa-plus"></i> <span data-i18n="ui-gauge.label.segment"></span></a>
+        <a href="#" class="editor-button editor-button-small" id="node-input-get-defaults" style="margin-top:4px;"><span data-i18n="ui-gauge.label.defaults"></span></a>
     </div>
     <div class="form-row">
         <h3 data-i18n="ui-gauge.label.labelling"></h3>

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -232,6 +232,7 @@
             // only show relevant options
 
             function showTypeOptions (type) {
+                debugger;
                 if (type === 'gauge-tile' || type === 'gauge-battery' || type === 'gauge-tank') {
                     $('#node-input-container-sizes').hide()
                     $('#node-input-container-gstyle').hide()
@@ -241,6 +242,8 @@
                     $('#node-input-container-gstyle').show()
                     $('#node-input-container-label-extras').show()
                 }
+
+                const otherGuages = ['gauge-battery', 'gauge-tank']
 
                 if (type === 'gauge-tank' && initGType !== 'gauge-tank') {
                     // set new min/max
@@ -291,7 +294,7 @@
                         const segment = segments[i]
                         generateSegment(i + 1, segment)
                     }
-                } else if (['gauge-half', 'gauge-34'].includes(type) && ['gauge-half', 'gauge-34'].includes(initGType)) {
+                } else if (initGType !== type) {
                     // we've actually changed type, not just being triggered by the initial NR load of palette
                     const inputMin = 0
                     const inputMax = 10
@@ -308,7 +311,7 @@
                         from: 7
                     }]
 
-                    if (!isDifferent(segments, nodeState.segments)) {
+                    if (!isDifferent(segments, nodeState.segments) || otherGuages.includes(initGType)) {
                         // clear existing segments
                         $('#node-input-segments-container').empty()
                         // add the new "defaults" for this gType
@@ -317,11 +320,11 @@
                             generateSegment(i + 1, segment)
                         }
                     }
-                    if (!isDifferent(inputMin, nodeState.min)) {
+                    if (!isDifferent(inputMin, nodeState.min) || otherGuages.includes(initGType)) {
                         // set new min
                         $('#node-input-min').val(0)
                     }
-                    if (!isDifferent(inputMax, nodeState.max)) {
+                    if (!isDifferent(inputMax, nodeState.max) || otherGuages.includes(initGType)) {
                         // set new max
                         $('#node-input-max').val(10)
                     }

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -9,6 +9,7 @@
 </style>
 
 <script type="text/javascript">
+    let nodeState
     function validateGaugeSegments (segments) {
         $('#node-input-validation-segments').hide()
         const min = parseFloat(this.min)
@@ -98,6 +99,67 @@
         label: function () { return this.name || this.title || this.gtype },
         labelStyle: function () { return this.name ? 'node_label_italic' : '' },
         oneditprepare: function () {
+            // Node state for later comparison
+            nodeState = this
+
+            function isDifferent (originalValue, newValue) {
+                // Normalize values (e.g., for strings and numbers)
+                function normalize (value) {
+                    if (typeof value === 'string') {
+                        // Convert string numbers to actual numbers and normalize string case
+                        return isNaN(value) ? value.toLowerCase() : parseFloat(value)
+                    }
+                    return value
+                }
+
+                // Check if both are of the same type after normalization
+                originalValue = normalize(originalValue)
+                newValue = normalize(newValue)
+
+                if (typeof originalValue !== typeof newValue) {
+                    return true // Different types
+                }
+
+                // Handle primitive values (numbers, strings, booleans, etc.)
+                if (typeof originalValue !== 'object' || originalValue === null || newValue === null) {
+                    return originalValue !== newValue
+                }
+
+                // Handle arrays
+                if (Array.isArray(originalValue) && Array.isArray(newValue)) {
+                    if (originalValue.length !== newValue.length) {
+                        return true // Different array lengths
+                    }
+                    for (let i = 0; i < originalValue.length; i++) {
+                        if (isDifferent(originalValue[i], newValue[i])) {
+                            return true // Difference found in array element
+                        }
+                    }
+                    return false // Arrays are the same
+                }
+
+                // Handle objects
+                if (typeof originalValue === 'object' && typeof newValue === 'object') {
+                    const keys1 = Object.keys(originalValue).sort()
+                    const keys2 = Object.keys(newValue).sort()
+
+                    // Check if object keys are different
+                    if (keys1.length !== keys2.length) {
+                        return true // Different number of keys
+                    }
+
+                    // Check if values for each key are different
+                    for (const key of keys1) {
+                        if (!keys2.includes(key) || isDifferent(originalValue[key], newValue[key])) {
+                            return true // Difference found in object property
+                        }
+                    }
+                    return false // Objects are the same
+                }
+
+                return false // Default case if nothing above matched
+            }
+
             // store reference to initial gtype so we can check if it's changed
             const initGType = this.gtype
     
@@ -229,12 +291,10 @@
                         const segment = segments[i]
                         generateSegment(i + 1, segment)
                     }
-                } else if (initGType !== type) {
+                } else if (['gauge-half', 'gauge-34'].includes(type) && ['gauge-half', 'gauge-34'].includes(initGType)) {
                     // we've actually changed type, not just being triggered by the initial NR load of palette
-    
-                    // set new min/max
-                    $('#node-input-min').val(0)
-                    $('#node-input-max').val(10)
+                    const inputMin = 0
+                    const inputMax = 10
 
                     // set some sensible segments
                     const segments = [{
@@ -247,12 +307,23 @@
                         color: '#EA5353',
                         from: 7
                     }]
-                    // clear existing segments
-                    $('#node-input-segments-container').empty()
-                    // add the new "defaults" for this gType
-                    for (let i = 0; i < segments.length; i++) {
-                        const segment = segments[i]
-                        generateSegment(i + 1, segment)
+
+                    if (!isDifferent(segments, nodeState.segments)) {
+                        // clear existing segments
+                        $('#node-input-segments-container').empty()
+                        // add the new "defaults" for this gType
+                        for (let i = 0; i < segments.length; i++) {
+                            const segment = segments[i]
+                            generateSegment(i + 1, segment)
+                        }
+                    }
+                    if (!isDifferent(inputMin, nodeState.min)) {
+                        // set new min
+                        $('#node-input-min').val(0)
+                    }
+                    if (!isDifferent(inputMax, nodeState.max)) {
+                        // set new max
+                        $('#node-input-max').val(10)
                     }
                 }
             }


### PR DESCRIPTION
## Description

This PR introduces two key changes to enhance the user experience when interacting with range and segment fields:

#### 1. Preserve Field Values:
The range (min / max) and segment (color / from) values will now be preserved when the user modifies the field inputs (`min`, `max`, `segment color`,  `segment from`, `add new segment`, `remove an existing segment`).
Previously, the values of these fields got reset to defaults on gauge change.

#### 2. Reset to Default Button:
A "Defaults" button has been added to allow users to quickly revert any changes made to the range and segment fields back to their original default values based on the selected gauge type.
<img width="234" alt="Screenshot 2024-09-20 at 10 53 42" src="https://github.com/user-attachments/assets/8f3b2d70-f043-4628-b101-df59792a47e9">

_This doesn't need e2e test update but node-red built-in help updated_

## Related Issue(s)

https://github.com/FlowFuse/node-red-dashboard/issues/1266

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

