### PR TITLE
Fix outdated documentation on show/hide of groups

### DIFF
--- a/nodes/widgets/locales/en-US/ui_control.html
+++ b/nodes/widgets/locales/en-US/ui_control.html
@@ -28,8 +28,8 @@
         hide: ['&lt;Page Name&gt;']
     }
     groups: {
-        show: ['&lt;Page Name&gt;:&lt;Group Name&gt;', '&lt;Group Name&gt;'],
-        hide: ['&lt;Group Name&gt;']
+        show: ['&lt;Page Name&gt;:&lt;Group Name&gt;', '&lt;Page Name&gt;:&lt;Group Name&gt;'],
+        hide: ['&lt;Page Name&gt;:&lt;Group Name&gt;']
     }
 }</pre>
     <h4>Enable/Disable Pages & Groups</h4>


### PR DESCRIPTION
## Description

Makes sure the documentation between the online docs and in-Editor docs is consistent

## Related Issue(s)

Closes #1646 