### PR TITLE
WYSIWYG - Add in empty img for dragging functionality

### DIFF
--- a/ui/src/layouts/Group.vue
+++ b/ui/src/layouts/Group.vue
@@ -25,6 +25,7 @@
                 @dragenter.prevent
             />
         </div>
+        <img ref="blank-img" style="position: absolute;" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt="">
     </div>
 </template>
 


### PR DESCRIPTION
## Description

- I'd removed this img as I couldn't recall why it was there, and it was causing a layout bug.
- I now remember it was there for the drag image placeholder, this was in turn then causing an error in the `resizable` handler that prevented propagation being blocked, so groups were resizing _and_ re-ordering together. This -reintroduction (and changing `position: absolute`) fixes all the issues.