### PR TITLE
images in ui-table

### DIFF
--- a/docs/nodes/widgets/ui-table.md
+++ b/docs/nodes/widgets/ui-table.md
@@ -139,6 +139,7 @@ _An example of a ui-table displaying various of the cell types available_
 - **Sparkline - Bar**: Renders the cell as a small bar chart without axes. The `Value` field should contain an array of numbers to be plotted.
 - **Button**: Renders a clickable button in the cell. The label of the button will be either the `row[key]` or the fixed string entered on the manual column configuration.
 - **Row Number**: Renders the row number into the cell.
+- **Image**: Renders the cell as an image. The "Image" value provided should be a valid URL.  A data url is also supported for base64 encoded images. When an invalid url is specified, an empty space will appear.
 
 #### Interaction: Buttons
 

--- a/nodes/widgets/locales/en-US/ui_table.html
+++ b/nodes/widgets/locales/en-US/ui_table.html
@@ -65,5 +65,11 @@
         <dd>Renders an interactive button in the cell. Will emit a <code>msg.action</code> of "button_click" and <code>msg.column</code> of the corresponding key</dd>
         <dt>Row Number <span class="property-type">number</span></dt>
         <dd>Requires no "key" to be provided as this will just render the row number (1 -> n).</dd>
+        <dt>Image <span class="property-type">url</span></dt>
+        <dd>
+            Renders the cell as an image. The "Image" value provided should be a valid URL.
+            A data url is also supported for base64 encoded images.
+            When an invalid url is specified, an empty space will appear.
+        </dd>
     </dl>
 </script>

--- a/nodes/widgets/ui_table.html
+++ b/nodes/widgets/ui_table.html
@@ -56,7 +56,8 @@
             { value: 'sparkline-trend', label: 'Sparkline - Trend (Array)' },
             { value: 'sparkline-bar', label: 'Sparkline - Bar (Array)' },
             { value: 'button', label: 'Button' },
-            { value: 'row', label: 'Row Number' }
+            { value: 'row', label: 'Row Number' },
+            { value: 'image', label: 'Image (https://...)' }
         ]
         RED.nodes.registerType('ui-table', {
             category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),

--- a/ui/src/widgets/ui-table/UITableCell.vue
+++ b/ui/src/widgets/ui-table/UITableCell.vue
@@ -29,6 +29,9 @@
     <template v-else-if="type === 'button'">
         <v-btn color="primary" variant="flat" @click="onButtonClick($event, item)">{{ value }}</v-btn>
     </template>
+    <template v-else-if="type === 'image'">
+        <v-img :src="value" />
+    </template>
     <template v-else>
         {{ value }}
     </template>


### PR DESCRIPTION
## Description

This PR supports a new *'Image'*  type in tables:

![image](https://github.com/user-attachments/assets/6f1cdfe1-f7a9-40fc-98ba-d3871c2574d3)

Also ***data urls for base64 encoded images*** are supported, like the Kohinoor Samudra images in the following flow (see [example_flow.txt](https://github.com/user-attachments/files/17502206/example_flow.txt)):

![image](https://github.com/user-attachments/assets/049e64fc-1e03-416f-9d33-9713073925ef)

Which results in the following table:

![image](https://github.com/user-attachments/assets/7e1ca12c-3f36-4cdf-ba55-d62ce93e2702)

Note that the ***last image is truncated***.   Don't know how to fix that unfortunately...

## Related Issue(s)

[1418](https://github.com/FlowFuse/node-red-dashboard/issues/1418)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [X] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

