### PR TITLE
Fix missing topic when value comes via onAction

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -6,7 +6,7 @@ const axios = require('axios')
 const v = require('../../package.json').version
 const datastore = require('../store/data.js')
 const statestore = require('../store/state.js')
-const { appendTopic, addConnectionCredentials, getThirdPartyWidgets } = require('../utils/index.js')
+const { appendTopic, addConnectionCredentials, getThirdPartyWidgets, getTopic } = require('../utils/index.js')
 
 // from: https://stackoverflow.com/a/28592528/3016654
 function join (...paths) {
@@ -603,7 +603,11 @@ module.exports = function (RED) {
 
             // Wrap execution in a try/catch to ensure we don't crash Node-RED
             try {
-                msg = await appendTopic(RED, widgetConfig, wNode, msg)
+                if (widgetConfig.topic || widgetConfig.topicType) {
+                    const dsMsg = datastore.get(id)
+                    const topic = dsMsg && await getTopic(RED, widgetConfig, wNode, dsMsg)
+                    msg.topic = topic ?? '' // ensure we have a topic property in the msg, even if it's an empty string
+                }
 
                 // pre-process the msg before send on the msg (if beforeSend is defined)
                 if (widgetEvents?.beforeSend && typeof widgetEvents.beforeSend === 'function') {

--- a/nodes/utils/index.js
+++ b/nodes/utils/index.js
@@ -15,14 +15,7 @@ function asyncEvaluateNodeProperty (RED, value, type, node, msg) {
 
 async function appendTopic (RED, config, wNode, msg) {
     // populate topic if the node specifies one
-    if (config.topic || config.topicType) {
-        try {
-            msg.topic = await asyncEvaluateNodeProperty(RED, config.topic, config.topicType || 'str', wNode, msg) || ''
-        } catch (_err) {
-            // do nothing
-            console.error(_err)
-        }
-    }
+    msg.topic = await getTopic(RED, config, wNode, msg)
 
     // ensure we have a topic property in the msg, even if it's an empty string
     if (!('topic' in msg)) {
@@ -30,6 +23,21 @@ async function appendTopic (RED, config, wNode, msg) {
     }
 
     return msg
+}
+
+async function getTopic (RED, config, wNode, msg) {
+    // populate topic if the node specifies one
+    let topic
+    if (config.topic || config.topicType) {
+        try {
+            topic = await asyncEvaluateNodeProperty(RED, config.topic, config.topicType || 'str', wNode, msg) || ''
+        } catch (_err) {
+            // do nothing
+            console.error(_err)
+        }
+    }
+
+    return topic
 }
 
 /**
@@ -116,6 +124,7 @@ function getThirdPartyWidgets (directory) {
 
 module.exports = {
     asyncEvaluateNodeProperty,
+    getTopic,
     appendTopic,
     addConnectionCredentials,
     getThirdPartyWidgets


### PR DESCRIPTION
closes #1632
closes #1453

## Description

Gets the datastore message and evaluates the topic from the stored msg in the onAction handler (similar to how it works for the text-edit widget which sends data via `onChange`)

## Related Issue(s)

#1632
#1453

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

