### PR TITLE
New Feature: wysiwyg design time editing - add and remove spacer widgets 

### DIFF
--- a/ui/src/EditTracking.js
+++ b/ui/src/EditTracking.js
@@ -6,9 +6,7 @@ const state = reactive({
     editPage: '',
     editMode: false,
     editorPath: '', // the custom httpAdminRoot path for the NR editor
-    isTrackingEdits: false,
-    originalGroups: [],
-    originalWidgets: []
+    isTrackingEdits: false
 })
 
 // Methods
@@ -28,49 +26,19 @@ function initialise (editKey, editPage, editorPath) {
 /**
  * Start tracking edits
  */
-function startEditTracking (groups, widgets) {
+function startEditTracking () {
     state.isTrackingEdits = true
-    updateEditTracking(groups, widgets)
 }
 
 /**
  * Stop tracking edits, clear editKey/editPage & exit edit mode
  */
-function exitEditMode () {
+function endEditMode () {
     state.editKey = ''
     state.editPage = ''
     state.editMode = false
     state.isTrackingEdits = false
     state.initialised = false
-    state.originalGroups = []
-    state.originalWidgets = []
-}
-
-/**
- * Update the original groups with the current groups
- */
-function updateEditTracking (groups, widgets) {
-    if (typeof groups !== 'undefined') {
-        state.originalGroups = JSON.parse(JSON.stringify(groups))
-    }
-    if (typeof widgets !== 'undefined') {
-        // only store the id, props and layout of each widget (that's all we need for comparison)
-        const groupIds = Object.keys(widgets)
-        const partials = {}
-        for (let i = 0; i < groupIds.length; i++) {
-            const groupId = groupIds[i]
-            const groupWidgets = widgets[groupId]
-            const partialWidgets = groupWidgets.map((w) => {
-                return {
-                    id: w.id,
-                    props: w.props,
-                    layout: w.layout
-                }
-            })
-            partials[groupId] = partialWidgets
-        }
-        state.originalWidgets = JSON.parse(JSON.stringify(partials))
-    }
 }
 
 // RO computed props
@@ -78,58 +46,6 @@ const editKey = computed(() => state.editKey)
 const editPage = computed(() => state.editPage)
 const editMode = computed(() => !!state.editKey && !!state.editPage)
 const editorPath = computed(() => state.editorPath)
-const originalGroups = computed(() => state.originalGroups)
-const originalWidgets = computed(() => state.originalWidgets)
 const isTrackingEdits = computed(() => state.isTrackingEdits)
 
-const groupPropertiesToCheck = [
-    (original, current) => +original.width === +current.width,
-    (original, current) => +original.height === +current.height,
-    (original, current) => +original.order === +current.order
-]
-
-const widgetPropertiesToCheck = [
-    (original, current) => +original.layout?.width === +current.layout?.width,
-    (original, current) => +original.layout?.height === +current.layout?.height,
-    (original, current) => +original.layout?.order === +current.layout?.order,
-    (original, current) => +original.props?.width === +current.props?.width,
-    (original, current) => +original.props?.height === +current.props?.height,
-    (original, current) => +original.props?.order === +current.props?.order
-]
-
-function isDirty (groups, widgets) {
-    console.log('isDirty', groups, widgets)
-    const originalGroups = state.originalGroups || []
-    // scan through each group and revert changes
-
-    for (let i = 0; i < originalGroups.length; i++) {
-        const originalGroup = originalGroups[i]
-        const currentGroup = groups?.find(group => group.id === originalGroup.id)
-        if (!currentGroup) {
-            console.warn('Group not found in pageGroups - as we do not currently support adding/removing groups, this should not happen!')
-            return true
-        }
-        // test group properties
-        if (groupPropertiesToCheck.some(check => !check(originalGroup, currentGroup))) {
-            return true
-        }
-
-        // test widgets belonging to this group
-        const originalWidgetValues = state.originalWidgets?.[originalGroup.id] || []
-        const currentWidgets = widgets?.[originalGroup.id] || []
-        for (let j = 0; j < originalWidgetValues.length; j++) {
-            const originalWidget = originalWidgetValues[j]
-            const currentWidget = currentWidgets.find(widget => widget.id === originalWidget.id)
-            if (!currentWidget) {
-                console.warn('Widget not found in pageWidgets - as we do not currently support adding/removing widgets, this should not happen!')
-                return true
-            }
-            if (widgetPropertiesToCheck.some(check => !check(originalWidget, currentWidget))) {
-                return true
-            }
-        }
-    }
-    return false
-}
-
-export { editKey, editMode, editPage, editorPath, originalGroups, originalWidgets, isDirty, isTrackingEdits, initialise, exitEditMode, startEditTracking, updateEditTracking }
+export { editKey, editMode, editPage, editorPath, isTrackingEdits, initialise, startEditTracking, endEditMode }

--- a/ui/src/layouts/Flex.vue
+++ b/ui/src/layouts/Flex.vue
@@ -22,7 +22,7 @@
                         {{ g.name }}
                     </template>
                     <template #text>
-                        <widget-group :group="g" :index="$index" :widgets="groupWidgets(g.id)" :resizable="editMode" :group-dragging="groupDragging.active" @resize="onGroupResize" />
+                        <widget-group :group="g" :index="$index" :widgets="groupWidgets(g.id)" :resizable="editMode" :group-dragging="groupDragging.active" @resize="onGroupResize" @widget-added="updateEditStateObjects" @widget-removed="updateEditStateObjects" @refresh-state-from-store="updateEditStateObjects" />
                     </template>
                 </v-card>
             </div>
@@ -117,12 +117,7 @@ export default {
     mounted () {
         console.log('flex layout mounted')
         if (this.editMode) { // mixin property
-            this.pageGroups = this.getPageGroups()
-            const pageGroupWidgets = {}
-            for (const group of this.pageGroups) {
-                pageGroupWidgets[group.id] = this.getGroupWidgets(group.id)
-            }
-            this.pageGroupWidgets = pageGroupWidgets
+            this.updateEditStateObjects()
             this.initializeEditTracking() // Mixin method
         }
     },
@@ -225,7 +220,7 @@ export default {
         },
         discardEdits () {
             this.revertEdits() // Mixin method
-            this.pageGroups = this.getPageGroups()
+            this.updateEditStateObjects()
         },
         async leaveEditMode () {
             let leave = true
@@ -253,6 +248,15 @@ export default {
                 return
             }
             this.pageGroups[opts.index].width = opts.width
+        },
+        updateEditStateObjects () {
+            console.log('updateEditStateObjects')
+            this.pageGroups = this.getPageGroups()
+            const pageGroupWidgets = {}
+            for (const group of this.pageGroups) {
+                pageGroupWidgets[group.id] = this.getGroupWidgets(group.id)
+            }
+            this.pageGroupWidgets = pageGroupWidgets
         }
     }
 }

--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -22,7 +22,7 @@
                         {{ g.name }}
                     </template>
                     <template #text>
-                        <widget-group :group="g" :index="$index" :widgets="groupWidgets(g.id)" :resizable="editMode" :group-dragging="groupDragging.active" @resize="onGroupResize" />
+                        <widget-group :group="g" :index="$index" :widgets="groupWidgets(g.id)" :resizable="editMode" :group-dragging="groupDragging.active" @resize="onGroupResize" @widget-added="updateEditStateObjects" @widget-removed="updateEditStateObjects" @refresh-state-from-store="updateEditStateObjects" />
                     </template>
                 </v-card>
             </div>
@@ -117,12 +117,7 @@ export default {
     mounted () {
         console.log('grid layout mounted')
         if (this.editMode) { // mixin property
-            this.pageGroups = this.getPageGroups()
-            const pageGroupWidgets = {}
-            for (const group of this.pageGroups) {
-                pageGroupWidgets[group.id] = this.getGroupWidgets(group.id)
-            }
-            this.pageGroupWidgets = pageGroupWidgets
+            this.updateEditStateObjects()
             this.initializeEditTracking() // Mixin method
         }
     },
@@ -225,7 +220,7 @@ export default {
         },
         discardEdits () {
             this.revertEdits() // Mixin method
-            this.pageGroups = this.getPageGroups()
+            this.updateEditStateObjects()
         },
         async leaveEditMode () {
             let leave = true
@@ -253,6 +248,15 @@ export default {
                 return
             }
             this.pageGroups[opts.index].width = opts.width
+        },
+        updateEditStateObjects () {
+            console.log('Updating edit state objects')
+            this.pageGroups = this.getPageGroups()
+            const pageGroupWidgets = {}
+            for (const group of this.pageGroups) {
+                pageGroupWidgets[group.id] = this.getGroupWidgets(group.id)
+            }
+            this.pageGroupWidgets = pageGroupWidgets
         }
     }
 }

--- a/ui/src/layouts/wysiwyg/resizable.scss
+++ b/ui/src/layouts/wysiwyg/resizable.scss
@@ -7,6 +7,11 @@
     --handle-size: 12px;
     --handle-opacity: 0.1; // initially mostly transparent - updated in hover
     --handle-accent: transparent; // initially no accent color - updated in hover
+    /* transitions to match vuetify cards/buttons etc */ 
+    transition-property: box-shadow, transform, opacity, border;
+    transition-duration: 0.28s;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    border-color: 0px dashed transparent;
     cursor: grab;
     &.resizing {
         z-index: 1000 !important;
@@ -25,6 +30,10 @@
     border: 1px solid black;
     border-radius: 6px;
     opacity: var(--handle-opacity);
+    /* transitions to match vuetify cards/buttons etc */ 
+    transition-property: box-shadow, transform, opacity, background;
+    transition-duration: 0.28s;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     &:hover, &:active {
         background-color: #eee;
         --handle-opacity: 1;
@@ -71,3 +80,31 @@
     display: inline-block;
     background-color: var(--handle-accent);
 }
+
+.nrdb-resizable {
+    --toolbar-opacity: 0;
+    &:hover {
+        --toolbar-opacity: 1;
+    }
+    .nrdb-resizable--toolbar {
+        position: absolute;
+        top: 8px;
+        right: 12px;
+        z-index: 101;
+        opacity: var(--toolbar-opacity, 0);
+        &:hover {
+            --toolbar-opacity: 1;
+        }
+        > .nrdb-resizable--toolbar-button {
+            width: 20px; // override theme sizing
+            height: 20px;
+            min-height: 20px;
+            min-width: 20px;
+            cursor: pointer;
+            &:hover {
+                --toolbar-opacity: 1;
+            }
+        }
+    }
+}
+

--- a/ui/src/store/index.mjs
+++ b/ui/src/store/index.mjs
@@ -4,12 +4,14 @@ import { createStore } from 'vuex'
 import ui from './ui.mjs'
 import data from './data.mjs'
 import setup from './setup.mjs'
+import wysiwyg from './wysiwyg.mjs'
 
 export default createStore({
     modules: {
         ui,
         data,
-        setup
+        setup,
+        wysiwyg
     },
     plugins: []
 })

--- a/ui/src/store/ui.mjs
+++ b/ui/src/store/ui.mjs
@@ -1,9 +1,40 @@
+/**
+ * @typedef {Object} Group
+ * @property {string} id - the group ID
+ * @property {'ui-group'} type
+ * @property {string} page - owner page ID
+ * @property {*} [*] - Other group properties
+ */
+/**
+ * @typedef {Object} Widget
+ * @property {string} id - the widget ID
+ * @property {string} type - the widget type e.g. ui-button, ui-text, ui-template
+ * @property {Object} props - the widget properties (typically the node properties)
+ * @property {Object} layout - the widget layout properties
+ * @property {Number | String} layout.order - order of the widget in the group
+ * @property {Number | String} layout.width - width of the widget in the group
+ * @property {Number | String} layout.height - height of the widget in the group
+ * @property {Object} state
+ * @property {Object} component
+ */
+/**
+ * @typedef {Object.<string, Widget>} Widgets - Widget ID to Widget lookup as per ui store state format
+ */
+/**
+ * @typedef {Array<Group>} PageGroups - Array of Group on the current given page
+ */
+/**
+ * @typedef {Object.<string, Array<Widget>} PageGroupsWidgets - Look up of Group ID to Array of Widgets for the current page
+ */
+
 // initial state
 const state = () => ({
     dashboards: null,
     pages: null,
-    groups: null,
     themes: null,
+    /** @type {Widgets} */
+    groups: null,
+    /** @type {Widgets} */
     widgets: null
 })
 
@@ -107,7 +138,6 @@ const getters = {
 
             // 4. Flatten the grouped data back into a single array
             const sorted = sortedGroups.flatMap((e) => e[1])
-            // sortData2(widgetsInGroup).map(e=>{ return {widgetorder: e.layout.order, ...{ ...(e.props.subflow ||{})}}})
             return sorted
         }
     },

--- a/ui/src/store/wysiwyg.mjs
+++ b/ui/src/store/wysiwyg.mjs
@@ -1,0 +1,324 @@
+import { markRaw } from 'vue'
+
+import { endEditMode, startEditTracking } from '../EditTracking.js'
+import UISpacer from '../widgets/ui-spacer/UISpacer.vue'
+
+// initial state
+const state = () => ({
+    originalGroups: null,
+    originalWidgets: null,
+    shadowWidgets: null // this is used to store widgets that have been removed during an edit session
+})
+
+// getters
+const getters = {
+    // edit time tracking:
+    originalGroups (state) {
+        return state.originalGroups
+    },
+    originalWidgets (state) {
+        return state.originalWidgets
+    },
+    isDirty: (state, getters, rootState) => (pageId, groups = null, widgets = null) => {
+        // when groups are passed in, they are an array of groups, convert to a key-value object
+        if (groups) {
+            groups = flattenPageGroups(groups)
+        }
+        // when widgets are passed in, they are in a nested object {groupId:{ id: widget1, id: widget2 } structure
+        // so we need to flatten them to a key-value object
+        if (widgets) {
+            widgets = flattenPageWidgets(widgets)
+        }
+
+        const originalWidgets = state.originalWidgets || {}
+        const currentWidgets = widgets || rootState.ui.widgets || {}
+        const originalGroups = state.originalGroups || {}
+        const currentGroups = groups || rootState.ui.groups || {}
+
+        let originalGroupsCount = 0
+        let currentGroupsCount = 0
+        let originalWidgetsCount = 0
+        let currentWidgetsCount = 0
+
+        // first filter to only items of interest (those matching the currentGroupId)
+        const originalPageGroups = new Map()
+        const originalPageGroupsWidgets = new Map()
+        const currentPageGroups = new Map()
+        const currentPageGroupsWidgets = new Map()
+        for (const key in originalGroups) {
+            if (originalGroups[key].page === pageId) {
+                originalPageGroups.set(originalGroups[key].id, originalGroups[key])
+                originalGroupsCount++
+            }
+        }
+        for (const key in currentGroups) {
+            if (currentGroups[key].page === pageId) {
+                currentPageGroups.set(currentGroups[key].id, currentGroups[key])
+                currentGroupsCount++
+            }
+        }
+        for (const key in originalWidgets) {
+            if (originalPageGroups.has(originalWidgets[key]?.props?.group)) {
+                originalPageGroupsWidgets.set(originalWidgets[key].id, originalWidgets[key])
+                originalWidgetsCount++
+            }
+        }
+        for (const key in currentWidgets) {
+            if (originalPageGroups.has(currentWidgets[key]?.props?.group)) {
+                currentPageGroupsWidgets.set(currentWidgets[key].id, currentWidgets[key])
+                currentWidgetsCount++
+            }
+        }
+
+        // fast test: if the number of groups or widgets has changed, we are dirty
+        if (originalGroupsCount !== currentGroupsCount) {
+            return true
+        }
+        if (originalWidgetsCount !== currentWidgetsCount) {
+            return true
+        }
+
+        // scan test: compare each group and widget
+        const groupPropertiesToCheck = [
+            (original, current) => +original.width === +current.width,
+            (original, current) => +original.height === +current.height,
+            (original, current) => +original.order === +current.order
+        ]
+        for (let idx = 0; idx < originalGroupsCount.length; idx++) {
+            const originalGroup = originalGroupsCount[idx]
+            const group = currentGroups[originalGroup.id]
+            if (!group) {
+                return true
+            }
+            for (const check of groupPropertiesToCheck) {
+                if (!check(originalGroup, group)) {
+                    return true
+                }
+            }
+        }
+
+        const widgetPropertiesToCheck = [
+            (original, current) => +original.layout?.width === +current.layout?.width,
+            (original, current) => +original.layout?.height === +current.layout?.height,
+            (original, current) => +original.layout?.order === +current.layout?.order,
+            (original, current) => +original.props?.width === +current.props?.width,
+            (original, current) => +original.props?.height === +current.props?.height,
+            (original, current) => +original.props?.order === +current.props?.order
+        ]
+        const pageGroupsWidgetsArray = Array.from(originalPageGroupsWidgets.values())
+        for (let idx = 0; idx < originalWidgetsCount; idx++) {
+            const originalWidget = pageGroupsWidgetsArray[idx]
+            const widget = currentWidgets[originalWidget.id]
+            if (!widget) {
+                return true // not found must be dirty
+            }
+            for (const check of widgetPropertiesToCheck) {
+                if (!check(originalWidget, widget)) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}
+
+const mutations = {
+    originalGroups (state, groups) {
+        state.originalGroups = groups
+    },
+    originalWidgets (state, widgets) {
+        state.originalWidgets = widgets
+    },
+    // addWidget (state, widget) {
+    //     state.widgets[widget.id] = widget
+    // },
+    // removeWidget (state, widgetId) {
+    //     state.shadowWidgets[widgetId] = state.widgets[widgetId]
+    //     delete state.widgets[widgetId]
+    // },
+    shadowWidgets (state, widgets) {
+        state.shadowWidgets = widgets
+    }
+}
+const actions = {
+    addSpacer ({ rootState, state, commit }, { group, name, order, height, width }) {
+        console.log('addSpacer', group, name, order, height, width)
+        if (!group) {
+            throw new Error('group is required')
+        }
+        // ensure group exists in state.groups
+        if (!rootState.ui.groups[group]) {
+            throw new Error('group does not exist')
+        }
+
+        const widget = {
+            id: newId(),
+            type: 'ui-spacer',
+            name: 'spacer',
+            component: markRaw(UISpacer),
+            props: {
+                group,
+                name: name || 'spacer',
+                tooltip: '',
+                order: order ?? 0,
+                width: width ?? 1,
+                height: height ?? 1,
+                className: '',
+                _users: [],
+                enabled: true,
+                visible: true
+            },
+            layout: {
+                order: order ?? 0,
+                width: width ?? 1,
+                height: height ?? 1
+            },
+            state: { enabled: true, visible: true, class: '' }
+        }
+        rootState.ui.widgets[widget.id] = widget
+        commit('ui/widgets', rootState.ui.widgets, { root: true })
+        return widget
+    },
+    removeWidget ({ rootState, state, commit }, payload) {
+        state.shadowWidgets[payload.id] = rootState.ui.widgets[payload.id]
+        delete rootState.ui.widgets[payload.id]
+        commit('ui/widgets', rootState.ui.widgets, { root: true })
+    },
+    /**
+     * @param {import('vuex').ActionContext} context
+     * @param {Object} payload
+     * @param {import('./ui.mjs').Groups} payload.groups
+     * @param {import('./ui.mjs').Widgets} payload.widgets
+     */
+    beginEditTracking ({ dispatch, state }, { groups, widgets }) {
+        console.log('beginEditTracking')
+        startEditTracking() // EditTracking method
+        dispatch('updateEditTracking', { groups, widgets })
+        state.shadowWidgets = {}
+    },
+    /**
+     * @param {import('vuex').ActionContext} context
+     * @param {Object} payload
+     * @param {Array<import('./ui.mjs').Groups>} payload.groups
+     * @param {import('./ui.mjs').GroupsWidgets} payload.widgets
+     */
+    updateEditTracking ({ commit }, { groups, widgets }) {
+        console.log('updateEditTracking')
+        commit('originalGroups', JSON.parse(JSON.stringify(flattenPageGroups(groups))))
+        const slimCopy = {}
+        /** @type {import('./ui.mjs').Widgets} */
+        const src = flattenPageWidgets(widgets)
+        for (const key in src) {
+            const w = src[key]
+            slimCopy[key] = {
+                id: w.id,
+                type: w.type,
+                props: { ...w.props },
+                layout: { ...w.layout }
+            }
+        }
+        commit('originalWidgets', slimCopy)
+    },
+    revertEdits ({ rootState, state, commit }) {
+        console.log('revertEdits')
+        const uiWidgets = rootState.ui.widgets
+        const uiGroups = rootState.ui.groups
+        const groupPropertiesOfInterest = ['width', 'height', 'order']
+        for (const key in uiGroups) {
+            const existingGroup = uiGroups[key]
+            const originalGroup = state.originalGroups[key]
+            if (!originalGroup) {
+                // group was added, remove it
+                delete uiGroups[key]
+            }
+            if (originalGroup) {
+                for (const prop of groupPropertiesOfInterest) {
+                    existingGroup[prop] = originalGroup[prop]
+                }
+            }
+        }
+
+        /** @type {Widgets} */
+        const originalWidgets = state.originalWidgets
+        const widgetLayoutPropertiesOfInterest = ['width', 'height', 'order']
+        const widgetPropsPropertiesOfInterest = ['width', 'height', 'order']
+        for (const key in originalWidgets) {
+            const originalWidget = originalWidgets[key]
+            if (!uiWidgets[key] && originalWidget) {
+                // widget was removed, bring it back
+                uiWidgets[key] = state.shadowWidgets[key]
+            }
+            if (uiWidgets[key] && !originalWidget) {
+                // widget was added, remove it
+                delete uiWidgets[key]
+            }
+            if (uiWidgets[key] && originalWidget) {
+                for (const prop of widgetPropsPropertiesOfInterest) {
+                    uiWidgets[key].props[prop] = originalWidget.props[prop]
+                }
+                for (const prop of widgetLayoutPropertiesOfInterest) {
+                    uiWidgets[key].layout[prop] = originalWidget.layout[prop]
+                }
+            }
+        }
+        // now scan for widgets that were added to uiWidgets and do not exist in originalWidgets
+        for (const key in uiWidgets) {
+            if (!originalWidgets[key]) {
+                delete uiWidgets[key]
+            }
+        }
+        commit('shadowWidgets', {}) // reset the shadow widgets since we have reverted the changes
+        commit('ui/widgets', uiWidgets, { root: true })
+        commit('ui/groups', uiGroups, { root: true })
+    },
+    endEditTracking ({ commit }) {
+        console.log('endEditTracking')
+        endEditMode() // EditTracking method
+        commit('originalGroups', null)
+        commit('originalWidgets', null)
+        commit('shadowWidgets', null)
+    }
+}
+
+function newId () {
+    return Date.now().toString(16).slice(2, 10) + Math.random().toString(16).slice(2, 10)
+}
+
+/**
+ * Flattens the PageGroups array to a flat lookup object
+ * @param {import('./ui.mjs').PageGroups} groups
+ * @returns {Object.<string, Group>}
+ */
+function flattenPageGroups (groups) {
+    const flat = {}
+    for (const key in groups) {
+        const g = groups[key]
+        flat[g.id] = g
+    }
+    return flat
+}
+
+/**
+ * Flattens the PageGroupsWidgets object to a flat lookup object
+ * @param {import('./ui.mjs').PageGroupsWidgets} groupWidgets
+ * @returns {Object.<string, Widget>} - Widget ID to Widget lookup
+ */
+function flattenPageWidgets (groupWidgets) {
+    const flat = {}
+    for (const groupId in groupWidgets) {
+        const widgets = groupWidgets[groupId]
+        for (let idx = 0; idx < widgets.length; idx++) {
+            const w = widgets[idx]
+            flat[w.id] = w
+        }
+    }
+    return flat
+}
+
+export default {
+    namespaced: true,
+    actions,
+    state,
+    getters,
+    mutations
+}


### PR DESCRIPTION
closes #1479

## Description

New feature - ability to add and remove widgets in the dashboard at edit time.

Refactors a lot of the non-store stuff into a new store named `wysiwyg` - this is primarily to take advantage of `actions` and preparation for https://github.com/FlowFuse/node-red-dashboard/issues/1481

This is an extension of (and thus) merges into https://github.com/FlowFuse/node-red-dashboard/issues/1468

### Demo

![chrome_txdDw0dM7w](https://github.com/user-attachments/assets/47717d1c-da60-4281-83dd-502d8e49412b)


## Related Issue(s)

#1479

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

