### PR TITLE
Sidebar strikethrough reset fix

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1211,6 +1211,7 @@
         const titleRow = parent.closest('.nrdb2-sb-list-header')
         const btnGroup = $('<div>', { class: 'nrdb2-sb-list-header-state-options', id: item.id }).appendTo(parent)
         if (nodes.includes(item.type)) {
+            debugger
             const visibleIcon = (item.visible === 'false' || item.visible === false) ? 'fa-eye-slash' : 'fa-eye'
             const visibleBtn = $('<a href="#" title="Hide" class="nr-db-sb-tab-visible-button editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa ' + visibleIcon + '"></i></a>').appendTo(btnGroup)
             visibleBtn.on('click', function (evt) {
@@ -1297,7 +1298,7 @@
     }
 
     function setStateClasses (item, row) {
-        if (!item.node.visible === 'true' || item.node.visible === false) {
+        if (item.node.visible === 'false' || item.node.visible === false) {
             row.addClass('nrdb2-sb-item-hidden')
         }
         if (item.node.disabled === 'true' || item.node.disabled === true) {

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1211,7 +1211,6 @@
         const titleRow = parent.closest('.nrdb2-sb-list-header')
         const btnGroup = $('<div>', { class: 'nrdb2-sb-list-header-state-options', id: item.id }).appendTo(parent)
         if (nodes.includes(item.type)) {
-            debugger
             const visibleIcon = (item.visible === 'false' || item.visible === false) ? 'fa-eye-slash' : 'fa-eye'
             const visibleBtn = $('<a href="#" title="Hide" class="nr-db-sb-tab-visible-button editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa ' + visibleIcon + '"></i></a>').appendTo(btnGroup)
             visibleBtn.on('click', function (evt) {


### PR DESCRIPTION
## Description

Steps to reproduce:
1. Hide a group in the sidebar (via the eye button), then the text will automatically become strikethrough:

   ![image](https://github.com/user-attachments/assets/285d8e27-453c-46ad-ac48-758a1c0bfea1)

2. Edit that group (via the edit button), and press the *"Done"* button of the ui-page config screen.

3. The sidebar tree will automatically refresh, but the value of the `visible` attribute has become a string `"false"` (instead of a boolean `false`):

   ![image](https://github.com/user-attachments/assets/3b254deb-10ba-4fac-a726-0a1e08c51efc)

4. Because the CSS class *"nr-db2-sb-item-hidden"* is _**not**_ applied anymore, the strikethrough will be gone (although the group is still not visible).

I have fixed this by supporting string "false" similiar to how it is done for the eye-icon, because that icon is showing the correct status.  And we need to keep the eye-icon status and the strikethrough of the label ***in sync***:

![image](https://github.com/user-attachments/assets/3ef46ebf-e45f-4f90-9aa5-6620ec991a93)

Note that the real root cause is in the ui-page hml config screen, which converts the `visible` property value from a boolean to a string, but that is already reported in another issue (and I will fix that in another PR).

## Related Issue(s)

[1296](https://github.com/FlowFuse/node-red-dashboard/issues/1296)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

