### PR TITLE
Handle no $socket

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -142,7 +142,7 @@ export default {
         }
     },
     created () {
-        this.$socket.on('ui-config', (topic, payload) => {
+        this.$socket?.on('ui-config', (topic, payload) => {
             this.loading = false
             console.log('ui-config received. topic:', topic, 'payload:', payload)
 


### PR DESCRIPTION
## Description

When auth fails for a Dashboard, the `this.$socket` object does not get populated, and so in `App.vue` the `this.$socket.on` function call throws an error

Part of investigating https://github.com/FlowFuse/node-red-dashboard/issues/1588