### PR TITLE
Fixed ui-text label cropping out on larger font sizes

### DIFF
--- a/ui/src/widgets/ui-text/UIText.vue
+++ b/ui/src/widgets/ui-text/UIText.vue
@@ -73,12 +73,14 @@ export default {
     flex-wrap: wrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    line-height: initial;
 }
 .nrdb-ui-text-value {
     font-weight: 600;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    line-height: initial;
 }
 
 /* Layouts */


### PR DESCRIPTION
## Description

The line height has been overridden from Vuetify's default value of `1.2rem`, which becomes more noticeable with larger font sizes

Before
<img width="844" alt="Screenshot 2024-10-04 at 10 34 26" src="https://github.com/user-attachments/assets/ec3615cd-9e30-4d97-b058-ccd9bef01e25">

After
<img width="851" alt="Screenshot 2024-10-04 at 10 32 57" src="https://github.com/user-attachments/assets/1df5a041-6773-4725-bc13-d76862533317">


## Related Issue(s)

https://github.com/FlowFuse/node-red-dashboard/issues/1358

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

