### PR TITLE
Group tooltips for line chart

### DIFF
--- a/cypress/fixtures/flows/dashboard-chart-options.json
+++ b/cypress/fixtures/flows/dashboard-chart-options.json
@@ -1,0 +1,210 @@
+[
+    {
+        "id": "chart-1",
+        "type": "ui-chart",
+        "z": "9524c548fb0b956c",
+        "group": "dashboard-ui-group",
+        "name": "chart-name",
+        "label": "chart-label",
+        "order": 2,
+        "chartType": "line",
+        "category": "",
+        "categoryType": "property",
+        "xAxisLabel": "",
+        "xAxisProperty": "",
+        "xAxisPropertyType": "property",
+        "xAxisType": "time",
+        "xAxisFormat": "",
+        "xAxisFormatType": "auto",
+        "yAxisLabel": "",
+        "yAxisProperty": "",
+        "ymin": "",
+        "ymax": "",
+        "action": "append",
+        "stackSeries": false,
+        "pointShape": "circle",
+        "pointRadius": 4,
+        "showLegend": true,
+        "removeOlder": 1,
+        "removeOlderUnit": "3600",
+        "removeOlderPoints": "10",
+        "colors": [
+            "#1f77b4",
+            "#aec7e8",
+            "#ff7f0e",
+            "#2ca02c",
+            "#98df8a",
+            "#d62728",
+            "#ff9896",
+            "#9467bd",
+            "#c5b0d5"
+        ],
+        "textColor": [
+            "#666666"
+        ],
+        "textColorDefault": true,
+        "gridColor": [
+            "#e5e5e5"
+        ],
+        "gridColorDefault": true,
+        "width": 6,
+        "height": "4",
+        "className": "",
+        "x": 1690,
+        "y": 640,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "da1332f160b6a255",
+        "type": "inject",
+        "z": "9524c548fb0b956c",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "[]",
+        "payloadType": "json",
+        "x": 1490,
+        "y": 680,
+        "wires": [
+            [
+                "chart-1"
+            ]
+        ]
+    },
+    {
+        "id": "13bf93c81c0bd0a7",
+        "type": "change",
+        "z": "9524c548fb0b956c",
+        "name": "rand",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "(\t    $minimum := 1;\t    $maximum := 10;\t    $round(($random() * ($maximum-$minimum)) + $minimum, 0)\t)",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 1490,
+        "y": 640,
+        "wires": [
+            [
+                "chart-1"
+            ]
+        ]
+    },
+    {
+        "id": "12a55e898bb4162f",
+        "type": "ui-button",
+        "z": "9524c548fb0b956c",
+        "group": "dashboard-ui-group",
+        "name": "random",
+        "label": "random",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "emulateClick": true,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "",
+        "payloadType": "date",
+        "topic": "topic",
+        "topicType": "msg",
+        "buttonColor": "",
+        "textColor": "",
+        "iconColor": "",
+        "x": 1340,
+        "y": 640,
+        "wires": [
+            [
+                "13bf93c81c0bd0a7"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-group",
+        "type": "ui-group",
+        "name": "Group Name",
+        "page": "dashboard-ui-page-1",
+        "width": "6",
+        "height": "1",
+        "order": 1,
+        "showTitle": true,
+        "className": "",
+        "visible": "true",
+        "disabled": "false"
+    },
+    {
+        "id": "dashboard-ui-page-1",
+        "type": "ui-page",
+        "name": "import demos",
+        "ui": "dashboard-ui-base",
+        "path": "/page4",
+        "icon": "home",
+        "layout": "grid",
+        "theme": "dashboard-ui-theme",
+        "order": 1,
+        "className": "",
+        "visible": "true",
+        "disabled": "false"
+    },
+    {
+        "id": "dashboard-ui-base",
+        "type": "ui-base",
+        "name": "base",
+        "path": "/dashboard",
+        "includeClientData": true,
+        "acceptsClientConfig": [
+            "ui-notification",
+            "ui-control"
+        ],
+        "showPathInSidebar": false,
+        "navigationStyle": "default",
+        "titleBarStyle": "default"
+    },
+
+
+
+    {
+        "id": "dashboard-ui-theme",
+        "type": "ui-theme",
+        "name": "Default",
+        "colors": {
+            "surface": "#ffffff",
+            "primary": "#6771f4",
+            "bgPage": "#e5dcdc",
+            "groupBg": "#ffffff",
+            "groupOutline": "#d39292"
+        },
+        "sizes": {
+            "pagePadding": "6px",
+            "groupGap": "12px",
+            "groupBorderRadius": "4px",
+            "widgetGap": "6px",
+            "density": "default"
+        }
+    }
+]

--- a/cypress/tests/widgets/chart-options.spec.js
+++ b/cypress/tests/widgets/chart-options.spec.js
@@ -96,15 +96,15 @@ describe('Node/-RED Dashboard 2.0 - Chart Widget - chart options', () => {
         })
     })
 
