### PR TITLE
Dropdown - emit msg on event

### DIFF
--- a/docs/nodes/widgets/ui-dropdown.md
+++ b/docs/nodes/widgets/ui-dropdown.md
@@ -20,6 +20,8 @@ props:
         dynamic: false
     Allow Search:
         description: Allows user to type a new value, filtering the list of possible values to choose.         
+    Msg trigger:
+        description: Specify when an output message should be send.  On every change or when the dropdown is closed.
 dynamic:
     Label:
         payload: msg.ui_update.label
@@ -32,6 +34,9 @@ dynamic:
         structure: ["Boolean"]
     Class:
         payload: msg.ui_update.class
+        structure: ["String"]
+    Msg trigger:
+        payload: msg.ui_update.msgTrigger
         structure: ["String"]
 ---
 

--- a/nodes/widgets/locales/en-US/ui_dropdown.html
+++ b/nodes/widgets/locales/en-US/ui_dropdown.html
@@ -41,5 +41,13 @@
         </dd>
         <dt class="optional">class <span class="property-type">string</span></dt>
         <dd>Add a CSS class, or more, to the Button at runtime.</dd>
+        <dt class="optional">msgTrigger <span class="property-type">string</span></dt>
+        <dd>
+            Specify when an output message should be triggered (especially useful for multi-selection dropdowns):
+            <ul>
+                <li><code>onChange</code>: each time the selection is changed (i.e. when options are selected or deselected).</li>
+                <li><code>onClose</code>: only when the dropdown is closed.</li>
+            </ul>
+        </dd>
     </dl>
 </script>

--- a/nodes/widgets/ui_dropdown.html
+++ b/nodes/widgets/ui_dropdown.html
@@ -40,7 +40,8 @@
                 topicType: { value: 'msg' },
                 className: { value: '' },
                 // This field controls if the used component is going to be a `v-combox` or a `v-select`, `v-combox` allows typing and filtering possible values
-                typeIsComboBox: { value: true }
+                typeIsComboBox: { value: true },
+                msgTrigger: { value: 'onChange' }
             },
             inputs: 1,
             outputs: 1,
@@ -60,6 +61,9 @@
                 }
                 if (this.typeIsComboBox === undefined) {
                     $('#node-input-typeIsComboBox').prop('checked', true)
+                }
+                if (this.msgTrigger === undefined) {
+                    $('#node-input-msgTrigger').val('onChange')
                 }
                 // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
                 // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
@@ -247,5 +251,12 @@
         <label for="node-input-topic"><i class="fa fa-tasks"></i> Topic</label>
         <input type="text" id="node-input-topic" style="width:70%" placeholder="optional msg.topic">
         <input type="hidden" id="node-input-topicType">
+    </div>
+    <div class="form-row">
+        <label for="node-input-msgTrigger"><i class="fa fa-paper-plane"></i> Msg trigger</label>
+        <select id="node-input-msgTrigger" style="width: 70%;">
+            <option value="onChange">On every change</option>
+            <option value="onClose">On dropdown closed</option>
+       </select>
     </div>
 </script>

--- a/nodes/widgets/ui_dropdown.js
+++ b/nodes/widgets/ui_dropdown.js
@@ -26,6 +26,10 @@ module.exports = function (RED) {
                         // dynamically set "label" property
                         statestore.set(group.getBase(), node, msg, 'multiple', update.multiple)
                     }
+                    if (typeof update.msgTrigger !== 'undefined') {
+                        // dynamically set "msgTrigger" property
+                        statestore.set(group.getBase(), node, msg, 'msgTrigger', update.msgTrigger)
+                    }
                 }
                 if (msg.options) {
                     // backward compatibility support

--- a/ui/src/widgets/ui-dropdown/UIDropdown.vue
+++ b/ui/src/widgets/ui-dropdown/UIDropdown.vue
@@ -4,6 +4,7 @@
         :multiple="multiple" :chips="chips" :clearable="clearable" :items="options" item-title="label"
         item-value="value" variant="outlined" hide-details="auto" auto-select-first
         :error-messages="options?.length ? '' : 'No options available'" @update:model-value="onChange"
+        @blur="onBlur"
     >
         <template #label>
             <!-- eslint-disable-next-line vue/no-v-html -->
@@ -14,7 +15,7 @@
         v-else v-model="value" :disabled="!state.enabled" :class="className" :multiple="multiple"
         :chips="chips" :clearable="clearable" :items="options" item-title="label" item-value="value" variant="outlined"
         hide-details="auto" :error-messages="options?.length ? '' : 'No options available'"
-        @update:model-value="onChange"
+        @update:model-value="onChange" @blur="onBlur"
     >
         <template #label>
             <!-- eslint-disable-next-line vue/no-v-html -->
@@ -131,6 +132,7 @@ export default {
                 this.updateDynamicProperty('multiple', updates.multiple)
                 this.updateDynamicProperty('chips', updates.chips)
                 this.updateDynamicProperty('clearable', updates.clearable)
+                this.updateDynamicProperty('msgTrigger', updates.msgTrigger)
             }
         },
         onChange () {
@@ -159,7 +161,19 @@ export default {
                 widgetId: this.id,
                 msg
             })
-            this.$socket.emit('widget-change', this.id, msg.payload)
+
+            const msgTrigger = this.getProperty('msgTrigger') || 'onChange'
+            if (msgTrigger === 'onChange') {
+                this.$socket.emit('widget-change', this.id, msg.payload)
+            }
+        },
+        onBlur () {
+            // The onBlur event is triggered when an element loses focus (e.g. when being closed),
+            // which can be used as an indicator that the user has finished interacting with the dropdown.
+            if (this.getProperty('msgTrigger') === 'onClose') {
+                const msg = this.messages[this.id] || {}
+                this.$socket.emit('widget-change', this.id, msg.payload)
+            }
         },
         select (value) {
             if (value !== undefined) {


### PR DESCRIPTION
## Description
This PR adds a new option to the ui-dropdown node to select when an output message should be triggered:

![image](https://github.com/user-attachments/assets/d1a5723a-fb46-4fd3-99d3-0afa689f6ffd)

As explained in the info panel:

![image](https://github.com/user-attachments/assets/92171b15-399a-4911-b1c0-fc241c67b910)

This `msgTrigger` property can also be dynamically set.  The default value is *"onChange"* like in the previous versions, to avoid breaking changes.

The following example flow demonstrates the default *"onChange"* value, which is then dynamically overwritten by a *"onClose"* value:

![dropdown_emit](https://github.com/user-attachments/assets/174697a5-8b63-43de-bd6a-21f29d880e66)

## Related Issue(s)

[1457](https://github.com/FlowFuse/node-red-dashboard/issues/1457)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [X] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

