### PR TITLE
Sidebar 'add group' missing

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1200,13 +1200,14 @@
                 }
                 return false // return false to click event to prevent default
             })
-            // add the "+ group" button
-            const groupEditButton = $(`<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button" title="${c_('layout.addGroup')}"><i class="fa fa-plus"></i></a>`).appendTo(btnGroup)
-            groupEditButton.on('click', function (evt) {
-                list.editableList('addItem')
-                evt.preventDefault()
-            })
         }
+
+        // add the "+ group" button
+        const groupEditButton = $(`<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button" title="${c_('layout.addGroup')}"><i class="fa fa-plus"></i></a>`).appendTo(btnGroup)
+        groupEditButton.on('click', function (evt) {
+            list.editableList('addItem')
+            evt.preventDefault()
+        })
 
         // if this is a group & it is not an unattached group, add the "_ spacer" button
         if (item.type === 'ui-group' && !!item.page) {


### PR DESCRIPTION
## Description

This PR makes sure that the *"Add group"* button is visible in the sidebar for all page layout types.   Currently it was not available for e.g. the tabs layout:

![image](https://github.com/user-attachments/assets/f8f94cfd-2aa7-4242-af24-93f72f3ff815)

I 'think' this code snippet was accidentally made conditional, during the development of the wysiwyg editor.

## Related Issue(s)

[1544](https://github.com/FlowFuse/node-red-dashboard/issues/1544): note that this issue contains two different problems

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