-    it('sets tooltip `mode` to "index" for donut charts', () => {
-        const chartName = 'donut-chart-1'
+    it('sets tooltip `mode` to "index" for doughnut charts', () => {
+        const chartName = 'doughnut-chart-1'
         const overrides = [
             {
                 id: 'chart-1', // the ID in the base flow fixture (required)
                 mode: 'merge',
                 data: {
                     label: chartName, // set the label
-                    chartType: 'donut' // change the chart type
+                    chartType: 'doughnut' // change the chart type
                 }
             }
         ]
@@ -120,7 +120,7 @@ describe('Node/-RED Dashboard 2.0 - Chart Widget - chart options', () => {
             should(win.uiCharts).is.not.empty()
             const chartObject = win.uiCharts['chart-1']
             should(chartObject).is.not.empty()
-            should(chartObject.chart.options.type).be.equal('donut')
+            should(chartObject.chart.options.type).be.equal('doughnut')
             should(chartObject.chart.options.interaction).be.an.Object()
             should(chartObject.chart.options.interaction.mode).be.equal('index')
             should(chartObject.chart.options.interaction).not.have.property('axis')

--- a/cypress/tests/widgets/chart-options.spec.js
+++ b/cypress/tests/widgets/chart-options.spec.js
@@ -1,0 +1,121 @@
+/// <reference types="cypress" />
+import should from 'should'
+
+/* eslint-disable cypress/no-unnecessary-waiting */
+describe('Node/-RED Dashboard 2.0 - Chart Widget - chart options', () => {
+    it('resets tooltip mode to "nearest" for bar charts', () => {
+        const chartName = 'bar-chart-1'
+        const overrides = [
+            {
+                id: 'chart-1', // the ID in the base flow fixture (required)
+                mode: 'merge',
+                data: {
+                    label: chartName, // set the label
+                    chartType: 'bar' // change the chart type to bar
+                }
+            }
+        ]
+        cy.deployFixture('dashboard-chart-options', overrides)
+        cy.visit('/dashboard/page1')
+        cy.reload()
+
+        cy.get('#nrdb-ui-widget-chart-1 > div > canvas').should('exist')
+        cy.clickAndWait(cy.get('button').contains('random'), 10)
+
+        // eslint-disable-next-line promise/catch-or-return, promise/always-return
+        cy.window().then(win => {
+            should(win.uiCharts).is.not.empty()
+            const barChart = win.uiCharts['chart-1']
+            should(barChart).is.not.empty()
+            should(barChart.chart.options.interaction).be.an.Object()
+            should(barChart.chart.options.interaction.mode).be.equal('nearest')
+            should(barChart.chart.options.interaction.axis).not.equal('x')
+        })
+    })
+
+    it('sets tooltip mode to "index" and axis x for line charts', () => {
+        const chartName = 'line-chart-1'
+        const overrides = [
+            {
+                id: 'chart-1', // the ID in the base flow fixture (required)
+                mode: 'merge',
+                data: {
+                    label: chartName, // set the label
+                    chartType: 'line' // change the chart type to line
+                }
+            }
+        ]
+        cy.deployFixture('dashboard-chart-options', overrides)
+        cy.visit('/dashboard/page1')
+        cy.reload()
+
+        cy.get('#nrdb-ui-widget-chart-1 > div > canvas').should('exist')
+        cy.clickAndWait(cy.get('button').contains('random'), 10)
+
+        // eslint-disable-next-line promise/catch-or-return, promise/always-return
+        cy.window().then(win => {
+            should(win.uiCharts).is.not.empty()
+            const lineChart = win.uiCharts['chart-1']
+            should(lineChart).is.not.empty()
+            should(lineChart.chart.options.interaction).be.an.Object()
+            should(lineChart.chart.options.interaction.mode).be.equal('index')
+            should(lineChart.chart.options.interaction.axis).be.equal('x')
+        })
+    })
+
+    it('hides legend when option is unchecked', () => {
+        const overrides = [
+            {
+                id: 'chart-1', // the ID in the base flow fixture (required)
+                mode: 'merge',
+                data: {
+                    label: 'scatter-without-legend', // set the label
+                    chartType: 'scatter', // change the chart type to scatter
+                    showLegend: false // hide the legend
+                }
+            }
+        ]
+        cy.deployFixture('dashboard-chart-options', overrides)
+        cy.visit('/dashboard/page1')
+        cy.reload()
+
+        cy.get('#nrdb-ui-widget-chart-1 > div > canvas').should('exist')
+        cy.clickAndWait(cy.get('button').contains('random'), 10)
+
+        // eslint-disable-next-line promise/catch-or-return, promise/always-return
+        cy.window().then(win => {
+            should(win.uiCharts).is.not.empty()
+            const barChart = win.uiCharts['chart-1']
+            should(barChart).is.not.empty()
+            should(barChart.chart.options.plugins.legend.display).be.false()
+        })
+    })
+
+    it('Shows legend when option is checked', () => {
+        const overrides = [
+            {
+                id: 'chart-1', // the ID in the base flow fixture (required)
+                mode: 'merge',
+                data: {
+                    label: 'scatter-chart-with-legend', // set the label
+                    chartType: 'scatter', // change the chart type to scatter
+                    showLegend: true // show the legend
+                }
+            }
+        ]
+        cy.deployFixture('dashboard-chart-options', overrides)
+        cy.visit('/dashboard/page1')
+        cy.reload()
+
+        cy.get('#nrdb-ui-widget-chart-1 > div > canvas').should('exist')
+        cy.clickAndWait(cy.get('button').contains('random'), 10)
+
+        // eslint-disable-next-line promise/catch-or-return, promise/always-return
+        cy.window().then(win => {
+            should(win.uiCharts).is.not.empty()
+            const barChart = win.uiCharts['chart-1']
+            should(barChart).is.not.empty()
+            should(barChart.chart.options.plugins.legend.display).be.true()
+        })
+    })
+})

--- a/cypress/tests/widgets/chart-options.spec.js
+++ b/cypress/tests/widgets/chart-options.spec.js
@@ -3,37 +3,7 @@ import should from 'should'
 
 /* eslint-disable cypress/no-unnecessary-waiting */
 describe('Node/-RED Dashboard 2.0 - Chart Widget - chart options', () => {
-    it('resets tooltip mode to "nearest" for bar charts', () => {
-        const chartName = 'bar-chart-1'
-        const overrides = [
-            {
-                id: 'chart-1', // the ID in the base flow fixture (required)
-                mode: 'merge',
-                data: {
-                    label: chartName, // set the label
-                    chartType: 'bar' // change the chart type to bar
-                }
-            }
-        ]
-        cy.deployFixture('dashboard-chart-options', overrides)
-        cy.visit('/dashboard/page1')
-        cy.reload()
-
-        cy.get('#nrdb-ui-widget-chart-1 > div > canvas').should('exist')
-        cy.clickAndWait(cy.get('button').contains('random'), 10)
-
-        // eslint-disable-next-line promise/catch-or-return, promise/always-return
-        cy.window().then(win => {
-            should(win.uiCharts).is.not.empty()
-            const barChart = win.uiCharts['chart-1']
-            should(barChart).is.not.empty()
-            should(barChart.chart.options.interaction).be.an.Object()
-            should(barChart.chart.options.interaction.mode).be.equal('nearest')
-            should(barChart.chart.options.interaction.axis).not.equal('x')
-        })
-    })
-
-    it('sets tooltip mode to "index" and axis x for line charts', () => {
+    it('sets tooltip `mode` to "x" for line charts', () => {
         const chartName = 'line-chart-1'
         const overrides = [
             {
@@ -41,7 +11,7 @@ describe('Node/-RED Dashboard 2.0 - Chart Widget - chart options', () => {
                 mode: 'merge',
                 data: {
                     label: chartName, // set the label
-                    chartType: 'line' // change the chart type to line
+                    chartType: 'line' // change the chart type
                 }
             }
         ]
@@ -55,11 +25,105 @@ describe('Node/-RED Dashboard 2.0 - Chart Widget - chart options', () => {
         // eslint-disable-next-line promise/catch-or-return, promise/always-return
         cy.window().then(win => {
             should(win.uiCharts).is.not.empty()
-            const lineChart = win.uiCharts['chart-1']
-            should(lineChart).is.not.empty()
-            should(lineChart.chart.options.interaction).be.an.Object()
-            should(lineChart.chart.options.interaction.mode).be.equal('index')
-            should(lineChart.chart.options.interaction.axis).be.equal('x')
+            const chartObject = win.uiCharts['chart-1']
+            should(chartObject).is.not.empty()
+            should(chartObject.chart.options.type).be.equal('line')
+            should(chartObject.chart.options.interaction).be.an.Object()
+            should(chartObject.chart.options.interaction.mode).be.equal('x')
+            should(chartObject.chart.options.interaction).not.have.property('axis')
+        })
+    })
+
+    it('sets tooltip `mode` to "nearest" and `axis` to "x" for scatter charts', () => {
+        const chartName = 'scatter-chart-1'
+        const overrides = [
+            {
+                id: 'chart-1', // the ID in the base flow fixture (required)
+                mode: 'merge',
+                data: {
+                    label: chartName, // set the label
+                    chartType: 'scatter' // change the chart type
+                }
+            }
+        ]
+        cy.deployFixture('dashboard-chart-options', overrides)
+        cy.visit('/dashboard/page1')
+        cy.reload()
+
+        cy.get('#nrdb-ui-widget-chart-1 > div > canvas').should('exist')
+        cy.clickAndWait(cy.get('button').contains('random'), 10)
+
+        // eslint-disable-next-line promise/catch-or-return, promise/always-return
+        cy.window().then(win => {
+            should(win.uiCharts).is.not.empty()
+            const chartObject = win.uiCharts['chart-1']
+            should(chartObject).is.not.empty()
+            should(chartObject.chart.options.type).be.equal('scatter')
+            should(chartObject.chart.options.interaction).be.an.Object()
+            should(chartObject.chart.options.interaction.mode).be.equal('nearest')
+            should(chartObject.chart.options.interaction.axis).be.equal('x')
+        })
+    })
+
+    it('sets tooltip `mode` to "index" for bar charts', () => {
+        const chartName = 'bar-chart-1'
+        const overrides = [
+            {
+                id: 'chart-1', // the ID in the base flow fixture (required)
+                mode: 'merge',
+                data: {
+                    label: chartName, // set the label
+                    chartType: 'bar' // change the chart type
+                }
+            }
+        ]
+        cy.deployFixture('dashboard-chart-options', overrides)
+        cy.visit('/dashboard/page1')
+        cy.reload()
+
+        cy.get('#nrdb-ui-widget-chart-1 > div > canvas').should('exist')
+        cy.clickAndWait(cy.get('button').contains('random'), 10)
+
+        // eslint-disable-next-line promise/catch-or-return, promise/always-return
+        cy.window().then(win => {
+            should(win.uiCharts).is.not.empty()
+            const chartObject = win.uiCharts['chart-1']
+            should(chartObject).is.not.empty()
+            should(chartObject.chart.options.type).be.equal('bar')
+            should(chartObject.chart.options.interaction).be.an.Object()
+            should(chartObject.chart.options.interaction.mode).be.equal('index')
+            should(chartObject.chart.options.interaction).not.have.property('axis')
+        })
+    })
+
+    it('sets tooltip `mode` to "index" for donut charts', () => {
+        const chartName = 'donut-chart-1'
+        const overrides = [
+            {
+                id: 'chart-1', // the ID in the base flow fixture (required)
+                mode: 'merge',
+                data: {
+                    label: chartName, // set the label
+                    chartType: 'donut' // change the chart type
+                }
+            }
+        ]
+        cy.deployFixture('dashboard-chart-options', overrides)
+        cy.visit('/dashboard/page1')
+        cy.reload()
+
+        cy.get('#nrdb-ui-widget-chart-1 > div > canvas').should('exist')
+        cy.clickAndWait(cy.get('button').contains('random'), 10)
+
+        // eslint-disable-next-line promise/catch-or-return, promise/always-return
+        cy.window().then(win => {
+            should(win.uiCharts).is.not.empty()
+            const chartObject = win.uiCharts['chart-1']
+            should(chartObject).is.not.empty()
+            should(chartObject.chart.options.type).be.equal('donut')
+            should(chartObject.chart.options.interaction).be.an.Object()
+            should(chartObject.chart.options.interaction.mode).be.equal('index')
+            should(chartObject.chart.options.interaction).not.have.property('axis')
         })
     })
 

--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -209,12 +209,15 @@ export default {
         updateInteraction () {
             switch (this.chart.config.type) {
             case 'line':
+                this.chart.options.interaction.mode = 'x'
+                break
+            case 'scatter':
                 this.chart.options.interaction.axis = 'x'
-                this.chart.options.interaction.mode = 'index'
+                this.chart.options.interaction.mode = 'nearest'
                 break
             default:
                 delete this.chart.options.interaction.axis
-                this.chart.options.interaction.mode = 'nearest' // default
+                this.chart.options.interaction.mode = 'index' // default
                 break
             }
         },

--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -209,6 +209,7 @@ export default {
         updateInteraction () {
             switch (this.chart.config.type) {
             case 'line':
+                delete this.chart.options.interaction.axis
                 this.chart.options.interaction.mode = 'x'
                 break
             case 'scatter':

--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -214,7 +214,7 @@ export default {
                 break
             default:
                 delete this.chart.options.interaction.axis
-                this.chart.options.plugins.mode = 'point'
+                this.chart.options.interaction.mode = 'nearest' // default
                 break
             }
         },

--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -22,7 +22,8 @@ export default {
     data () {
         return {
             chart: null,
-            hasData: false
+            hasData: false,
+            chartUpdateDebounceTimeout: null
         }
     },
     computed: {
@@ -35,19 +36,20 @@ export default {
     watch: {
         'props.label': function (value) {
             this.chart.options.plugins.title.text = value
-            this.chart.update()
+            this.chartUpdate(false)
         },
         'props.chartType': function (value) {
             this.chart.config.type = value
-            this.chart.update()
+            this.updateInteraction()
+            this.chartUpdate(false)
         },
         'props.xAxisType': function (value) {
             this.chart.options.scales.x.type = value
-            this.chart.update()
+            this.chartUpdate(false)
         },
         'props.xAxisFormatType': function (value) {
             this.chart.options.scales.x.time.displayFormats = this.getXDisplayFormats(value)
-            this.chart.update()
+            this.chartUpdate(false)
         }
     },
     created () {
@@ -166,6 +168,7 @@ export default {
                 animation: false,
                 maintainAspectRatio: false,
                 borderJoinStyle: 'round',
+                interaction: {},
                 scales,
                 plugins: {
                     title: {
@@ -185,10 +188,52 @@ export default {
         }
         const chart = new Chart(el, config)
 
+        // Useful for debugging: uncomment to expose the chart object to the window
+        // window.uiChart = window.uiChart || {}
+        // window.uiChart[this.id] = chart
+
         // don't want chart to be reactive, so we can use shallowRef
         this.chart = shallowRef(chart)
+
+        // ensure the chart is updated with the correct interaction mode
+        // based on the type of chart we are creating
+        this.updateInteraction()
     },
     methods: {
+        updateInteraction () {
+            switch (this.chart.config.type) {
+            case 'line':
+                this.chart.options.interaction.axis = 'x'
+                this.chart.options.interaction.mode = 'index'
+                break
+            default:
+                delete this.chart.options.interaction.axis
+                this.chart.options.plugins.mode = 'point'
+                break
+            }
+        },
+        chartUpdate (immediate = true) {
+            // for data adding, we want to update immediately
+            // but in some cases, like updating multiple props, we want to debounce
+            if (immediate) {
+                if (this.chartUpdateDebounceTimeout) {
+                    clearTimeout(this.chartUpdateDebounceTimeout)
+                    this.chartUpdateDebounceTimeout = null
+                }
+                this.chart.update()
+                return
+            }
+            if (this.chartUpdateDebounceTimeout) {
+                return
+            }
+            this.chartUpdateDebounceTimeout = setTimeout(() => {
+                try {
+                    this.chart.update()
+                } finally {
+                    this.chartUpdateDebounceTimeout = null
+                }
+            }, 30)
+        },
         // given an object, return the value of the category property (which can be nested)
         getLabel (value, category) {
             if (this.props.categoryType !== 'property') {
@@ -261,7 +306,7 @@ export default {
         clear () {
             this.chart.data.labels = []
             this.chart.data.datasets = []
-            this.chart.update()
+            this.chartUpdate()
             this.hasData = false
         },
         add (msg) {
@@ -295,7 +340,7 @@ export default {
             if (this.props.chartType === 'line' || this.props.chartType === 'scatter') {
                 this.limitDataSize()
             }
-            this.chart.update()
+            this.chartUpdate()
         },
         addPoints (payload, datapoint, label) {
             const d = {


### PR DESCRIPTION
## Description

Groups tooltips on `line` type charts using the [interactions](https://www.chartjs.org/docs/latest/samples/tooltip/interactions.html) options 

NOTES:
* I wrapped the call to `this.chart.update` into a `chartUpdate` method so that we can debounce the multiple calls generated by property updates (the props are `watch`ed individually) 
  * I then noted we dont actually support dynamic prop updates 🤦‍♂️ BUT I left it in as dynamic updates are listed as a TODO and this will avoid unnecessary chart update calls.
* I added some debugging where I add the `chart` object to the `window` object so that during debugging, I can see the actual config and data applied to the chart. This was super useful. So instead of deleting it, I let it in commented with a note for future devs to take advantage of.  fee free to remove it.



## Related Issue(s)

#1254

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

