### PR TITLE
No default dialog title

### DIFF
--- a/ui/src/layouts/DialogGroup.vue
+++ b/ui/src/layouts/DialogGroup.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/html-self-closing -->
 <template>
     <v-dialog v-if="group.groupType === 'dialog'" v-model="isActive" :attach="`nrdb-ui-group-${group.id}`" :style="dialogStyles">
-        <v-card title="Dialog">
+        <v-card>
             <template v-if="group.showTitle" #title>
                 {{ group.name }}
             </template>


### PR DESCRIPTION
## Description

This checkbox only works correct in a dialog group, when deactivated:

![image](https://github.com/user-attachments/assets/6ffbe862-69cb-4616-abf3-c7cf5bf4250e)

1. When _active_, the dialog name is displayed correctly as title:

   ![image](https://github.com/user-attachments/assets/96e30958-f991-4f1a-88c1-da58eb2e7b35)

2. When _inactive_, the hardcoded title "Dialog" is displayed as title:

   ![image](https://github.com/user-attachments/assets/f47c61df-63bc-4d3e-9e54-fdda81c58535)


## Related Issue(s)

[1633](https://github.com/FlowFuse/node-red-dashboard/issues/1633)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

