### PR TITLE
Support internal HTTPS for WYSIWYG

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -1130,7 +1130,17 @@ module.exports = function (RED) {
         const host = RED.settings.uiHost
         const port = RED.settings.uiPort
         const httpAdminRoot = RED.settings.httpAdminRoot
-        const url = 'http://' + (`${host}:${port}/${httpAdminRoot}flows`).replace('//', '/')
+        let scheme = 'http://'
+        let httpsAgent
+        if (RED.settings.requireHttps) {
+            if (RED.settings.https) {
+                httpsAgent = new Agent({
+                    rejectUnauthorized: false
+                })
+            }
+            scheme = 'https://'
+        }
+        const url = scheme + (`${host}:${port}/${httpAdminRoot}flows`).replace('//', '/')
         console.log('url', url)
         // get request body
         const dashboardId = req.params.dashboardId


### PR DESCRIPTION
closes #1473

## Description

- Checks `RED.settings.requireHttps` and switches the URL scheme to "https://"
- Also, if `RED.settings.https` is "something", apply an HTTPS agent too 
    - _(this bit i am not 100% sure about - might be just as well to apply the agent regardless of `RED.settings.https`) - lets see how it goes, it solves the OPs current issue)_


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

