### PR TITLE
Charts: Don't add to xLabels for non-categorical charts

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -487,8 +487,6 @@ export default {
                 // ChartsJS doesn't like undefined data points
                 const data = Array(xLabels.length).fill({})
                 if (xIndex === -1) {
-                    // Add the new x-value to xLabels
-                    xLabels.push(datapoint.x)
                     // Add data to the end of the array
                     data.push(datapoint)
                 } else {


### PR DESCRIPTION
## Description

- Removes the addition of the xLabel for non-categorical/radial charts 
- This was causing mis-alignment of `data` and the x-axis limits.

## Related Issue(s)

Closes #1411 