### PR TITLE
Group tabs - select first tab after navigation

### DIFF
--- a/ui/src/layouts/Tabs.vue
+++ b/ui/src/layouts/Tabs.vue
@@ -70,6 +70,14 @@ export default {
         WidgetGroup
     },
     mixins: [Responsiveness],
+    beforeRouteEnter (to, from, next) {
+        next(vm => {
+            // Select the first tabsheet every time the user arrives on this page
+            if (vm.orderedGroups && vm.orderedGroups.length > 0) {
+                vm.tab = 0
+            }
+        })
+    },
     data () {
         return {
             tab: 0


### PR DESCRIPTION
## Description

When use group tabs, the first tab is correctly loaded at the start.  However when you select another tab, navigate to another page and back to the original page, then no tab is selected anymore.  And as a result the page only shows the tabs but the tab content area is empty.

This PR makes sure the first tabsheet is always selected, every time you navigate to the page with the tabs:

![select-first-tab](https://github.com/user-attachments/assets/d77798fb-66ef-4a25-985a-e777ec51f124)

## Related Issue(s)

[1534](https://github.com/FlowFuse/node-red-dashboard/issues/1534)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

