### PR TITLE
Add client data to nodes with multiple outputs

### DIFF
--- a/nodes/utils/index.js
+++ b/nodes/utils/index.js
@@ -38,23 +38,40 @@ async function appendTopic (RED, config, wNode, msg) {
  */
 function addConnectionCredentials (RED, msg, conn, config) {
     if (config.includeClientData) {
-        if (!msg._client) {
-            msg._client = {}
-        }
-        RED.plugins.getByType('node-red-dashboard-2').forEach(plugin => {
-            if (plugin.hooks?.onAddConnectionCredentials && msg) {
-                msg = plugin.hooks.onAddConnectionCredentials(conn, msg)
+        
+        // Add _client to each element
+        const addClientData = (item) => {
+            if (!item._client) {
+                item._client = {}
             }
-        })
-        msg._client = {
-            ...msg._client,
-            ...{
-                socketId: conn.id,
-                socketIp: conn.handshake?.address
+            RED.plugins.getByType('node-red-dashboard-2').forEach(plugin => {
+                if (plugin.hooks?.onAddConnectionCredentials && item) {
+                    item = plugin.hooks.onAddConnectionCredentials(conn, item);
+                }
+            });
+            item._client = {
+                ...item._client,
+                ...{
+                    socketId: conn.id,
+                    socketIp: conn.handshake?.address
+                }
+            };
+            return item;
+        };
+
+        // Handle arrays and nested arrays
+        const processMsg = (data) => {
+            if (Array.isArray(data)) {
+                return data.map(item => processMsg(item));
+            } else if (typeof data === 'object' && data !== null) {
+                return addClientData(data)
             }
-        }
+            return data;
+        };
+
+        msg = processMsg(msg)
     }
-    return msg
+    return msg;
 }
 
 function getThirdPartyWidgets (directory) {


### PR DESCRIPTION
## Description

When a UI-Node has multiple outputs, Node-RED sends an array of messages, with each message corresponding by index to the respective output of the node that should be triggered. The current Dashboard implementation for appending client data assumes that the message is not an array. As a result, the client data is added in the wrong place, causing issues.

## Related Issue(s)

#1532

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

