### PR TITLE
Gauge - Revert to using only width to calculate value font-size

### DIFF
--- a/ui/src/widgets/ui-gauge/types/UIGaugeDial.vue
+++ b/ui/src/widgets/ui-gauge/types/UIGaugeDial.vue
@@ -394,18 +394,14 @@ export default {
         },
         resizeText () {
             const clientWidth = this.$refs.value?.clientWidth
-            const clientHeight = this.$refs.value?.clientHeight
-
-            // work out how much space we have within which to render the value/icon/range
-            const minDimension = Math.min(clientWidth || 0, clientHeight || 0)
             this.size = 'default'
-            if (minDimension < 80) {
+            if (clientWidth < 80) {
                 this.size = 'xxs'
-            } else if (minDimension < 150) {
+            } else if (clientWidth < 150) {
                 this.size = 'xs'
-            } else if (minDimension < 225) {
+            } else if (clientWidth < 225) {
                 this.size = 'sm'
-            } else if (minDimension < 300) {
+            } else if (clientWidth < 300) {
                 this.size = 'md'
             } else {
                 this.size = 'lg'


### PR DESCRIPTION
## Description

- Problem introduced in https://github.com/FlowFuse/node-red-dashboard/pull/1353/files#diff-db418d12c562abfca7a5d735428a2e24ac2cd54a3795550187a71f698335474fR396-R409 
- It used the height _or_ width to calculate the value font-size, was causing the `height` to win too often and therefore rendering very small.
- This reverts it back to how it was, where it just considers the gauge's width.

## Related Issue(s)

Fixes #1385 

