### PR TITLE
New Widget: Audio

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -130,6 +130,7 @@ export default ({ mode }) => {
               text: 'Widgets',
               collapsed: false,
               items: [
+                { text: 'ui-audio', link: '/nodes/widgets/ui-audio' },
                 { text: 'ui-button', link: '/nodes/widgets/ui-button' },
                 { text: 'ui-button-group', link: '/nodes/widgets/ui-button-group' },
                 { text: 'ui-control', link: '/nodes/widgets/ui-control' },

--- a/docs/nodes/widgets.md
+++ b/docs/nodes/widgets.md
@@ -8,6 +8,11 @@ description: Explore the wide range of widgets available in Node-RED Dashboard 2
     import WidgetGrid from '../components/WidgetGrid.vue'
 
     const general = [{
+        name: 'Audio',
+        widget: 'ui-audio',
+        image: '/images/node-examples/ui-audio.png',
+        description: 'Adds a audio player to your dashboard.'
+    }, {
         name: 'Button',
         widget: 'ui-button',
         image: '/images/node-examples/ui-button.png',

--- a/docs/nodes/widgets/ui-audio.md
+++ b/docs/nodes/widgets/ui-audio.md
@@ -1,0 +1,76 @@
+---
+description: "Play dynamically audio files with ui-audio in Node-RED Dashboard 2.0."
+props:
+    Group: Defines which group of the UI Dashboard this widget will render in.
+    Size: Controls the width of the button with respect to the parent group. Maximum value is the width of the group.
+    Source:
+        description: The source is the url where the audio file can be fetched..
+        dynamic: true 
+    Autoplay:
+        description: Specify whether the audio file will start playing automatically.
+        dynamic: true
+    Loop:
+        description: Specify whether the audio should be looping, i.e. start playing automatically again when ended.
+        dynamic: true
+    Muted:
+        description: Specify whether the audio should be muted.
+        dynamic: true
+controls:
+    enabled:
+        example: true | false
+        description: Allow control over whether or not the button is clickable.
+dynamic:
+    Source:
+        payload: msg.ui_update.source
+        structure: ["String"]
+    Autoplay:
+        payload: msg.ui_update.autoplay
+        structure: ["'on' | 'off'"]
+    Loop:
+        payload: msg.ui_update.loop
+        structure: ["'on' | 'off'"]
+    Muted:
+        payload: msg.ui_update.muted
+        structure: ["'on' | 'off'"]
+---
+
+<script setup>
+    import { ref } from 'vue'
+
+    import ExampleButtonHold from '../../examples/ui-button-hold.json'
+
+    import TryDemo from "./../../components/TryDemo.vue"
+    import FlowViewer from '../../components/FlowViewer.vue'
+    
+    const examples = ref({
+      'hold': ExampleButtonHold
+    })
+</script>
+
+
+<TryDemo href="button-example">
+
+# Audio `ui-audio`
+
+</TryDemo>
+
+Adds a clickable button to your dashboard.
+
+## Properties
+
+<PropsTable/>
+
+## Dynamic Properties
+
+<DynamicPropsTable/>
+
+## Controls
+
+<ControlsTable/>
+
+## Example
+
+### Simple Button
+
+![Example of a Button](/images/node-examples/ui-button.png "Example of a Button"){data-zoomable}
+*Example of a rendered button in a Dashboard.*

--- a/nodes/widgets/locales/en-US/ui_audio.html
+++ b/nodes/widgets/locales/en-US/ui_audio.html
@@ -1,0 +1,31 @@
+<script type="text/html" data-help-name="ui-audio">
+    <p>
+        Plays an audio file in the dashboard.
+    </p>
+    <p>
+        Each received <code>msg.payload</code> will contain a new source, i.e. a new audio file url.
+    </p>
+    <h3>Properties</h3>
+    <dl class="message-properties">
+        <dt>Source <span class="property-type">string</span></dt>
+        <dd>The source is the url where the audio file can be fetched.</dd>
+        <dt>Autoplay <span class="property-type">list</span></dt>
+        <dd>Specify whether the audio file will start playing automatically.</dd>
+        <dt>Loop <span class="property-type">list</span></dt>
+        <dd>Specify whether the audio should be looping, i.e. start playing automatically again when ended.</dd>
+        <dt>Muted <span class="property-type">list</span></dt>
+        <dd>Specify whether the audio should be muted.</dd>
+    </dl>
+    <h3>Dynamic Properties (Inputs)</h3>
+    <p>Any of the following can be appended to a <code>msg.ui_update</code> in order to override or set properties on this node at runtime.</p>
+    <dl class="message-properties">
+        <dt class="optional">src<span class="property-type">string</span></dt>
+        <dd>Override the configured audio source.</dd>
+        <dt class="optional">autoplay<span class="property-type">'on' | 'off'</span></dt>
+        <dd>Override the configured autoplay setting .</dd>
+        <dt class="optional">loop<span class="property-type">'on' | 'off'</span></dt>
+        <dd>Override the configured looping behaviour.</dd>
+        <dt class="optional">muted<span class="property-type">'on' | 'off'</span></dt>
+        <dd>Override the configured muted setting.</dd>
+    </dl>
+</script>

--- a/nodes/widgets/locales/en-US/ui_audio.json
+++ b/nodes/widgets/locales/en-US/ui_audio.json
@@ -1,0 +1,17 @@
+{
+    "ui-audio": {
+        "label": {
+            "group": "Group",
+            "size": "Size",
+            "icon": "Icon",
+            "source": "Source",
+            "autoplay": "Autoplay",
+            "loop": "Loop",
+            "muted": "Muted"
+        },
+        "option": {
+            "on": "On",
+            "off": "Off"
+       }
+    }
+}

--- a/nodes/widgets/ui_audio.html
+++ b/nodes/widgets/ui_audio.html
@@ -1,0 +1,113 @@
+<script type="text/javascript">
+    (function () {
+        RED.nodes.registerType('ui-audio', {
+            category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+            color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
+            defaults: {
+                group: { type: 'ui-group', required: true },
+                name: { value: '' },
+                order: { value: 0 },
+                width: {
+                    value: 0,
+                    validate: function (v) {
+                        const width = v || 0
+                        const currentGroup = $('#node-input-group').val() || this.group
+                        const groupNode = RED.nodes.node(currentGroup)
+                        const valid = !groupNode || +width >= 0
+                        $('#node-input-size').toggleClass('input-error', !valid)
+                        return valid
+                    }
+                },
+                height: { value: 0 },
+                src: { value: ''},
+                autoplay: { value: 'off' },
+                loop: { value: 'off' },
+                muted: { value: 'off' }
+            },
+            inputs: 1,
+            outputs: 1,
+            align: 'right',
+            icon: 'font-awesome/fa-volume-up',
+            paletteLabel: 'audio',
+            label: function () { return this.name },
+            labelStyle: function () { return this.name ? 'node_label_italic' : '' },
+            oneditprepare: function () {
+                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+                if (RED.nodes.subflow(this.z)) {
+                    // change inputs from hidden to text & display them
+                    $('#node-input-width').attr('type', 'text')
+                    $('#node-input-height').attr('type', 'text')
+                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                } else {
+                    // not in a subflow, use the elementSizer
+                    $('div.form-row.nr-db-ui-element-sizer-row').show()
+                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('#node-input-size').elementSizer({
+                        width: '#node-input-width',
+                        height: '#node-input-height',
+                        group: '#node-input-group'
+                    })
+                }
+
+                // use jQuery UI tooltip to convert the plain old title attribute to a nice tooltip
+                $('.ui-node-popover-title').tooltip({
+                    show: {
+                        effect: 'slideDown',
+                        delay: 150
+                    }
+                })
+            }
+        })
+    })()
+</script>
+
+<script type="text/html" data-template-name="ui-audio">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-audio.label.group"></label>
+        <input type="text" id="node-input-group">
+    </div>
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-audio.label.size"></label>
+        <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-audio.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-audio.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row">
+        <label for="node-input-src"><i class="fa fa-globe"></i> <span data-i18n="ui-audio.label.source"></label>
+        <input type="text" id="node-input-src">
+    </div>
+    <div class="form-row">
+        <label for="node-input-autoplay"><i class="fa fa-play-circle"></i> <span data-i18n="ui-audio.label.autoplay"></label>
+        <select id="node-input-autoplay" style="width:70%;">
+            <option value="on" data-i18n="ui-audio.option.on"></option>
+            <option value="off" data-i18n="ui-audio.option.off"></option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-loop"><i class="fa fa-retweet"></i> <span data-i18n="ui-audio.label.loop"></label>
+        <select id="node-input-loop" style="width:70%;">
+            <option value="on" data-i18n="ui-audio.option.on"></option>
+            <option value="off" data-i18n="ui-audio.option.off"></option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-muted"><i class="fa fa-volume-up"></i> <span data-i18n="ui-audio.label.muted"></label>
+        <select id="node-input-muted" style="width:70%;">
+            <option value="on" data-i18n="ui-audio.option.on"></option>
+            <option value="off" data-i18n="ui-audio.option.off"></option>
+        </select>
+    </div>
+    <div class="form-tips"><b>Note</b>: Autoplay will only work after a user gesture (e.g. click on the dashboard).</span></div>
+</script>

--- a/nodes/widgets/ui_audio.js
+++ b/nodes/widgets/ui_audio.js
@@ -1,0 +1,61 @@
+const statestore = require('../store/state.js')
+
+module.exports = function (RED) {
+    function AudioNode (config) {
+        const node = this
+
+        RED.nodes.createNode(this, config)
+
+        // which group are we rendering this widget
+        const group = RED.nodes.getNode(config.group)
+
+        const evts = {
+            onAction: true,
+            beforeSend: function (msg) {
+                if (msg.ui_update) {
+                    const updates = msg.ui_update
+
+                    if (updates) {
+                        if (typeof updates.src !== 'undefined') {
+                            // dynamically set "src" property
+                            statestore.set(group.getBase(), node, msg, 'src', updates.src)
+                        }
+                        if (typeof updates.autoplay !== 'undefined') {
+                            if (['on', 'off'].includes(updates.autoplay)) {
+                                // dynamically set "autoplay" property
+                                statestore.set(group.getBase(), node, msg, 'autoplay', updates.autoplay)
+                            } else {
+                                node.error('Property msg.ui_update.autoplay should be "on" or "off"')
+                            }
+                        }
+                        if (typeof updates.loop !== 'undefined') {
+                            if (['on', 'off'].includes(updates.loop)) {
+                                // dynamically set "loop" property
+                                statestore.set(group.getBase(), node, msg, 'loop', updates.loop)
+                            } else {
+                                node.error('Property msg.ui_update.loop should be "on" or "off"')
+                            }
+                        }
+                        if (typeof updates.muted !== 'undefined') {
+                            if (['on', 'off'].includes(updates.muted)) {
+                                // dynamically set "muted" property
+                                statestore.set(group.getBase(), node, msg, 'muted', updates.muted)
+                            } else {
+                                node.error('Property msg.ui_update.muted should be "on" or "off"')
+                            }
+                        }
+                    }
+                }
+                return msg
+            }
+        }
+
+        // inform the dashboard UI that we are adding this node
+        if (group) {
+            group.register(node, config, evts)
+        } else {
+            node.error('No group configured')
+        }
+    }
+    RED.nodes.registerType('ui-audio', AudioNode)
+}

--- a/nodes/widgets/ui_audio.js
+++ b/nodes/widgets/ui_audio.js
@@ -1,3 +1,4 @@
+const datastore = require('../store/data.js')
 const statestore = require('../store/state.js')
 
 module.exports = function (RED) {
@@ -11,7 +12,26 @@ module.exports = function (RED) {
 
         const evts = {
             onAction: true,
+            onInput: function (msg, send) {
+                // store the latest msg passed to node, only if a source is supplied in the payload
+                if (typeof msg.payload === 'string') {
+                    datastore.save(group.getBase(), node, msg)
+                }
+                // only send msg on if we have passthru enabled
+                if (config.passthru) {
+                    send(msg)
+                }
+            },
             beforeSend: function (msg) {
+                if (msg.playback === 'play') {
+                    const lastMsg = datastore.get(node.id)
+                    // TODO zou eigenlijk de last message met een payload moeten zijn.
+                    const src = lastMsg?.payload || config.src
+                    if (typeof src !== 'string' || src.trim() === '') {
+                        node.warn('Cannot play audio when no source has been specified')
+                    }
+                }
+
                 if (msg.ui_update) {
                     const updates = msg.ui_update
 

--- a/package.json
+++ b/package.json
@@ -143,11 +143,11 @@
             "ui-chart": "nodes/widgets/ui_chart.js",
             "ui-gauge": "nodes/widgets/ui_gauge.js",
             "ui-notification": "nodes/widgets/ui_notification.js",
+            "ui-audio": "nodes/widgets/ui_audio.js",
             "ui-markdown": "nodes/widgets/ui_markdown.js",
             "ui-template": "nodes/widgets/ui_template.js",
             "ui-event": "nodes/widgets/ui_event.js",
-            "ui-control": "nodes/widgets/ui_control.js",
-            "ui-audio": "nodes/widgets/ui_audio.js"
+            "ui-control": "nodes/widgets/ui_control.js"
         }
     },
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
             "ui-markdown": "nodes/widgets/ui_markdown.js",
             "ui-template": "nodes/widgets/ui_template.js",
             "ui-event": "nodes/widgets/ui_event.js",
-            "ui-control": "nodes/widgets/ui_control.js"
+            "ui-control": "nodes/widgets/ui_control.js",
+            "ui-audio": "nodes/widgets/ui_audio.js"
         }
     },
     "overrides": {

--- a/ui/src/widgets/index.mjs
+++ b/ui/src/widgets/index.mjs
@@ -1,3 +1,4 @@
+import UIAudio from './ui-audio/UIAudio.vue'
 import UIButton from './ui-button/UIButton.vue'
 import UIButtonGroup from './ui-button-group/UIButtonGroup.vue'
 import UIChart from './ui-chart/UIChart.vue'
@@ -21,6 +22,7 @@ import UITextInput from './ui-text-input/UITextInput.vue'
 
 // Named exports for use in other components
 export {
+    UIAudio,
     UIButton,
     UIButtonGroup,
     UIChart,
@@ -48,6 +50,7 @@ export { useDataTracker } from './data-tracker.mjs'
 
 // Exported as an object for look up by widget name
 export default {
+    'ui-audio': UIAudio,
     'ui-button': UIButton,
     'ui-button-group': UIButtonGroup,
     'ui-chart': UIChart,

--- a/ui/src/widgets/ui-audio/UIAudio.vue
+++ b/ui/src/widgets/ui-audio/UIAudio.vue
@@ -2,8 +2,6 @@
     <!-- if you remove the `controls` attribute, you MUST click something on the page before initiating play -->
     <audio
         ref="audio"
-        width="100%"
-        height="100%"
         controls
         :autoplay="autoplay"
         :loop="loop"
@@ -120,6 +118,10 @@ export default {
 </script>
 
 <style>
+.nrdb-ui-audio audio {
+    width: 100%;
+    height: 100%;
+}
 .hidden {
     display: none !important;
 }

--- a/ui/src/widgets/ui-audio/UIAudio.vue
+++ b/ui/src/widgets/ui-audio/UIAudio.vue
@@ -1,0 +1,122 @@
+<template>
+    <!-- if you remove the `controls` attribute, you MUST click something on the page before initiating play -->
+    <audio
+        ref="audio"
+        width="100%"
+        height="100%"
+        controls
+        :autoplay="autoplay"
+        :loop="loop"
+        :muted="muted"
+        :src="value"
+        @play="handlePlayerEvents"
+        @pause="handlePlayerEvents"
+        @ended="handlePlayerEvents"
+    />
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+    name: 'DBUIAudio',
+    inject: ['$socket', '$dataTracker'],
+    props: {
+        id: { type: String, required: true },
+        props: { type: Object, default: () => ({}) },
+        state: { type: Object, default: () => ({}) }
+    },
+    emits: ['mounted'],
+    data () {
+        return {
+            show: false,
+            tik: 0,
+            countdown: 0,
+            timeouts: {
+                close: null,
+                step: null
+            }
+        }
+    },
+    computed: {
+        ...mapState('data', ['messages']),
+        value: function () {
+            // Get the value (i.e. the notification text content) from the last input msg
+            const value = this.messages[this.id]?.payload
+            return value
+        },
+        loop () {
+            if (this.getProperty('loop') === 'on') {
+                return true
+            } else {
+                return false
+            }
+        },
+        muted () {
+            if (this.getProperty('muted') === 'on') {
+                return true
+            } else {
+                return false
+            }
+        },
+        autoplay () {
+            if (this.getProperty('autoplay') === 'on') {
+                return true
+            } else {
+                return false
+            }
+        }
+    },
+    created () {
+        // can't do this in setup as we have custom onInput function
+        this.$dataTracker(this.id, this.onMsgInput, null, this.onDynamicProperties)
+    },
+    mounted () {
+        this.$emit('mounted', this)
+    },
+    methods: {
+        onDynamicProperties (msg) {
+            const updates = msg.ui_update
+            if (!updates) {
+                return
+            }
+            this.updateDynamicProperty('src', updates.src)
+            this.updateDynamicProperty('autoplay', updates.autoplay)
+            this.updateDynamicProperty('loop', updates.loop)
+            this.updateDynamicProperty('muted', updates.muted)
+        },
+        onMsgInput (msg) {
+            // Make sure the last msg (that has a payload, containing the notification content) is being stored
+            if (msg.payload) {
+                this.$store.commit('data/bind', {
+                    widgetId: this.id,
+                    msg
+                })
+            }
+
+            switch (msg.playback) {
+            case 'play':
+                this.$refs.audio.play()
+                break
+            case 'stop':
+                this.$refs.audio.src = ''
+                break
+            case 'pause':
+                this.$refs.audio.pause()
+                break
+            }
+        },
+        handlePlayerEvents (event) {
+            const msg = this.messages[this.id] || {}
+            msg._event = event.type
+            this.$socket.emit('widget-action', this.id, msg)
+        }
+    }
+}
+</script>
+
+<style>
+.hidden {
+    display: none !important;
+}
+</style>

--- a/ui/src/widgets/ui-audio/UIAudio.vue
+++ b/ui/src/widgets/ui-audio/UIAudio.vue
@@ -42,7 +42,7 @@ export default {
         ...mapState('data', ['messages']),
         value: function () {
             // Get the value (i.e. the notification text content) from the last input msg
-            const value = this.messages[this.id]?.payload
+            const value = this.messages[this.id]?.payload || this.props.src
             return value
         },
         loop () {

--- a/ui/src/widgets/ui-audio/UIAudio.vue
+++ b/ui/src/widgets/ui-audio/UIAudio.vue
@@ -96,13 +96,17 @@ export default {
 
             switch (msg.playback) {
             case 'play':
-                this.$refs.audio.play()
+                this.$refs.audio.play().catch((err) => {
+                    console.error('Error playing audio:', err)
+                })
                 break
             case 'stop':
                 this.$refs.audio.src = ''
                 break
             case 'pause':
-                this.$refs.audio.pause()
+                this.$refs.audio.pause().catch((err) => {
+                    console.error('Error pausing audio:', err)
+                })
                 break
             }
         },


### PR DESCRIPTION
## Description

This PR adds a new ui-audio widget to the palette, which can be used to play dynamically audio files in the dashboard D2.  Similar like the audio-out node of dashboard 1.

I marked this PR as draft, because it is not fully completed.  I need some feedback to complete it.  Until then I ***won't*** be working on this PR, so would be nice if somebody could assist me so I can finalize this PR.  Thanks!

This is how it looks in my Chrome browser:

![image](https://github.com/user-attachments/assets/acde1fe3-e9c8-4d2c-b677-386d60c1dd4e)

Example flow to demonstrate that all the properties can be dynamically overwritten via inpute messages:
```
[{"id":"3c290f1ea6cf8b36","type":"inject","z":"4aad778b57d4f47b","name":"Pause","props":[{"p":"playback","v":"pause","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1890,"y":3540,"wires":[["b6d975ba7cfabfcd"]]},{"id":"436efb1217534529","type":"inject","z":"4aad778b57d4f47b","name":"Stop","props":[{"p":"playback","v":"stop","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1890,"y":3500,"wires":[["b6d975ba7cfabfcd"]]},{"id":"bfc886482dbdb38c","type":"debug","z":"4aad778b57d4f47b","name":"Audio output","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":2250,"y":3140,"wires":[]},{"id":"b6d975ba7cfabfcd","type":"ui-audio","z":"4aad778b57d4f47b","group":"1e2acdd1dfa22bf9","name":"","order":0,"width":"6","height":"1","src":"","autoplay":"off","controls":"show","loop":"off","muted":"off","x":2080,"y":3140,"wires":[["bfc886482dbdb38c"]]},{"id":"f878114e50dace0a","type":"inject","z":"4aad778b57d4f47b","name":"Enable","props":[{"p":"enabled","v":"true","vt":"bool"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1890,"y":2920,"wires":[["b6d975ba7cfabfcd"]]},{"id":"e5b91f1f4fb4fd55","type":"inject","z":"4aad778b57d4f47b","name":"Muted off","props":[{"p":"ui_update.muted","v":"off","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1880,"y":3180,"wires":[["b6d975ba7cfabfcd"]]},{"id":"59303ca2418166c2","type":"inject","z":"4aad778b57d4f47b","name":"Muted on","props":[{"p":"ui_update.muted","v":"on","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1880,"y":3140,"wires":[["b6d975ba7cfabfcd"]]},{"id":"03afd1a13fc70794","type":"inject","z":"4aad778b57d4f47b","name":"Loop off","props":[{"p":"ui_update.loop","v":"off","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1890,"y":3260,"wires":[["b6d975ba7cfabfcd"]]},{"id":"c340c61db669fc1f","type":"inject","z":"4aad778b57d4f47b","name":"Loop on","props":[{"p":"ui_update.loop","v":"on","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1880,"y":3220,"wires":[["b6d975ba7cfabfcd"]]},{"id":"900f167dee26d78b","type":"inject","z":"4aad778b57d4f47b","name":"Autoplay on","props":[{"p":"ui_update.autoplay","v":"on","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1870,"y":3300,"wires":[["b6d975ba7cfabfcd"]]},{"id":"f4c14f571d72b9e6","type":"inject","z":"4aad778b57d4f47b","name":"Autoplay off","props":[{"p":"ui_update.autoplay","v":"off","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1870,"y":3340,"wires":[["b6d975ba7cfabfcd"]]},{"id":"a516fd15f0df3401","type":"inject","z":"4aad778b57d4f47b","name":"Src Friends","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"http://www.sitcomsonline.com/sounds/friends1996.wav","payloadType":"str","x":1870,"y":3380,"wires":[["b6d975ba7cfabfcd"]]},{"id":"b89a1933c291bc6b","type":"inject","z":"4aad778b57d4f47b","name":"Src StarWars","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"https://www2.cs.uic.edu/~i101/SoundFiles/ImperialMarch60.wav","payloadType":"str","x":1870,"y":3420,"wires":[["b6d975ba7cfabfcd"]]},{"id":"4fbc55f25609fb08","type":"inject","z":"4aad778b57d4f47b","name":"Play","props":[{"p":"playback","v":"play","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1890,"y":3460,"wires":[["b6d975ba7cfabfcd"]]},{"id":"b737027f04ea228f","type":"inject","z":"4aad778b57d4f47b","name":"Disable","props":[{"p":"enabled","v":"false","vt":"bool"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1890,"y":2960,"wires":[["b6d975ba7cfabfcd"]]},{"id":"80bc186add2ddefc","type":"inject","z":"4aad778b57d4f47b","name":"Visible","props":[{"p":"visible","v":"true","vt":"bool"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1890,"y":3000,"wires":[["b6d975ba7cfabfcd"]]},{"id":"73a1c76f72ec86f2","type":"inject","z":"4aad778b57d4f47b","name":"Invisible","props":[{"p":"visible","v":"false","vt":"bool"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":1880,"y":3040,"wires":[["b6d975ba7cfabfcd"]]},{"id":"1e2acdd1dfa22bf9","type":"ui-group","name":"Experiments","page":"e06eacf47a88bb87","width":"6","height":"1","order":1,"showTitle":true,"className":"","visible":"true","disabled":"false"},{"id":"e06eacf47a88bb87","type":"ui-page","name":"Alarm","ui":"be29745a6e568f30","path":"/alarm","icon":"lock","layout":"grid","theme":"092547d34959327c","breakpoints":[{"name":"Default","px":0,"cols":3},{"name":"Tablet","px":576,"cols":6},{"name":"Small Desktop","px":768,"cols":9},{"name":"Desktop","px":1024,"cols":12}],"order":7,"className":"","visible":true,"disabled":false},{"id":"be29745a6e568f30","type":"ui-base","name":"Node-RED","path":"/dashboard","appIcon":"","includeClientData":true,"acceptsClientConfig":["ui-notification","ui-control","ui-chart","ui-text-input","ui-dropdown"],"showPathInSidebar":false,"showPageTitle":true,"navigationStyle":"icon","titleBarStyle":"default"},{"id":"092547d34959327c","type":"ui-theme","name":"Theme Name","colors":{"surface":"#ffffff","primary":"#0094ce","bgPage":"#eeeeee","groupBg":"#ffffff","groupOutline":"#cccccc"}}]
```
![image](https://github.com/user-attachments/assets/edd9809a-6067-4ae0-b83f-3af70ccc7b73)

Open issues:
1. When e.g. a "play" command is send to this node, it could fail.  For example when there is no src url set, or when the user hasn't executed any manual actions yet on the page (because browsers don't like sites to start playing audio automatically).  Which is normal, but you only see a message in the browser console.  Which might be confusing for users to understand why it doesn't play.  Should I send those errors as output messages?  If yes, which format should those messages have?
2. Currently the audio element is displayed on a specified group.  As a result the audio will stop playing if you navigate to another tab in the dashboard.  Not sure if that is wanted behaviour, or how I could fix that (if not wanted).
3. A html audio element has a [controls](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio) property which you can use to show or hide the controls (i.e. play button, and so on...).  I first had supported that, but if you don't show the controls you simply get an empty area which is quite useless.  So I thought it would better if you could enable or hide the ui-audio widget via the dashboard build-in features `msg.visible` and `msg.enabled`.  But those don't work (see example flow above).  No idea whether I need to do something special for that.
4. I have not added a unit test.  Although I know that is important, I have to be honest that my limited free time doesn't allow me to start reading about how to do that.  So would be nice if anybody else could add that.
5. The documentation md file is near complete but there should be also a nice image of element and a demo flow.  Again I would appreciate if somebody else could add those.

## Related Issue(s)

Closes #52

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [X] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

