### PR TITLE
Layout switching configuration with dynamic property support

### DIFF
--- a/cypress/fixtures/flows/dashboard-switches.json
+++ b/cypress/fixtures/flows/dashboard-switches.json
@@ -61,6 +61,352 @@
         "wires": [
             []
         ]
+    },{
+        "id": "dashboard-ui-button-layout-left",
+        "type": "ui-button",
+        "z": "62c98d3bf1ed37c0",
+        "group": "dashboard-ui-group-4",
+        "name": "",
+        "label": "Button - Layout (Left)",
+        "order": 2,
+        "width": 0,
+        "height": 0,
+        "emulateClick": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "true",
+        "payloadType": "bool",
+        "topic": "",
+        "topicType": "str",
+        "buttonColor": "",
+        "textColor": "",
+        "iconColor": "",
+        "x": 180,
+        "y": 400,
+        "wires": [
+            [
+                "e934c132f83bc548"
+            ]
+        ]
+    },
+    {
+        "id": "9e3d9eb72e4781b3",
+        "type": "function",
+        "z": "62c98d3bf1ed37c0",
+        "name": "Store Latest Msg",
+        "func": "global.set('msg', msg)\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 970,
+        "y": 320,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "dashboard-ui-switch-change-layout",
+        "type": "ui-switch",
+        "z": "62c98d3bf1ed37c0",
+        "name": "",
+        "label": "Change layout",
+        "group": "dashboard-ui-group-4",
+        "order": 1,
+        "width": "0",
+        "height": "0",
+        "passthru": false,
+        "decouple": true,
+        "topic": "topic",
+        "topicType": "str",
+        "style": "",
+        "className": "",
+        "layout": "",
+        "clickableArea": "switch",
+        "onvalue": "on",
+        "onvalueType": "str",
+        "onicon": "",
+        "oncolor": "",
+        "offvalue": "off",
+        "offvalueType": "str",
+        "officon": "",
+        "offcolor": "",
+        "x": 740,
+        "y": 480,
+        "wires": [
+            [
+                "9e3d9eb72e4781b3"
+            ]
+        ]
+    },
+    {
+        "id": "e934c132f83bc548",
+        "type": "change",
+        "z": "62c98d3bf1ed37c0",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "ui_update.layout",
+                "pt": "msg",
+                "to": "row-left",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 430,
+        "y": 400,
+        "wires": [
+            [
+                "dashboard-ui-switch-change-layout"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-button-layout-center",
+        "type": "ui-button",
+        "z": "62c98d3bf1ed37c0",
+        "group": "dashboard-ui-group-4",
+        "name": "",
+        "label": "Button - Layout (Center)",
+        "order": 6,
+        "width": 0,
+        "height": 0,
+        "emulateClick": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "true",
+        "payloadType": "bool",
+        "topic": "",
+        "topicType": "str",
+        "buttonColor": "",
+        "textColor": "",
+        "iconColor": "",
+        "x": 170,
+        "y": 440,
+        "wires": [
+            [
+                "0741382ee9cf8cd2"
+            ]
+        ]
+    },
+    {
+        "id": "0741382ee9cf8cd2",
+        "type": "change",
+        "z": "62c98d3bf1ed37c0",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "ui_update.layout",
+                "pt": "msg",
+                "to": "row-center",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 430,
+        "y": 440,
+        "wires": [
+            [
+                "dashboard-ui-switch-change-layout"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-button-layout-right",
+        "type": "ui-button",
+        "z": "62c98d3bf1ed37c0",
+        "group": "dashboard-ui-group-4",
+        "name": "",
+        "label": "Button - Layout (Right)",
+        "order": 5,
+        "width": 0,
+        "height": 0,
+        "emulateClick": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "true",
+        "payloadType": "bool",
+        "topic": "",
+        "topicType": "str",
+        "buttonColor": "",
+        "textColor": "",
+        "iconColor": "",
+        "x": 180,
+        "y": 480,
+        "wires": [
+            [
+                "af8260a8a9e039af"
+            ]
+        ]
+    },
+    {
+        "id": "af8260a8a9e039af",
+        "type": "change",
+        "z": "62c98d3bf1ed37c0",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "ui_update.layout",
+                "pt": "msg",
+                "to": "row-right",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 430,
+        "y": 480,
+        "wires": [
+            [
+                "dashboard-ui-switch-change-layout"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-button-layout-col-center",
+        "type": "ui-button",
+        "z": "62c98d3bf1ed37c0",
+        "group": "dashboard-ui-group-4",
+        "name": "",
+        "label": "Button - Layout (Col Center)",
+        "order": 4,
+        "width": 0,
+        "height": 0,
+        "emulateClick": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "true",
+        "payloadType": "bool",
+        "topic": "",
+        "topicType": "str",
+        "buttonColor": "",
+        "textColor": "",
+        "iconColor": "",
+        "x": 160,
+        "y": 520,
+        "wires": [
+            [
+                "cf50eac9097f2e04"
+            ]
+        ]
+    },
+    {
+        "id": "cf50eac9097f2e04",
+        "type": "change",
+        "z": "62c98d3bf1ed37c0",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "ui_update.layout",
+                "pt": "msg",
+                "to": "col-center",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 430,
+        "y": 520,
+        "wires": [
+            [
+                "dashboard-ui-switch-change-layout"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-button-layout-spread",
+        "type": "ui-button",
+        "z": "62c98d3bf1ed37c0",
+        "group": "dashboard-ui-group-4",
+        "name": "",
+        "label": "Button - Layout (Spread)",
+        "order": 3,
+        "width": 0,
+        "height": 0,
+        "emulateClick": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "true",
+        "payloadType": "bool",
+        "topic": "",
+        "topicType": "str",
+        "buttonColor": "",
+        "textColor": "",
+        "iconColor": "",
+        "x": 170,
+        "y": 560,
+        "wires": [
+            [
+                "c8afc95375dcf813"
+            ]
+        ]
+    },
+    {
+        "id": "c8afc95375dcf813",
+        "type": "change",
+        "z": "62c98d3bf1ed37c0",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "ui_update.layout",
+                "pt": "msg",
+                "to": "row-spread",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 430,
+        "y": 560,
+        "wires": [
+            [
+                "dashboard-ui-switch-change-layout"
+            ]
+        ]
     },
     {
         "id": "dashboard-ui-group",
@@ -258,6 +604,19 @@
         "id": "dashboard-ui-group-3",
         "type": "ui-group",
         "name": "Group 3",
+        "page": "dashboard-ui-page-1",
+        "width": "6",
+        "height": "1",
+        "order": -1,
+        "showTitle": true,
+        "className": "",
+        "visible": "true",
+        "disabled": "false"
+    },
+    {
+        "id": "dashboard-ui-group-4",
+        "type": "ui-group",
+        "name": "Group 4",
         "page": "dashboard-ui-page-1",
         "width": "6",
         "height": "1",

--- a/cypress/fixtures/flows/dashboard-switches.json
+++ b/cypress/fixtures/flows/dashboard-switches.json
@@ -173,12 +173,12 @@
         ]
     },
     {
-        "id": "dashboard-ui-button-layout-center",
+        "id": "dashboard-ui-button-layout-left-swapped",
         "type": "ui-button",
         "z": "62c98d3bf1ed37c0",
         "group": "dashboard-ui-group-4",
         "name": "",
-        "label": "Button - Layout (Center)",
+        "label": "Button - Layout (Left Swapped)",
         "order": 6,
         "width": 0,
         "height": 0,
@@ -214,7 +214,7 @@
                 "t": "set",
                 "p": "ui_update.layout",
                 "pt": "msg",
-                "to": "row-center",
+                "to": "row-left-swapped",
                 "tot": "str"
             }
         ],
@@ -232,71 +232,12 @@
         ]
     },
     {
-        "id": "dashboard-ui-button-layout-right",
+        "id": "dashboard-ui-button-layout-spread",
         "type": "ui-button",
         "z": "62c98d3bf1ed37c0",
         "group": "dashboard-ui-group-4",
         "name": "",
-        "label": "Button - Layout (Right)",
-        "order": 5,
-        "width": 0,
-        "height": 0,
-        "emulateClick": false,
-        "tooltip": "",
-        "color": "",
-        "bgcolor": "",
-        "className": "",
-        "icon": "",
-        "iconPosition": "left",
-        "payload": "true",
-        "payloadType": "bool",
-        "topic": "",
-        "topicType": "str",
-        "buttonColor": "",
-        "textColor": "",
-        "iconColor": "",
-        "x": 180,
-        "y": 480,
-        "wires": [
-            [
-                "af8260a8a9e039af"
-            ]
-        ]
-    },
-    {
-        "id": "af8260a8a9e039af",
-        "type": "change",
-        "z": "62c98d3bf1ed37c0",
-        "name": "",
-        "rules": [
-            {
-                "t": "set",
-                "p": "ui_update.layout",
-                "pt": "msg",
-                "to": "row-right",
-                "tot": "str"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 430,
-        "y": 480,
-        "wires": [
-            [
-                "dashboard-ui-switch-change-layout"
-            ]
-        ]
-    },
-    {
-        "id": "dashboard-ui-button-layout-col-center",
-        "type": "ui-button",
-        "z": "62c98d3bf1ed37c0",
-        "group": "dashboard-ui-group-4",
-        "name": "",
-        "label": "Button - Layout (Col Center)",
+        "label": "Button - Layout (Spread)",
         "order": 4,
         "width": 0,
         "height": 0,
@@ -332,7 +273,7 @@
                 "t": "set",
                 "p": "ui_update.layout",
                 "pt": "msg",
-                "to": "col-center",
+                "to": "row-spread",
                 "tot": "str"
             }
         ],
@@ -350,12 +291,12 @@
         ]
     },
     {
-        "id": "dashboard-ui-button-layout-spread",
+        "id": "dashboard-ui-button-layout-spread-swapped",
         "type": "ui-button",
         "z": "62c98d3bf1ed37c0",
         "group": "dashboard-ui-group-4",
         "name": "",
-        "label": "Button - Layout (Spread)",
+        "label": "Button - Layout (Spread Swapped)",
         "order": 3,
         "width": 0,
         "height": 0,
@@ -391,7 +332,7 @@
                 "t": "set",
                 "p": "ui_update.layout",
                 "pt": "msg",
-                "to": "row-spread",
+                "to": "row-spread-swapped",
                 "tot": "str"
             }
         ],

--- a/cypress/tests/widgets/switch.spec.js
+++ b/cypress/tests/widgets/switch.spec.js
@@ -140,6 +140,13 @@ describe('Node-RED Dashboard 2.0 - Change the layout', () => {
         cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-left')
     })
 
+    it('change the layout to row-left-swapped', () => {
+        cy.resetContext()
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-left-swapped'))
+
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-left-swapped')
+    })
+
     it('change the layout to row-spread', () => {
         cy.resetContext()
         cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-spread'))
@@ -147,24 +154,10 @@ describe('Node-RED Dashboard 2.0 - Change the layout', () => {
         cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-spread')
     })
 
-    it('change the layout to col-center', () => {
+    it('change the layout to row-spread-swapped', () => {
         cy.resetContext()
-        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-col-center'))
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-spread-swapped'))
 
-        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--col-center')
-    })
-
-    it('change the layout to row-right', () => {
-        cy.resetContext()
-        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-right'))
-
-        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-right')
-    })
-
-    it('change the layout to row-center', () => {
-        cy.resetContext()
-        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-center'))
-
-        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-center')
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-spread-swapped')
     })
 })

--- a/cypress/tests/widgets/switch.spec.js
+++ b/cypress/tests/widgets/switch.spec.js
@@ -126,3 +126,45 @@ describe('Node-RED Dashboard 2.0 - Switches in "Show Input" mode', () => {
         cy.get('#nrdb-ui-widget-dashboard-ui-switch-show-input').find('.v-input.v-input--horizontal').should('have.class', 'active')
     })
 })
+
+describe('Node-RED Dashboard 2.0 - Change the layout', () => {
+    beforeEach(() => {
+        cy.deployFixture('dashboard-switches')
+        cy.visit('/dashboard/page1')
+    })
+
+    it('change the layout to row-left', () => {
+        cy.resetContext()
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-left'))
+
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-left')
+    })
+
+    it('change the layout to row-spread', () => {
+        cy.resetContext()
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-spread'))
+
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-spread')
+    })
+
+    it('change the layout to col-center', () => {
+        cy.resetContext()
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-col-center'))
+
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--col-center')
+    })
+
+    it('change the layout to row-right', () => {
+        cy.resetContext()
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-right'))
+
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-right')
+    })
+
+    it('change the layout to row-center', () => {
+        cy.resetContext()
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-layout-center'))
+
+        cy.get('#nrdb-ui-widget-dashboard-ui-switch-change-layout .nrdb-switch').should('have.class', 'nrdb-ui-switch--row-center')
+    })
+})

--- a/docs/nodes/widgets/ui-switch.md
+++ b/docs/nodes/widgets/ui-switch.md
@@ -7,7 +7,7 @@ props:
         description: The text shown within the button.
         dynamic: true
     Layout:
-        description: Defines how the label and the switch are arranged. Users can choose between different layout options such as aligning elements to the left, center, right, spreading them evenly in a row or centering them in a column.
+        description: Defines how the label and the switch are arranged. Users can choose between different layout options such as aligning elements to the left, left reversed, spread evenly or spread evenly but in reversed order.
         dynamic: true
     Clickable:
         description: The clickable area (which will result in the switch toggling).

--- a/docs/nodes/widgets/ui-switch.md
+++ b/docs/nodes/widgets/ui-switch.md
@@ -3,12 +3,27 @@ description: Utilize the ui-switch widget in Node-RED Dashboard 2.0 to create in
 props:
     Group: Defines which group of the UI Dashboard this widget will render in.
     Size: Controls the width of the button with respect to the parent group. Maximum value is the width of the group.
-    Label: The text shown within the button.
-    Clickable: The clickable area (which will result in the switch toggling).
-    On Icon: If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "on" state. No need to include the <code>mdi</code> prefix.
-    Off Icon: If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "off" state. No need to include the <code>mdi</code> prefix.
-    On Color: If provided with a icons, this colour is used for the icon when in "on" state
-    Off Color: If provided with a icons, this colour is used for the icon when in "off" state
+    Label:
+        description: The text shown within the button.
+        dynamic: true
+    Layout:
+        description: Defines how the label and the switch are arranged. Users can choose between different layout options such as aligning elements to the left, center, right, spreading them evenly in a row or centering them in a column.
+        dynamic: true
+    Clickable:
+        description: The clickable area (which will result in the switch toggling).
+        dynamic: true
+    On Icon:
+        description: If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "on" state. No need to include the <code>mdi</code> prefix.
+        dynamic: true
+    Off Icon:
+        description: If provided, this <a href="https://pictogrammers.com/library/mdi/" target="_blank">Material Design icon</a> will replace the default switch when in "off" state. No need to include the <code>mdi</code> prefix.
+        dynamic: true
+    On Color:
+        description: If provided with a icons, this colour is used for the icon when in "on" state
+        dynamic: true
+    Off Color:
+        description: If provided with a icons, this colour is used for the icon when in "off" state
+        dynamic: true
     Passthrough: If enabled, the widget will pass through the input message to the output.
     Indicator: Only available when "Passthrough" is set to <code>false</code>. Defines whether the switch shows the status of the output, or any provided input via <code>msg.payload</code>.
     On Payload: The type & value to output in <code>msg.payload</code> when the switch is turned on.
@@ -24,6 +39,9 @@ dynamic:
     Label:
         payload: msg.ui_update.label
         structure: ["Boolean"]
+    Layout:
+        payload: msg.ui_update.layout
+        structure: ["String"]
     Clickable:
         payload: msg.ui_update.clickableArea
         structure: ["String"]

--- a/nodes/widgets/locales/en-US/ui_switch.html
+++ b/nodes/widgets/locales/en-US/ui_switch.html
@@ -24,6 +24,16 @@
         <dd>If "Icon" is defined, this property controls which side of the "Label" the icon will render on</dd>
         <dt>Label <span class="property-type">string</span></dt>
         <dd>The text shown within the button. If not provided, then the button will only render the icon. It supports HTML content</dd>
+        <dt>Layout <span class="property-type">row-left | row-center | row-right | row-spread | col-center</span></dt>
+        <dd>Specifies how the label and switch input are arranged. The options include:
+            <ul>
+                <li><code>row-left</code>: Aligns elements to the left in a row.</li>
+                <li><code>row-center</code>: Centers elements horizontally in a row.</li>
+                <li><code>row-right</code>: Aligns elements to the right in a row.</li>
+                <li><code>row-spread</code>: Spreads elements evenly across the row.</li>
+                <li><code>col-center</code>: Centers elements in a column.</li>
+            </ul>
+        </dd>
         <dt>Clickable <span class="property-type">string</span></dt>
         <dd>The part of the horizontal line that is clickable.  By default only the switch icon will be clickable.</dd>
         <dt>Icon <span class="property-type">default | custom</span></dt>
@@ -58,6 +68,10 @@
         <dd>Change the switch label at runtime.</dd>
     </dl>
     <dl class="message-properties">
+        <dt class="optional">layout <span class="property-type">string</span></dt>
+        <dd>Chose from "row-left", "row-center", "row-right", "row-spread", "col-center"</dd>
+    </dl>
+    <dl class="message-properties">
         <dt class="optional">clickableArea <span class="property-type">string</span></dt>
         <dd>
             Change the clickable area at runtime:
@@ -74,7 +88,7 @@
     </dl>
     <dl class="message-properties">
         <dt class="optional">decouple <span class="property-type">boolean</span></dt>
-        <dd>Change the indicator at runtime.  When <code>true</code> the icon shows state of the input, and when <code>false</code> the state of the output</dd>
+        <dd>Change the indicator at runtime. When <code>true</code> the icon shows state of the input, and when <code>false</code> the state of the output</dd>
     </dl>
     <dl class="message-properties">
         <dt class="optional">oncolor <span class="property-type">string</span></dt>

--- a/nodes/widgets/locales/en-US/ui_switch.html
+++ b/nodes/widgets/locales/en-US/ui_switch.html
@@ -24,14 +24,13 @@
         <dd>If "Icon" is defined, this property controls which side of the "Label" the icon will render on</dd>
         <dt>Label <span class="property-type">string</span></dt>
         <dd>The text shown within the button. If not provided, then the button will only render the icon. It supports HTML content</dd>
-        <dt>Layout <span class="property-type">row-left | row-center | row-right | row-spread | col-center</span></dt>
+        <dt>Layout <span class="property-type">row-left | row-left-swapped | row-spread | row-spread-swapped</span></dt>
         <dd>Specifies how the label and switch input are arranged. The options include:
             <ul>
                 <li><code>row-left</code>: Aligns elements to the left in a row.</li>
-                <li><code>row-center</code>: Centers elements horizontally in a row.</li>
-                <li><code>row-right</code>: Aligns elements to the right in a row.</li>
+                <li><code>row-left-swapped</code>: Aligns elements to the left in a row but in reversed order.</li>
                 <li><code>row-spread</code>: Spreads elements evenly across the row.</li>
-                <li><code>col-center</code>: Centers elements in a column.</li>
+                <li><code>row-spread-swapped</code>: Spreads elements evenly across the row but in reversed order.</li>
             </ul>
         </dd>
         <dt>Clickable <span class="property-type">string</span></dt>
@@ -69,7 +68,7 @@
     </dl>
     <dl class="message-properties">
         <dt class="optional">layout <span class="property-type">string</span></dt>
-        <dd>Chose from "row-left", "row-center", "row-right", "row-spread", "col-center"</dd>
+        <dd>Chose from "row-left", "row-left-swapped", "row-spread", "row-spread-swapped"</dd>
     </dl>
     <dl class="message-properties">
         <dt class="optional">clickableArea <span class="property-type">string</span></dt>

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -130,8 +130,10 @@
                     }
                 })
 
