### PR TITLE
Notification: sanetized style fix

### DIFF
--- a/ui/src/widgets/ui-notification/UINotification.vue
+++ b/ui/src/widgets/ui-notification/UINotification.vue
@@ -64,7 +64,7 @@ export default {
             const value = this.messages[this.id]?.payload
 
             // Sanetize the html to avoid XSS attacks.
-            // Allow 'script' tags to allow styling of the notification content.
+            // Allow 'style' tags to allow styling of the notification content.
             // The FORCE_BODY is required to avoid 'style' tags (at the start of the value string) still being skipped.
             const sanetizedValue = DOMPurify.sanitize(value, { ADD_TAGS: ['style'], FORCE_BODY: true })
             return sanetizedValue

--- a/ui/src/widgets/ui-notification/UINotification.vue
+++ b/ui/src/widgets/ui-notification/UINotification.vue
@@ -62,8 +62,12 @@ export default {
         value: function () {
             // Get the value (i.e. the notification text content) from the last input msg
             const value = this.messages[this.id]?.payload
-            // Sanetize the html to avoid XSS attacks
-            return DOMPurify.sanitize(value)
+
+            // Sanetize the html to avoid XSS attacks.
+            // Allow 'script' tags to allow styling of the notification content.
+            // The FORCE_BODY is required to avoid 'style' tags (at the start of the value string) still being skipped.
+            const sanetizedValue = DOMPurify.sanitize(value, { ADD_TAGS: ['style'], FORCE_BODY: true })
+            return sanetizedValue
         },
         allowConfirm () {
             return this.getProperty('allowConfirm')


### PR DESCRIPTION
## Description

See bug report and example flow in [this](https://discourse.nodered.org/t/issue-with-html-notifications-on-dashboard-after-upgrade/93813) Discourse question.

The solution is simply to tell DOMpurify that `script` tags are allowed.  Then it looks better to me:

![image](https://github.com/user-attachments/assets/e3168283-d1a8-40e3-9b26-ff690a7a3a11)

Of course this opens again some backdoors for possible CSS injection.  Unfortunately I cannot do much about that...

## Related Issue(s)

None

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

