### PR TITLE
Switch - click custom switch icon fix

### DIFF
--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -26,7 +26,7 @@
             readonly
             @click.stop="switchClickable ? toggle() : null"
         />
-        <v-btn v-else-if="!loading" variant="text" :disabled="!state.enabled" :icon="icon" :color="color" @click="toggle" />
+        <v-btn v-else-if="!loading" variant="text" :disabled="!state.enabled" :icon="icon" :color="color" @click.stop="toggle" />
         <v-progress-circular v-else indeterminate color="primary" />
     </div>
 </template>


### PR DESCRIPTION
## Description

Seems a ***breaking change*** has been introduced by my recent pull request [https://github.com/FlowFuse/node-red-dashboard/pull/1511] to allow clickable area "None" for ui-switches.

The user says that the icon is not clickable anymore, but in fact what happens is that the click event is propagated up into the dom tree.  Since the parent div element has - since PR 1511 - also a click handler, the toggle will be called a second time:

![image](https://github.com/user-attachments/assets/1c3949bc-432e-46e8-ac84-8bf30ab479dd)

Since the `toggle` function is called twice, it looks like the custom icon is not clickable anymore.

## Related Issue(s)

[1522](https://github.com/FlowFuse/node-red-dashboard/issues/1522)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