-                $('.nr-db-switch-layout-' + (this.layout || 'row-spread')).addClass('selected');
-                ['.nr-db-switch-layout-row-left', '.nr-db-switch-layout-row-left-swapped', '.nr-db-switch-layout-row-spread', '.nr-db-switch-layout-row-spread-swapped']
+                // select default option
+                $('#nr-db-switch-layout-' + (this.layout || 'row-spread')).addClass('selected');
+                // add click handlers
+                ['#nr-db-switch-layout-row-left', '#nr-db-switch-layout-row-left-swapped', '#nr-db-switch-layout-row-spread', '#nr-db-switch-layout-row-spread-swapped']
                     .forEach(function (id) {
                         $(id).click(function (e) {
                             $('.nr-db-switch-layout').removeClass('selected')
@@ -212,24 +214,24 @@
             <input type="hidden" id="node-input-layout">
             <input type="hidden" id="node-input-layoutAlign" >
             <div>
-                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-left">
+                <a href="#" id="nr-db-switch-layout-row-left" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-left">
                     <span class="nr-db-switch-layout-label">label</span>
                     <span class="nr-db-switch-layout-value">switch</span>
                     <div class="nr-db-switch-layout-checkbox"></div>
                 </a>
-                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-left-swapped">
+                <a href="#" id="nr-db-switch-layout-row-left-swapped" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-left">
                     <span class="nr-db-switch-layout-value">switch</span>
                     <span class="nr-db-switch-layout-label">label</span>
                     <div class="nr-db-switch-layout-checkbox"></div>
                 </a>
             </div>
             <div>
-                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-spread">
+                <a href="#" id="nr-db-switch-layout-row-spread" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-spread">
                     <span class="nr-db-switch-layout-label">label</span>
                     <span class="nr-db-switch-layout-value">switch</span>
                     <div class="nr-db-switch-layout-checkbox"></div>
                 </a>
-                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-spread-swapped">
+                <a href="#" id="nr-db-switch-layout-row-spread-swapped" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-spread">
                     <span class="nr-db-switch-layout-value">switch</span>
                     <span class="nr-db-switch-layout-label">label</span>
                     <div class="nr-db-switch-layout-checkbox"></div>
@@ -309,23 +311,21 @@
         border-color: var(--red-ui-form-input-border-selected-color, #333);
         color: var(--red-ui-secondary-text-color-selected, #333);
     }
-    .nr-db-switch-layout span {
-        position: absolute;
-    }
     .nr-db-switch-layout-value {
         font-weight: bold;
     }
-    .nr-db-switch-layout-row span { top: 20px; }
-    
-    .nr-db-switch-layout-row-left .nr-db-switch-layout-label { left: 2px; }
-    .nr-db-switch-layout-row-left .nr-db-switch-layout-value { left: 34px; }
-    .nr-db-switch-layout-row-left-swapped .nr-db-switch-layout-label { left: 48px; }
-    .nr-db-switch-layout-row-left-swapped .nr-db-switch-layout-value { left: 2px; }
-
-    .nr-db-switch-layout-row-spread .nr-db-switch-layout-label { left: 2px; }
-    .nr-db-switch-layout-row-spread .nr-db-switch-layout-value { right: 2px; }
-    .nr-db-switch-layout-row-spread-swapped .nr-db-switch-layout-label { left: 2px; }
-    .nr-db-switch-layout-row-spread-swapped .nr-db-switch-layout-value { right: 2px; }
+    .nr-db-switch-layout-row {
+        display: inline-flex;
+        align-items: center;
+        padding: 3px;
+    }
+    .nr-db-switch-layout-row-left {
+        justify-content: flex-start;
+        gap: 3px;
+    }
+    .nr-db-switch-layout-row-spread {
+        justify-content: space-between;
+    }
 
     .nr-db-switch-layout-col span { width: 100%;  text-align: center; left: 0px;}
     .nr-db-switch-layout-checkbox {

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -30,6 +30,7 @@
                 topicType: { value: 'msg' },
                 style: { value: '' },
                 className: { value: '' },
+                layout: { value: 'row-spread' },
                 clickableArea: { value: 'switch' },
                 // on state
                 onvalue: { value: true, validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('onvalueType') : function (v) { return true }) },
@@ -128,6 +129,17 @@
                         delay: 150
                     }
                 })
+
+                $('.nr-db-switch-layout-' + (this.layout || 'row-spread')).addClass('selected');
+                ['.nr-db-switch-layout-row-left', '.nr-db-switch-layout-row-center', '.nr-db-switch-layout-row-right', '.nr-db-switch-layout-row-spread', '.nr-db-switch-layout-col-center']
+                    .forEach(function (id) {
+                        $(id).click(function (e) {
+                            $('.nr-db-switch-layout').removeClass('selected')
+                            $(this).addClass('selected')
+                            $('#node-input-layout').val(id.substring('.nr-db-switch-layout-'.length))
+                            e.preventDefault()
+                        })
+                    })
             },
             oneditsave: function () {
                 if ($('#node-input-custom-icons').val() === 'default') {
@@ -194,6 +206,42 @@
             </a>
         </div>
     </div>
+    <div class="form-row">
+        <label style="vertical-align: top"><i class="fa fa-th-large"></i> <span>Layout</span></label>
+        <div style="display:inline-block">
+            <input type="hidden" id="node-input-layout">
+            <input type="hidden" id="node-input-layoutAlign" >
+            <div>
+                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-left">
+                    <span class="nr-db-switch-layout-label">label</span>
+                    <span class="nr-db-switch-layout-value">switch</span>
+                    <div class="nr-db-switch-layout-checkbox"></div>
+                </a>
+                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-center">
+                    <span class="nr-db-switch-layout-label">label</span>
+                    <span class="nr-db-switch-layout-value">switch</span>
+                    <div class="nr-db-switch-layout-checkbox"></div>
+                </a>
+                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-right">
+                    <span class="nr-db-switch-layout-label">label</span>
+                    <span class="nr-db-switch-layout-value">switch</span>
+                    <div class="nr-db-switch-layout-checkbox"></div>
+                </a>
+            </div>
+            <div>
+                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-spread">
+                    <span class="nr-db-switch-layout-label">label</span>
+                    <span class="nr-db-switch-layout-value">switch</span>
+                    <div class="nr-db-switch-layout-checkbox"></div>
+                </a>
+                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-col nr-db-switch-layout-col-center">
+                    <span class="nr-db-switch-layout-label">label</span>
+                    <span class="nr-db-switch-layout-value">switch</span>
+                    <div class="nr-db-switch-layout-checkbox"></div>
+                </a>
+            </div>
+        </div>
+    </div>
     <!--<div class="form-row">
         <label for="node-input-tooltip"><i class="fa fa-info-circle"></i> Tooltip</label>
         <input type="text" id="node-input-tooltip" placeholder="optional tooltip">
@@ -248,3 +296,62 @@
         <input type="hidden" id="node-input-topicType">
     </div>
 </script>
+
+<style>
+    .nr-db-switch-layout {
+        position:relative;
+        display: inline-block;
+        width: 96px;
+        height: 60px;
+        border-radius:3px;
+        border:1px solid var(--red-ui-form-input-border-color, #bbb);
+        cursor:pointer;
+        color: #666;
+        margin-right: 10px;
+        margin-bottom: 10px;
+    }
+    .nr-db-switch-layout.selected, .nr-db-switch-layout:hover {
+        border-color: var(--red-ui-form-input-border-selected-color, #333);
+        color: var(--red-ui-secondary-text-color-selected, #333);
+    }
+    .nr-db-switch-layout span {
+        position: absolute;
+    }
+    .nr-db-switch-layout-value {
+        font-weight: bold;
+    }
+    .nr-db-switch-layout-row span { top: 20px; }
+    .nr-db-switch-layout-row-left .nr-db-switch-layout-label { left: 2px; }
+    .nr-db-switch-layout-row-left .nr-db-switch-layout-value { left: 34px; }
+    .nr-db-switch-layout-row-spread .nr-db-switch-layout-label { left: 2px; }
+    .nr-db-switch-layout-row-spread .nr-db-switch-layout-value { right: 2px; }
+    .nr-db-switch-layout-row-center .nr-db-switch-layout-label { left: 11px; }
+    .nr-db-switch-layout-row-center .nr-db-switch-layout-value { right: 11px; }
+    .nr-db-switch-layout-row-right .nr-db-switch-layout-label { right: 50px; }
+    .nr-db-switch-layout-row-right .nr-db-switch-layout-value { right: 2px; }
+
+    .nr-db-switch-layout-col span { width: 100%;  text-align: center; left: 0px;}
+    .nr-db-switch-layout-col-center .nr-db-switch-layout-label { top: 12px; }
+    .nr-db-switch-layout-col-center .nr-db-switch-layout-value { top: 26px; }
+    .nr-db-switch-layout-checkbox {
+        display: none;
+        width: 10px;
+        height: 10px;
+        border-radius: 10px;
+        border: 1px solid var(--red-ui-primary-border-color, #bbb);
+        position: absolute;
+        right: -5px;
+        top: -5px;
+        background: var(--red-ui-secondary-background, #fff);
+    }
+    .nr-db-switch-layout.selected .nr-db-switch-layout-checkbox {
+        display:inline-block;
+        box-shadow: inset 0px 0px 0px 2px #fff;
+        background: #333;
+        border-color: #333;
+    }
+    .nr-db-ui-manual-size-row {
+        display: none;
+    }
+
+</style>

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -131,7 +131,7 @@
                 })
 
                 $('.nr-db-switch-layout-' + (this.layout || 'row-spread')).addClass('selected');
-                ['.nr-db-switch-layout-row-left', '.nr-db-switch-layout-row-center', '.nr-db-switch-layout-row-right', '.nr-db-switch-layout-row-spread', '.nr-db-switch-layout-col-center']
+                ['.nr-db-switch-layout-row-left', '.nr-db-switch-layout-row-left-swapped', '.nr-db-switch-layout-row-spread', '.nr-db-switch-layout-row-spread-swapped']
                     .forEach(function (id) {
                         $(id).click(function (e) {
                             $('.nr-db-switch-layout').removeClass('selected')
@@ -217,14 +217,9 @@
                     <span class="nr-db-switch-layout-value">switch</span>
                     <div class="nr-db-switch-layout-checkbox"></div>
                 </a>
-                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-center">
-                    <span class="nr-db-switch-layout-label">label</span>
+                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-left-swapped">
                     <span class="nr-db-switch-layout-value">switch</span>
-                    <div class="nr-db-switch-layout-checkbox"></div>
-                </a>
-                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-right">
                     <span class="nr-db-switch-layout-label">label</span>
-                    <span class="nr-db-switch-layout-value">switch</span>
                     <div class="nr-db-switch-layout-checkbox"></div>
                 </a>
             </div>
@@ -234,9 +229,9 @@
                     <span class="nr-db-switch-layout-value">switch</span>
                     <div class="nr-db-switch-layout-checkbox"></div>
                 </a>
-                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-col nr-db-switch-layout-col-center">
-                    <span class="nr-db-switch-layout-label">label</span>
+                <a href="#" class="nr-db-switch-layout nr-db-switch-layout-row nr-db-switch-layout-row-spread-swapped">
                     <span class="nr-db-switch-layout-value">switch</span>
+                    <span class="nr-db-switch-layout-label">label</span>
                     <div class="nr-db-switch-layout-checkbox"></div>
                 </a>
             </div>
@@ -321,18 +316,18 @@
         font-weight: bold;
     }
     .nr-db-switch-layout-row span { top: 20px; }
+    
     .nr-db-switch-layout-row-left .nr-db-switch-layout-label { left: 2px; }
     .nr-db-switch-layout-row-left .nr-db-switch-layout-value { left: 34px; }
+    .nr-db-switch-layout-row-left-swapped .nr-db-switch-layout-label { left: 48px; }
+    .nr-db-switch-layout-row-left-swapped .nr-db-switch-layout-value { left: 2px; }
+
     .nr-db-switch-layout-row-spread .nr-db-switch-layout-label { left: 2px; }
     .nr-db-switch-layout-row-spread .nr-db-switch-layout-value { right: 2px; }
-    .nr-db-switch-layout-row-center .nr-db-switch-layout-label { left: 11px; }
-    .nr-db-switch-layout-row-center .nr-db-switch-layout-value { right: 11px; }
-    .nr-db-switch-layout-row-right .nr-db-switch-layout-label { right: 50px; }
-    .nr-db-switch-layout-row-right .nr-db-switch-layout-value { right: 2px; }
+    .nr-db-switch-layout-row-spread-swapped .nr-db-switch-layout-label { left: 2px; }
+    .nr-db-switch-layout-row-spread-swapped .nr-db-switch-layout-value { right: 2px; }
 
     .nr-db-switch-layout-col span { width: 100%;  text-align: center; left: 0px;}
-    .nr-db-switch-layout-col-center .nr-db-switch-layout-label { top: 12px; }
-    .nr-db-switch-layout-col-center .nr-db-switch-layout-value { top: 26px; }
     .nr-db-switch-layout-checkbox {
         display: none;
         width: 10px;

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -132,6 +132,10 @@ module.exports = function (RED) {
                         // dynamically set "officon" property
                         statestore.set(group.getBase(), node, msg, 'officon', updates.officon)
                     }
+                    if (typeof updates.layout !== 'undefined') {
+                        // dynamically set "layout" property
+                        statestore.set(group.getBase(), node, msg, 'layout', updates.layout)
+                    }
                 }
 
                 msg = await appendTopic(RED, config, node, msg)

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -218,25 +218,19 @@ export default {
         align-items: center;
         justify-content: flex-start;
     }
-    &--row-center {
-        align-items: center;
-        justify-content: center;
-    }
-    &--row-right {
+    &--row-left-swapped {
         align-items: center;
         justify-content: flex-end;
+        flex-direction: row-reverse;
     }
     &--row-spread {
         align-items: center;
         justify-content: space-between;
     }
-    &--col-center {
+    &--row-spread-swapped {
         align-items: center;
-        justify-content: center;
-        flex-direction: column;
-        label, span {
-            text-align: center;
-        }
+        justify-content: space-between;
+        flex-direction: row-reverse;
     }
 }
 </style>

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="nrdb-switch" :class="{'nrdb-nolabel': !label, [className]: !!className}">
+    <div class="nrdb-switch" :class="computedClass">
         <label
             v-if="label"
             class="v-label"
@@ -50,6 +50,11 @@ export default {
         label () {
             return this.getProperty('label')
         },
+        layout () {
+            // This spreaded layout will be the default for the existing flows
+            // which doesn't have the layout property
+            return this.getProperty('layout') || 'row-spread'
+        },
         icon () {
             const onicon = this.getProperty('onicon')
             const officon = this.getProperty('officon')
@@ -59,6 +64,13 @@ export default {
                 return 'mdi-' + icon.replace(/^mdi-/, '')
             } else {
                 return null
+            }
+        },
+        computedClass () {
+            return {
+                ...(this.layout && { [`nrdb-ui-switch--${this.layout}`]: true }),
+                'nrdb-nolabel': !this.label,
+                [this.className]: !!this.className
             }
         },
         color () {
@@ -121,6 +133,7 @@ export default {
                 return
             }
             this.updateDynamicProperty('label', updates.label)
+            this.updateDynamicProperty('layout', updates.layout)
             this.updateDynamicProperty('clickableArea', updates.clickableArea)
             this.updateDynamicProperty('decouple', updates.decouple)
             this.updateDynamicProperty('oncolor', updates.oncolor)
@@ -170,26 +183,60 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
 .nrdb-switch {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    gap: 4px;
+    .v-switch {
+        flex-grow: 0;
+    }
+    .v-input {
+        align-items: center;
+        display: flex;
+    }
+    .v-input__control {
+        .v-selection-control {
+            justify-content: flex-end;
+            min-height: 20px;
+            .v-selection-control__wrapper {
+                height: 20px;
+            }
+        }
+    }
+    &.nrdb-nolabel .v-selection-control {
+        justify-content: center;
+    }
+    > .v-progress-circular > svg {
+        width: 24px;
+        height: 24px;
+    }
 }
-.nrdb-switch label {
-    flex-grow: 1;
-}
-.nrdb-switch .v-switch {
-    flex-grow: 0;
-}
-.nrdb-switch .v-selection-control {
-    justify-content: flex-end;
-}
-.nrdb-switch.nrdb-nolabel .v-selection-control {
-    justify-content: center;
-}
-.nrdb-switch > .v-progress-circular > svg {
-    width: 24px;
-    height: 24px;
+
+/* Layouts */
+.nrdb-ui-switch {
+    &--row-left {
+        align-items: center;
+        justify-content: flex-start;
+    }
+    &--row-center {
+        align-items: center;
+        justify-content: center;
+    }
+    &--row-right {
+        align-items: center;
+        justify-content: flex-end;
+    }
+    &--row-spread {
+        align-items: center;
+        justify-content: space-between;
+    }
+    &--col-center {
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        label, span {
+            text-align: center;
+        }
+    }
 }
 </style>


### PR DESCRIPTION
## Description

This feature includes,

1. Switching between 5 different layouts `row-left`,  `row-left-swapped`, `row-spread`,  `row-spread-swapped` which is similar with `ui-text` node
2. Dynamic property support for the newly added layout property
3. Docs updated for the newly added property `Layout` and marked `dynamic: true` in the docs for the existing dynamic properties which haven't marked previously
4. Necessary E2E tests are added


## Related Issue(s)

https://github.com/FlowFuse/node-red-dashboard/issues/1236

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

