### PR TITLE
ui-dropdown: msg.options info fix

### DIFF
--- a/nodes/widgets/ui_dropdown.html
+++ b/nodes/widgets/ui_dropdown.html
@@ -217,7 +217,7 @@
         </div>
         <a
             data-html="true"
-            title="Dynamic Property: Send 'msg.options' in order to override this property."
+            title="Dynamic Property: Send 'msg.ui_update.options' in order to override this property."
             class="red-ui-button ui-node-popover-title"
             style="margin-left: 4px; cursor: help; font-size: 0.625rem; border-radius: 50%; width: 24px; height: 24px; display: inline-flex; justify-content: center; align-items: center;">
             <i style="font-family: ui-serif;">fx</i>


### PR DESCRIPTION
## Description

Somebody reported that the node's info still contained `msg.options` instead of `msg.ui_update.options`.  
The md doc is already fine.

## Related Issue(s)

[1553](https://github.com/FlowFuse/node-red-dashboard/issues/1553)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

