### PR TITLE
Layout does not edit the `ui-spacer` node with `editConfig`

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1127,9 +1127,9 @@
      * @param {Object} list - The editableList instance associated with this item
      */
     function addRowActions (parent, item, list) {
-        const configNodes = ['ui-base', 'ui-page', 'ui-link', 'ui-group', 'ui-theme']
+        const configNodes = ['ui-base', 'ui-page', 'ui-link', 'ui-group', 'ui-theme', 'ui-spacer']
         const btnGroup = $('<div>', { class: 'nrdb2-sb-list-header-button-group', id: item.id }).appendTo(parent)
-        if (!configNodes.includes(item.type) && item.type !== 'ui-spacer') {
+        if (!configNodes.includes(item.type)) {
             const focusButton = $(`<a href="#" class="nr-db-sb-tab-focus-button editor-button editor-button-small nr-db-sb-list-header-button" title="${c_('layout.focus')}"><i class="fa fa-bullseye"></i></a>`).appendTo(btnGroup)
             focusButton.on('click', function (evt) {
                 RED.view.reveal(item.id)

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1236,7 +1236,7 @@ async function showDashboardWysiwygEditor (pageId, baseId) {
                     evt.preventDefault()
                     const widget = toDashboardItem(spacerNode)
                     list.editableList('addItem', widget)
-                    RED.editor.edit(widget.node)
+                    RED.editor.editConfig('', spacerNode.type, spacerNode.id)
                 })
                 .appendTo(btnGroup)
         }


### PR DESCRIPTION
Fixes https://discourse.nodered.org/t/bug-when-adding-spacer-dashboard-2/94316

## Description

In #1516, the prefix to use in input element identifiers has been replaced by `node-config-input`.

Until now the layout treated `ui-spacer` as a normal node and edited it with `RED.editor.edit()` which uses the`node-input` prefix. This is why the input is no longer prepared (the selection is missing).

## Related Issue(s)

#1516

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

