### PR TITLE
ui-template: typo in element name

### DIFF
--- a/nodes/widgets/ui_template.html
+++ b/nodes/widgets/ui_template.html
@@ -362,7 +362,7 @@
         </div>
     </div>
     <div class="form-row">
-        <label for="node-input-temlplateScope"><i class="fa fa-dot-circle-o"></i> <span data-i18n="ui-template.label.scope"></span></label>
+        <label for="node-input-templateScope"><i class="fa fa-dot-circle-o"></i> <span data-i18n="ui-template.label.scope"></span></label>
         <select style="width:76%" id="node-input-templateScope">
             <option value="local" data-i18n="ui-template.label.widget-group"></option>
             <option value="widget:page" data-i18n="ui-template.label.widget-page"></option>


### PR DESCRIPTION
## Description

Somebody reported a small typo in the ui-template node html screen.

## Related Issue(s)

Closes #1619

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

