### PR TITLE
Allow RED.settings.ui as fallback settings for size

### DIFF
--- a/nodes/widgets/ui_file_input.js
+++ b/nodes/widgets/ui_file_input.js
@@ -19,7 +19,7 @@ module.exports = function (RED) {
 
         // get max file size supported
         const MAX_FILESIZE_DEFAULT = 1e6
-        const maxFileSize = RED.settings.dashboard?.maxHttpBufferSize || MAX_FILESIZE_DEFAULT
+        const maxFileSize = RED.settings.dashboard?.maxHttpBufferSize || RED.settings.ui?.maxHttpBufferSize || MAX_FILESIZE_DEFAULT
 
         config.maxFileSize = maxFileSize
 


### PR DESCRIPTION
This is part of FlowFuse/flowfuse#4933

## Description

<!-- Describe your changes in detail -->
Allows loading `maxHttpBufferSize` from `RED.settings.ui` as well `RED.settings.dashboad`

FF uses `RED.settings.ui` as the default.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

