### PR TITLE
fix handbook link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -37,7 +37,7 @@ body:
   id: estimation
   attributes:
     label: Have you provided an initial effort estimate for this issue?
-    description: See our [handbook](https://flowfuse.com/handbook/development/releases/planning/#effort-estimation) for more details.
+    description: See our [handbook](https://flowfuse.com/handbook/development/project-management/#sizing-issues) for more details.
     multiple: false
     options:
       - I have provided an initial effort estimate


### PR DESCRIPTION
## Description

Fixes the handbook link in the "new issue" template
