### PR TITLE
Update node version that's used when running deploy-docs GH action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
       - run: npm ci
       - name: Build


### PR DESCRIPTION
## Description

Latest vite version falls over with node 16. This should have been flagged when https://github.com/FlowFuse/node-red-dashboard/pull/1586 was merged (cc @cstns) 