### PR TITLE
Allow pwa to be built without error in dev mode

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -24,7 +24,7 @@ export default defineConfig({
             manifest: false,
 
             injectManifest: {
-                maximumFileSizeToCacheInBytes: 3000000,
+                maximumFileSizeToCacheInBytes: process.env.NODE_ENV === 'development' ? 6000000 : 3000000,
                 globPatterns: ['**/*.{js,css,html,svg,png,ico,ttf,eot,woff,woff2}']
             },
 


### PR DESCRIPTION
## Description
This change permits larger artifacts in dev mode builds

PWA v1.0.0 makes exceeding maximumFileSizeToCacheInBytes an error (was a warning in < v1.0.0)

PWA deps were updated in https://github.com/FlowFuse/node-red-dashboard/pull/1649 to satisfy sec audit

See https://vite-pwa-org.netlify.app/guide/faq.html#missing-assets-from-sw-precache-manifest for details on the change




### Before PWA v1.0.0 updates
```
../dist/assets/mindmap-definition-fc14e90a-B1LrfW9A.js        1,071.49 kB │ gzip:   217.66 kB
../dist/assets/flowchart-elk-definition-4a651766-CvQN9B7X.js  3,112.04 kB │ gzip:   563.64 kB
../dist/assets/index-DC6e6DMw.js                              5,172.69 kB │ gzip: 1,174.88 kB
✓ built in 15.71s

PWA v0.20.1
Building src/sw.js service worker ("es" format)...
vite v5.4.14 building for development...
✓ 70 modules transformed.
../dist/sw.mjs  80.93 kB │ gzip: 19.77 kB
✓ built in 137ms

PWA v0.20.1
mode      injectManifest
format:   es
precache  58 entries (7915.57 KiB)
files generated
  ../dist/sw.js
warnings
  assets/flowchart-elk-definition-4a651766-CvQN9B7X.js is 3.11 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.       
  assets/index-DC6e6DMw.js is 5.2 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.
```

### After PWA v1.0.0 updates
```
../dist/assets/mindmap-definition-fc14e90a-CZKEYQPE.js        1,071.49 kB │ gzip:   217.66 kB
../dist/assets/flowchart-elk-definition-4a651766-DlPnSY9y.js  3,112.04 kB │ gzip:   563.64 kB
../dist/assets/index-C8AKq6yb.js                              5,217.05 kB │ gzip: 1,185.75 kB
✓ built in 15.04s

PWA v1.0.0
Building src/sw.js service worker ("es" format)...
vite v5.4.16 building for development...
✓ 70 modules transformed.
../dist/sw.mjs  80.93 kB │ gzip: 19.77 kB
✓ built in 157ms
error during build:
Error:
  Configure "injectManifest.maximumFileSizeToCacheInBytes" to change the limit: the default value is 2 MiB.
  Check https://vite-pwa-org.netlify.app/guide/faq.html#missing-assets-from-sw-precache-manifest for more information.
  Assets exceeding the limit:
  - assets/flowchart-elk-definition-4a651766-DlPnSY9y.js is 3.11 MB, and won't be precached.
  - assets/index-C8AKq6yb.js is 5.25 MB, and won't be precached.
```


## Related Issue(s)

https://github.com/FlowFuse/node-red-dashboard/pull/1649

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

