### PR TITLE
Allow specifying target in ui-control

### DIFF
--- a/docs/nodes/widgets/ui-control.md
+++ b/docs/nodes/widgets/ui-control.md
@@ -96,6 +96,15 @@ msg.payload = {
 }
 ```
 
+ You can also specify a `target` property to open the website in a new browser window or tab.
+ 
+```js
+msg.payload = {
+    url: 'https://nodered.org',
+    target: '_blank'
+}
+```
+
 ### Show/Hide
 
 You can programmaticaly show/hide groups and pages with the following payload into `ui-control`:

--- a/nodes/widgets/locales/en-US/ui_control.html
+++ b/nodes/widgets/locales/en-US/ui_control.html
@@ -49,6 +49,11 @@
     <pre>msg.payload = {
     url: 'https://url.goes.here'
 }</pre>
+    <p>You can also specify a target to open the link in a new browser window or tab.</p>
+    <pre>msg.payload = {
+    url: 'https://url.goes.here',
+    target: '_blank'
+}</pre>
     <h3>Events List</h3>
     <p>When any browser client connects or loses connection, changes tab, or expands or collapses a group this node will emit a <code>msg</code> containing:</p>
     <ul>

--- a/nodes/widgets/ui_control.html
+++ b/nodes/widgets/ui_control.html
@@ -36,8 +36,8 @@
 
 <script type="text/html" data-template-name="ui-control">
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="ui-control.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]ui-control.placeholder.name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
     <div class="form-row">
         <label for="node-input-ui"><i class="fa fa-bookmark"></i> UI</label>

--- a/ui/src/widgets/ui-control/UIControl.vue
+++ b/ui/src/widgets/ui-control/UIControl.vue
@@ -216,8 +216,13 @@ export default {
             }
 
             if ('url' in payload) {
-                // we are setting the url
-                window.location.href = payload.url
+                if ('target' in payload) {
+                    // Open the link in a new browser window or tab
+                    window.open(payload.url, payload.target)
+                } else {
+                    // Open the link in the same window
+                    window.location.href = payload.url
+                }
             }
         })
     },


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Allows specifying a `target` along with `url` in order to open external links in new tabs

```js
msg.payload = {
    url: 'https://nodered.org',
    target: '_blank'
}
```
## Related Issue(s)

<!-- What issue does this PR relate to? -->
Closes #1163
## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [X] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

