### PR TITLE
Button Group Wrap

### DIFF
--- a/ui/src/widgets/ui-button-group/UIButtonGroup.vue
+++ b/ui/src/widgets/ui-button-group/UIButtonGroup.vue
@@ -2,7 +2,7 @@
     <div class="nrdb-ui-button-group-wrapper">
         <!-- eslint-disable-next-line vue/no-v-html -->
         <label v-if="label" class="v-label" v-html="label" />
-        <v-btn-toggle v-model="selection" mandatory divided :rounded="props.rounded ? 'xl' : ''" :color="selectedColor" :disabled="!state.enabled" @update:model-value="onChange(selection)">
+        <v-btn-toggle v-model="selection" class="d-flex flex-wrap" mandatory divided :rounded="props.rounded ? 'xl' : ''" :color="selectedColor" :disabled="!state.enabled" @update:model-value="onChange(selection)">
             <v-btn v-for="option in options" :key="option.value" :value="option.value">
                 <template v-if="option.icon && option.label !== undefined && option.label !== ''" #prepend>
                     <v-icon size="x-large" :icon="`mdi-${option.icon.replace(/^mdi-/, '')}`" />
@@ -154,6 +154,7 @@ export default {
     width: max-content;
     border-width: thin;
     border-color: rgba(var(--v-border-color), var(--v-border-opacity));
+    min-height: fit-content;
 }
 /* default styling for an unselected option */
 .nrdb-ui-button-group-wrapper .v-btn--variant-elevated {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Enable the button group widget to allow content wrapping. In the future we could add some additional code to equalize button widths for a consistent appearance. ...or feel free to give suggestions.

https://github.com/user-attachments/assets/fe501fa6-c46f-4abd-a9c7-a64a511ae820
 ### VS Current Behavior

https://github.com/user-attachments/assets/999eb6b3-e791-4fe4-8113-a84262de7e46

## Related Issue(s)
Closes #1330
<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

