### PR TITLE
Use CSS variable for background color

### DIFF
--- a/nodes/widgets/ui_form.html
+++ b/nodes/widgets/ui_form.html
@@ -494,7 +494,7 @@
     </div>
     <div class="form-row">
         <!-- Tabsheets -->
-        <ul style="background: #fff; min-width: 600px; margin-bottom: 20px;" id="node-ui-form-tabsheets"></ul>
+        <ul style="background: var(--red-ui-secondary-background); min-width: 600px; margin-bottom: 20px;" id="node-ui-form-tabsheets"></ul>
     </div>
     <div id="node-ui-form-tabsheets-content" style="min-height: 150px">
         <!-- Content of all tabsheets -->

--- a/nodes/widgets/ui_form.html
+++ b/nodes/widgets/ui_form.html
@@ -494,7 +494,7 @@
     </div>
     <div class="form-row">
         <!-- Tabsheets -->
-        <ul style="background: var(--red-ui-secondary-background); min-width: 600px; margin-bottom: 20px;" id="node-ui-form-tabsheets"></ul>
+        <ul style="background: var(--red-ui-secondary-background, #fff); min-width: 600px; margin-bottom: 20px;" id="node-ui-form-tabsheets"></ul>
     </div>
     <div id="node-ui-form-tabsheets-content" style="min-height: 150px">
         <!-- Content of all tabsheets -->


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Currently, the form node has a hard-coded color for a background, which causes issues with themes.

This PR fixes that by using a CSS variable instead.

|Now|Then|
|-|-|
|<img width="434" alt="SCR-20240930-klfu" src="https://github.com/user-attachments/assets/a91611a6-30be-4be6-905b-449b549ccdba">|<img width="434" alt="SCR-20240930-kllb" src="https://github.com/user-attachments/assets/d98c01ab-e188-4c8c-8877-2b13480017bf">|


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

