### PR TITLE
Use an HTTPS Agent and HTTPS scheme if RED.settings.https is set

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -1,3 +1,4 @@
+const { Agent } = require('https')
 const path = require('path')
 
 const axios = require('axios')
@@ -1130,7 +1131,17 @@ module.exports = function (RED) {
         const host = RED.settings.uiHost
         const port = RED.settings.uiPort
         const httpAdminRoot = RED.settings.httpAdminRoot
-        const url = 'http://' + (`${host}:${port}/${httpAdminRoot}flows`).replace('//', '/')
+        let scheme = 'http://'
+        let httpsAgent
+        if (RED.settings.https) {
+            const https = (typeof RED.settings.https === 'function' ? RED.settings.https() : RED.settings.https) || {}
+            httpsAgent = new Agent({
+                rejectUnauthorized: false,
+                ...https
+            })
+            scheme = 'https://'
+        }
+        const url = scheme + (`${host}:${port}/${httpAdminRoot}flows`).replace('//', '/')
         console.log('url', url)
         // get request body
         const dashboardId = req.params.dashboardId
@@ -1234,6 +1245,7 @@ module.exports = function (RED) {
             const getResponse = await axios.request({
                 method: 'GET',
                 headers: getHeaders,
+                httpsAgent,
                 url
             })
 
@@ -1314,6 +1326,7 @@ module.exports = function (RED) {
             const postResponse = await axios.request({
                 method: 'POST',
                 headers: postHeaders,
+                httpsAgent,
                 url,
                 data: {
                     flows,

--- a/ui/src/layouts/Group.vue
+++ b/ui/src/layouts/Group.vue
@@ -116,17 +116,12 @@ export default {
         },
         widgetStyles () {
             return (widget) => {
-                // `grid-template-columns: minmax(0, 1fr); grid-template-rows: repeat(${w.props.height}, minmax(var(--widget-row-height), auto)); grid-row-end: span ${w.props.height}; grid-column-end: span min(${ getWidgetWidth(w.props.width) }, var(--layout-columns))`"
                 const styles = {}
                 const height = widget.props.height || widget.layout.height
                 const width = widget.props.width || widget.layout.width
-                if (height) {
-                    styles['grid-row-end'] = `span ${height}`
-                    styles['grid-template-rows'] = `repeat(${height}, minmax(var(--widget-row-height), auto))`
-                }
-                if (width) {
-                    styles['grid-column-end'] = `span min(${this.getWidgetWidth(width)}, var(--layout-columns))`
-                }
+                styles['grid-row-end'] = `span ${height}`
+                styles['grid-template-rows'] = `repeat(${height}, minmax(var(--widget-row-height), auto))`
+                styles['grid-column-end'] = `span min(${this.getWidgetWidth(+width)}, var(--layout-columns))`
                 return styles
             }
         }
@@ -171,11 +166,11 @@ export default {
             return style
         },
         getWidgetWidth (width) {
-            if (width) {
+            const w = +width // convert to number if it's a string
+            if (!isNaN(w) && w > 0) {
                 return Math.min(width, this.columns)
-            } else {
-                return this.columns
             }
+            return this.columns
         },
         addSpacer () {
             this.$store.dispatch('wysiwyg/addSpacer', {


### PR DESCRIPTION
fixes #1473

## Description

Supersedes https://github.com/FlowFuse/node-red-dashboard/pull/1480

- Checks `RED.settings.https` is "something" and if yes:
   - switches the URL scheme to "https://"
   - Adds an HTTPS `Agent` & spreads whatever is in `RED.settings.https` into the Agent (permitting any extras to be included or to override the default `rejectUnauthorized: false` if so desired) 

### NOTE:

I have tested a variation of this code on a users VM (thanks for the support @Paul-Reed)
By variation, I mean an older branch but the relevant parts of this PR were used and verified.

## Related Issue(s)

#1473

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

