### PR TITLE
Drive app name via Base's "Name" field

### DIFF
--- a/docs/user/pwa.md
+++ b/docs/user/pwa.md
@@ -35,6 +35,12 @@ You'll then be prompted to name your application:
 
 ## Customization
 
+### Name
+
+You can personalize your application's name to enhance branding and make it easily recognizable. 
+
+To customize the name, select "Edit Settings" in the Dashboard 2.0 sidebar. Then modify the "Name" field. You may need to restart Node-RED in order for the change to take effect in the application when installed.
+
 ### Icon
 
 You can personalize your Dashboard's App Icon to enhance branding and make it easily recognizable. To customize the icon, simply add a URL to the image in the App Icon field under the ui-base configuration. For detailed instructions, visit the [UI Base documentation](/nodes/config/ui-base.html#application-icon).

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -142,14 +142,14 @@ module.exports = function (RED) {
             uiShared.app.get('/dashboard/manifest.webmanifest', (req, res) => {
                 const hasAppIcon = (config.appIcon && config.appIcon.trim() !== '')
                 const manifest = {
-                    name: 'Node-RED Dashboard 2.0',
-                    short_name: 'Dashboard',
+                    name: config.name,
+                    short_name: config.name,
                     start_url: './',
                     display: 'standalone',
                     background_color: '#ffffff',
                     lang: 'en',
                     scope: './',
-                    description: 'Node-RED Dashboard 2.0',
+                    description: config.name,
                     theme_color: '#ffffff',
                     icons: [
                         { src: hasAppIcon ? config.appIcon : 'pwa-64x64.png', sizes: '64x64', type: 'image/png' },


### PR DESCRIPTION
## Description

- Removes the hardcoded `name` in the `manifest`.
- In theory, this should be served up dynamically on each request, but when using dev tools, the `name` wasn't updated until after a Node-RED restart which is odd, but it does update/work.
- Updated documentation too

## Related Issue(s)

Closes #1375 