### PR TITLE
Provided default breakpoints when there's nothing defined

### DIFF
--- a/ui/src/mixins/responsiveness.js
+++ b/ui/src/mixins/responsiveness.js
@@ -26,12 +26,6 @@ export default {
     methods: {
         countColumns () {
             let cols = 0
-            const defaultBreakpoints = [
-                { name: 'Default', px: 0, cols: 3 },
-                { name: 'Tablet', px: 576, cols: 6 },
-                { name: 'Small Desktop', px: 768, cols: 9 },
-                { name: 'Desktop', px: 1024, cols: 12 }
-            ]
             if (this.page) {
                 // set default breakpoints if none are defined
                 const b = this.page.breakpoints || defaultBreakpoints

--- a/ui/src/mixins/responsiveness.js
+++ b/ui/src/mixins/responsiveness.js
@@ -26,14 +26,22 @@ export default {
     methods: {
         countColumns () {
             let cols = 0
+            const defaultBreakpoints = [
+                { name: 'Default', px: 0, cols: 3 },
+                { name: 'Tablet', px: 576, cols: 6 },
+                { name: 'Small Desktop', px: 768, cols: 9 },
+                { name: 'Desktop', px: 1024, cols: 12 }
+            ]
             if (this.page) {
-                const b = this.page.breakpoints
+                // set default breakpoints if none are defined
+                const b = this.page.breakpoints || defaultBreakpoints
                 // ensure breakpoints are sorted in reverse order
                 const breakpoints = b.sort((a, b) => a.px - b.px)
 
                 breakpoints.forEach((bp) => {
                     if (window.innerWidth >= bp.px) {
-                        cols = bp.cols
+                        // ensure cols is a number
+                        cols = Number(bp.cols)
                     }
                 })
             }

--- a/ui/src/mixins/responsiveness.js
+++ b/ui/src/mixins/responsiveness.js
@@ -28,7 +28,15 @@ export default {
             let cols = 0
             if (this.page) {
                 // set default breakpoints if none are defined
-                const b = this.page.breakpoints || defaultBreakpoints
+                let b = this.page.breakpoints
+                if (!b || !Array.isArray(b) || b.length === 0) {
+                    b = [
+                        { name: 'Default', px: 0, cols: 3 },
+                        { name: 'Tablet', px: 576, cols: 6 },
+                        { name: 'Small Desktop', px: 768, cols: 9 },
+                        { name: 'Desktop', px: 1024, cols: 12 }
+                    ]
+                }
                 // ensure breakpoints are sorted in reverse order
                 const breakpoints = b.sort((a, b) => a.px - b.px)
 


### PR DESCRIPTION
## Description

### Problem
When using old flow which doesn't have screen size breakpoints if throws `undefined` as the breakpoints are not defined under `const breakpoints = b.sort((a, b) => a.px - b.px)`

### Solution
Provided default breakpoints when there's no breakpoints defined as per the [documentation](https://dashboard.flowfuse.com/nodes/config/ui-page.html#mobile)

_This doesn't require any updates of the documentation of E2E tests_

## Related Issue(s)

https://github.com/FlowFuse/node-red-dashboard/issues/1370

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

