### PR TITLE
Only show tooltip value if > 0 in a stacked bar chart

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -226,7 +226,7 @@ export default {
                             return true
                         },
                         filter: (tooltipItem, tooltipIndex) => {
-                            if (this.props.chartType === 'histogram') {
+                            if (this.props.chartType === 'histogram' || (this.props.chartType === 'bar' && this.props.stackSeries)) {
                                 // don't show tooltips for empty data points
                                 return tooltipItem.parsed.y !== undefined && tooltipItem.parsed.y > 0
                             } else if (this.props.chartType === 'line') {


### PR DESCRIPTION
## Description

Had a customer recently raise a bit of friction whereby their bar chart tooltips had a lot of values, but a few where the values were `0`. They've asked if we can filter out the `0` values, which, given we already do this in Histograms, makes sense.

Now, I have made the decision to only implement this for _stacked_ bar charts. This is because in a side-by-side grouping, space on the x-axis is set aside for each series, and it could lead to confusion for _why_ that space is left. The tooltip will clarify that a series exists with a value of `0`, hence the empty space. For a _stacked_ bar chart, this is not an issue.