### PR TITLE
Docs: Ensure we have an appropriate example timestamp in the Chart docs

### DIFF
--- a/docs/nodes/widgets/ui-chart.md
+++ b/docs/nodes/widgets/ui-chart.md
@@ -136,6 +136,8 @@ Then, the last piece of the puzzle would be to set the `y` property would be one
 - If your data is a simple numerical value, you can leave this blank, and the chart will automatically use the value of `msg.payload`.
 - If your data is an object, you can provide the key of the value in your data, e.g. `{"myTime": 1743608192522, "myValue": 123}` would set the "Y" property to the type `key` and the value `myValue`.
 
+Note: Timestamps must be in milliseconds (ms). This follows the JavaScript standard for representing time as the number of milliseconds elapsed since the Unix epoch (January 1, 1970, 00:00:00 UTC).
+
 #### Interpolation Methods for Line Charts
 
 Interpolation defines how the line is drawn between data points on a line chart. In Dashboard, you can choose between several interpolation methods to suit your data visualization needs:

--- a/docs/nodes/widgets/ui-chart.md
+++ b/docs/nodes/widgets/ui-chart.md
@@ -129,12 +129,12 @@ A very common use case of Node-RED is to process timeseries data, such as sensor
 The value for the `x` property would then be one of two things:
 
 - If your data is a simple numerical value, you can leave this blank, and the chart will automatically use the current date/time.
-- If your data is an object, you can provide the key of the timestamp in your data, e.g. `{"myTime": 1234567890}` would set the "X" property to the type `key` and the value `myTime`.
+- If your data is an object, you can provide the key of the timestamp in your data, e.g. `{"myTime": 1743608192522}` would set the "X" property to the type `key` and the value `myTime`.
 
 Then, the last piece of the puzzle would be to set the `y` property would be one of two options:
 
 - If your data is a simple numerical value, you can leave this blank, and the chart will automatically use the value of `msg.payload`.
-- If your data is an object, you can provide the key of the value in your data, e.g. `{"myTime": 1234567890, "myValue": 123}` would set the "Y" property to the type `key` and the value `myValue`.
+- If your data is an object, you can provide the key of the value in your data, e.g. `{"myTime": 1743608192522, "myValue": 123}` would set the "Y" property to the type `key` and the value `myValue`.
 
 #### Interpolation Methods for Line Charts
 


### PR DESCRIPTION
## Description

In my lazy attempt to write a timestamp using 1 -> 0, I accidentally typed out a legitimate timestamp in seconds from Epoch, but this led to confusion around scale/units.

Instead, I've put in a legitimate timestamp to ensure this confusion doesn't occur going forward.

## Related Issue(s)

Closes #1640 