### PR TITLE
WYSIWYG: Tidy up styling/positioning of the Edit Controls

### DIFF
--- a/ui/src/components/ConfirmDialog.vue
+++ b/ui/src/components/ConfirmDialog.vue
@@ -2,8 +2,8 @@
     <v-dialog v-model="visible" max-width="500">
         <v-card :title="title" :text="message" :prepend-icon="icon">
             <v-card-actions>
-                <v-btn v-if="cancelButton !== null" variant="flat" color="primary" @click="_cancel">{{ cancelButton }}</v-btn>
-                <v-btn v-if="okButton !== null" variant="flat" color="warning" @click="_confirm">{{ okButton }}</v-btn>
+                <v-btn v-if="cancelButton !== null" variant="outlined" color="red" @click="_cancel">{{ cancelButton }}</v-btn>
+                <v-btn v-if="okButton !== null" variant="outlined" color="green-darken-2" @click="_confirm">{{ okButton }}</v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -6,9 +6,7 @@
             </template>
             <v-app-bar-title>
                 <template v-if="dashboard.showPageTitle === true || dashboard.showPageTitle === undefined">
-                    {{ pageTitle }}<v-chip v-if="showEditingIconInAppBar" v-tooltip="`${currentEditPage.name} is in edit mode`" color="warning" :to="currentEditPage.type === 'ui-page' ? { name: currentEditPage.route.name } : null">
-                        <v-icon>mdi-pencil</v-icon>
-                    </v-chip>
+                    {{ pageTitle }}
                 </template>
                 <div id="app-bar-title" />
             </v-app-bar-title>
@@ -193,10 +191,6 @@ export default {
                 return this.orderedPages.find(p => p.id === editPage.value)
             }
             return null
-        },
-        showEditingIconInAppBar: function () {
-            // show the edit icon in the app bar if the page is in edit mode and the drawer is closed
-            return !!(this.currentEditPage && (this.drawer === false || this.rail === true))
         }
     },
     watch: {

--- a/ui/src/layouts/wysiwyg/EditControls.vue
+++ b/ui/src/layouts/wysiwyg/EditControls.vue
@@ -1,10 +1,11 @@
 <template>
     <div class="nrdb-ui-editor-tray-container">
         <div class="nrdb-ui-editor-tray">
-            <v-btn v-tooltip="'Leave Edit Mode'" :disabled="saveBusy" variant="outlined" icon="mdi-close" color="warning" @click="cancel" />
-            <v-btn v-tooltip="'Discard Changes'" :disabled="!dirty || saveBusy" variant="outlined" color="secondary" icon="mdi-arrow-u-left-top" @click="discard" />
-            <v-btn v-tooltip="'Save Changes'" :disabled="!dirty || saveBusy" variant="flat" icon="mdi-content-save-outline" color="success" :loading="saveBusy" @click="save" />
+            <v-btn v-tooltip="'Leave Edit Mode'" :disabled="saveBusy" variant="outlined" icon="mdi-close" color="red-darken-1" @click="cancel" />
+            <v-btn v-tooltip="'Discard Changes'" :disabled="!dirty || saveBusy" variant="outlined" color="blue" icon="mdi-arrow-u-left-top" @click="discard" />
+            <v-btn v-tooltip="'Save Changes'" :disabled="!dirty || saveBusy" variant="outlined" icon="mdi-content-save-outline" color="green" :loading="saveBusy" @click="save" />
         </div>
+        <div class="nrdb-edit-mode--message">In Edit Mode</div>
     </div>
 </template>
 
@@ -39,20 +40,26 @@ export default {
 <style scoped lang="scss">
 .nrdb-ui-editor-tray-container {
     position: fixed;
-    bottom: 24px;
+    top: 0;
+    left: 0;
+    z-index: 1000;
     width: 100%;
     display: flex;
     justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    --shadow: 0px 0px 5px #000000de;
 }
 .nrdb-ui-editor-tray {
     background-color: white;
     border: 1px solid #ccc;
-    box-shadow: 0px 0px 5px #00000021;
-    padding: 12px;
-    border-radius: 4px;
+    padding: 6px 12px;
+    border-bottom-left-radius: 12px;
+    border-bottom-right-radius: 12px;
     display: flex;
-    gap: 6px;
-    border-radius: 2rem;
+    gap: 12px;
+    box-shadow: var(--shadow);
+    z-index: 2;
     .v-btn {
         border-radius: 2.6rem;
         // override theme for consistent button size
@@ -64,5 +71,14 @@ export default {
     button:disabled {
         filter: grayscale(1);
     }
+}
+.nrdb-edit-mode--message {
+    padding: 3px 9px;
+    font-size: 0.875rem;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+    background-color: rgb(var(--v-theme-navigation-background));
+    color: rgba(var(--v-theme-on-navigation-background),var(--v-high-emphasis-opacity));
+    box-shadow: var(--shadow);
 }
 </style>


### PR DESCRIPTION
## Description

<img width="1632" alt="Screenshot 2024-11-04 at 11 18 42" src="https://github.com/user-attachments/assets/d52d2790-2972-4015-9eda-332b957111fd">

- Improve the colouring of the buttons in the Edit Controls and confirmation Dialog.
- Move the "Actions" to the top of the screen, as they felt a little lost floating in the middle at the bottom.
- Remove the "Pencil" icon from the page title, and instead have an "In Edit Mode" note under the actions bar