### PR TITLE
Ensure in-Editor markdown & template documentation renders

### DIFF
--- a/nodes/widgets/locales/en-US/ui_markdown.html
+++ b/nodes/widgets/locales/en-US/ui_markdown.html
@@ -1,6 +1,6 @@
-<script type="text/html" data-help-name="ui-text">
+<script type="text/html" data-help-name="ui-markdown">
     <p>
-        Converts markdown to rendered HTML int the Dashboard.
+        Converts markdown to rendered HTML into the Dashboard.
     </p>
     <p>
         Can be use for rendering labels, headers or even full blog articles. If you're

--- a/nodes/widgets/locales/en-US/ui_template.html
+++ b/nodes/widgets/locales/en-US/ui_template.html
@@ -1,5 +1,6 @@
 
-  (see [full docs](https://dashboard.flowfuse.com/nodes/widgets/ui-template.html))
+<script type="text/markdown" data-help-name="ui-template">
+(see [full docs](https://dashboard.flowfuse.com/nodes/widgets/ui-template.html))
 
 The content of `ui-template` is controlled by the "Type" property.
 
@@ -148,3 +149,5 @@ e.g.
   color: green;
 }
 ```
+
+</script>  


### PR DESCRIPTION
## Description

- Not sure how this happened, but the `ui-template` docs stopped rendering, this fixes it by informing Node-RED of the content type (markdown)
- We also had a copy/paste error, which meant the in-editor markdown documentation has never rendered, so I've fixed that too.

## Related Issue(s)

Closes #1391 