### PR TITLE
ui-control colon in group name

### DIFF
--- a/docs/nodes/widgets/ui-control.md
+++ b/docs/nodes/widgets/ui-control.md
@@ -123,6 +123,7 @@ msg.payload = {
 ```
 
 _Note:_ `pages` can be subbed with `tabs` as per Dashboard 1.0 and `groups` can also be subbed with `group` as per Dashboard 1.0.
+_Note:_ when the `group` name contains a colon `:`, then that should be escaped using a backslash `\`.
 
 ### Enable/Disable
 

--- a/nodes/widgets/locales/en-US/ui_control.html
+++ b/nodes/widgets/locales/en-US/ui_control.html
@@ -33,7 +33,7 @@
     }
 }</pre>
     <h4>Enable/Disable Pages & Groups</h4>
-    <p>Dashboard pages & groups can be disabled & re-enabled by sending a <code>msg.payload</code> object with the format
+    <p>Dashboard pages & groups can be disabled & re-enabled by sending a <code>msg.payload</code> object with the format</p>
     <pre>msg.payload = {
     pages: {
         enable: ['&lt;Page Name&gt;', '&lt;Page Name&gt;'],
@@ -44,6 +44,7 @@
         disable: ['&lt;Group Name&gt;']
     }
 }</pre>
+    <p>When the group name contains a colon <code>:</code>, that needs to be escaped using a backslash <code>\</code>. </p>
     <h4>External URL</h4>
     <p>It is possible to trigger navigation to an external site, away from your Dashboard by passing in a URL string.</p>
     <pre>msg.payload = {

--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -26,6 +26,12 @@ module.exports = function (RED) {
             ui.emit('ui-control:' + node.id, msg, node)
         }
 
+        function splitUnEscapedColon (str) {
+            // Split only on colons (:) that ar not escaped, i.e. not  preceded by a backslash (\\).
+            // And for each part replace the escaped colons again by normal colons.
+            return str.split(/(?<!\\):/).map(part => part.replace(/\\:/g, ':'))
+        }
+
         const evts = {
             onInput: function (msg, send, done) {
                 const wNode = RED.nodes.getNode(node.id)
@@ -111,28 +117,28 @@ module.exports = function (RED) {
                     })
                     if ('show' in groups) {
                         const gs = groups.show.map((g) => {
-                            const levels = g.split(':')
+                            const levels = splitUnEscapedColon(g)
                             return levels.length > 1 ? levels[1] : g
                         })
                         updateStore(allGroups, gs, msg, 'visible', true)
                     }
                     if ('hide' in groups) {
                         const gh = groups.hide.map((g) => {
-                            const levels = g.split(':')
+                            const levels = splitUnEscapedColon(g)
                             return levels.length > 1 ? levels[1] : g
                         })
                         updateStore(allGroups, gh, msg, 'visible', false)
                     }
                     if ('enable' in groups) {
                         const ge = groups.enable.map((g) => {
-                            const levels = g.split(':')
+                            const levels = splitUnEscapedColon(g)
                             return levels.length > 1 ? levels[1] : g
                         })
                         updateStore(allGroups, ge, msg, 'disabled', false)
                     }
                     if ('disable' in groups) {
                         const gd = groups.disable.map((g) => {
-                            const levels = g.split(':')
+                            const levels = splitUnEscapedColon(g)
                             return levels.length > 1 ? levels[1] : g
                         })
                         updateStore(allGroups, gd, msg, 'disabled', true)

--- a/ui/src/widgets/ui-control/UIControl.vue
+++ b/ui/src/widgets/ui-control/UIControl.vue
@@ -44,8 +44,14 @@ export default {
                 })
             }
 
+            function splitUnEscapedColon (str) {
+                // Split only on colons (:) that ar not escaped, i.e. not  preceded by a backslash (\\).
+                // And for each part replace the escaped colons again by normal colons.
+                return str.split(/(?<!\\):/).map(part => part.replace(/\\:/g, ':'))
+            }
+
             function setGroup (name, prop, value) {
-                const [pageName, groupName] = name.split(':')
+                const [pageName, groupName] = splitUnEscapedColon(name)
                 const groups = vue.findBy('group', 'name', groupName)
                 if (groups.length === 1) {
                     set('group', groupName, prop, value)
@@ -175,7 +181,7 @@ export default {
             if ('groups' in payload) {
                 if ('show' in payload.groups) {
                     payload.groups.show.forEach((name) => {
-                        const groupName = name.split(':')[1]
+                        const groupName = splitUnEscapedColon(name)[1]
                         const exactGroup = vue.groups ? Object.values(vue.groups).find(group => group.name === groupName) : null
 
                         if (exactGroup?.groupType === 'dialog') {
@@ -189,7 +195,7 @@ export default {
                 }
                 if ('hide' in payload.groups) {
                     payload.groups.hide.forEach((name) => {
-                        const groupName = name.split(':')[1]
+                        const groupName = splitUnEscapedColon(name)[1]
                         const exactGroup = vue.groups ? Object.values(vue.groups).find(group => group.name === groupName) : null
 
                         if (exactGroup?.groupType === 'dialog') {


### PR DESCRIPTION
## Description

When a group name contains a colon `":"`:

![image](https://github.com/user-attachments/assets/d7597666-1c29-4983-a241-62f5e3f4160c)

Then you should be able to _**escape**_  (using backslashes) that colon for the ui-control node like this:

![image](https://github.com/user-attachments/assets/9818e749-256a-4aec-a3b9-6aaa7158c473)

Otherwise it will trigger an error that group name *"This is"* cannot be found...

This PR splits only by non-escaped colons, and removes the escape characters afterwards.  Then it seems to work:

![groupname_colon](https://github.com/user-attachments/assets/8de04306-a28a-4aa2-882d-565e2e3d51c7)

## Related Issue(s)

[1550](https://github.com/FlowFuse/node-red-dashboard/issues/1550)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [X] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

