### PR TITLE
Switch custom icon not clickable

### DIFF
--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -21,6 +21,7 @@
             v-if="!icon" v-model="status"
             :disabled="!state.enabled"
             :class="{'active': status, 'nrdb-ui-switch-default-cursor': !switchClickable}"
+            :style="{'pointer-events': switchClickable ? 'inherit' : 'none'}"
             hide-details="auto" color="primary"
             :loading="loading ? (status === true ? 'secondary' : 'primary') : null"
             readonly
@@ -30,7 +31,7 @@
             v-else-if="!loading"
             variant="text"
             :disabled="!state.enabled"
-            :style="{cursor: switchClickable ? 'pointer' : 'default'}"
+            :style="{'pointer-events': switchClickable ? 'inherit' : 'none', cursor: switchClickable ? 'pointer' : 'default'}"
             :icon="icon"
             :color="color"
             @click.stop="switchClickable ? toggle() : null"

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -26,7 +26,15 @@
             readonly
             @click.stop="switchClickable ? toggle() : null"
         />
-        <v-btn v-else-if="!loading" variant="text" :disabled="!state.enabled" :icon="icon" :color="color" @click="toggle" />
+        <v-btn
+            v-else-if="!loading"
+            variant="text"
+            :disabled="!state.enabled"
+            :style="{cursor: switchClickable ? 'pointer' : 'default'}"
+            :icon="icon"
+            :color="color"
+            @click.stop="switchClickable ? toggle() : null"
+        />
         <v-progress-circular v-else indeterminate color="primary" />
     </div>
 </template>


### PR DESCRIPTION
## Description

While implementing pull request [1511](https://github.com/FlowFuse/node-red-dashboard/pull/1511) (i.e. clickable area "None" for ui-switch), seems I overlooked the custom icons had a special part in the vue template.

When clickable area is "None", the custom icon switch should also be non-clickable.
You can use the example flow from another issue (see [1522](https://github.com/FlowFuse/node-red-dashboard/issues/1522)) to test this: just change the clickable area to "None".

## Related Issue(s)

[1521](https://github.com/FlowFuse/node-red-dashboard/issues/1521)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

