### PR TITLE
Update node version that's used when running "publish release" GH action

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: Install Dependencies
         run: npm ci
       - name: Run Tests


### PR DESCRIPTION
## Description

Same issue as https://github.com/FlowFuse/node-red-dashboard/pull/1596