### PR TITLE
Handle trailing slashes in the URL

### DIFF
--- a/cypress/fixtures/flows/trailing-slashes-redirect.json
+++ b/cypress/fixtures/flows/trailing-slashes-redirect.json
@@ -1,0 +1,86 @@
+[
+    {
+        "id": "tab-1",
+        "type": "tab",
+        "label": "UI",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "dashboard-ui-base",
+        "type": "ui-base",
+        "name": "UI Name",
+        "path": "/dashboard",
+        "includeClientData": true,
+        "acceptsClientConfig": [
+            "ui-notification",
+            "ui-control"
+        ]
+    },
+    {
+        "id": "dashboard-ui-page-1",
+        "type": "ui-page",
+        "name": "Page 1",
+        "ui": "dashboard-ui-base",
+        "path": "/page1",
+        "icon": "",
+        "layout": "grid",
+        "theme": "dashboard-ui-theme",
+        "order": -1,
+        "className": "",
+        "visible": "true",
+        "disabled": false
+    },
+    {
+        "id": "dashboard-ui-theme",
+        "type": "ui-theme",
+        "name": "Theme Name",
+        "colors": {
+            "surface": "#ffffff",
+            "primary": "#0094ce",
+            "bgPage": "#eeeeee",
+            "groupBg": "#ffffff",
+            "groupOutline": "#cccccc"
+        }
+    },
+    {
+        "id": "dashboard-ui-group-widgets",
+        "type": "ui-group",
+        "name": "just a group",
+        "page": "dashboard-ui-page-1",
+        "width": "6",
+        "height": "1",
+        "order": 1,
+        "showTitle": true,
+        "className": "",
+        "visible": "true",
+        "disabled": "false"
+    },
+    {
+        "id": "d506363d3f2c88cd",
+        "type": "ui-button",
+        "z": "3069e2ce342ccdc8",
+        "group": "dashboard-ui-group-widgets",
+        "name": "",
+        "label": "Just a button",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 580,
+        "y": 100,
+        "wires": [
+            []
+        ]
+    }
+]

--- a/cypress/tests/behaviours/trailing-slash.spec.js
+++ b/cypress/tests/behaviours/trailing-slash.spec.js
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+describe('Trailing Slash Handling', () => {
+    beforeEach(() => {
+        cy.deployFixture('trailing-slashes-redirect')
+        cy.visit('/dashboard/page1')
+    })
+    it('should redirect URLs with trailing slashes', () => {
+        cy.visit('/dashboard/page1/')
+        cy.contains('just a group')
+    })
+
+    it('should load the page without trailing slashes', () => {
+        cy.visit('/dashboard/page1')
+        cy.contains('just a group')
+    })
+    it('should load the page with parameters without trailing slashes', () => {
+        cy.visit('/dashboard/page1?key=value')
+        cy.contains('just a group')
+    })
+})

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -126,18 +126,30 @@ module.exports = function (RED) {
 
             uiShared.app.use(config.path, uiShared.httpMiddleware, express.static(path.join(__dirname, '../../dist')))
 
-            // Redirect any requests with a trailing slash to the same path without the trailing slash
+            // Middleware to enforce canonical URLs without trailing slashes.
+            //
+            // In some configurations (e.g., with NGINX), requests might include
+            // a trailing slash. For consistency, SEO benefits, and to reduce duplicate
+            // content issues, we redirect such URLs to their non-trailing version.
+            //
+            // This middleware:
+            // - Applies only to GET and HEAD requests.
+            // - Ignores the root path ("/").
+            // - Redirects (301) URLs ending with a trailing slash to their non-trailing equivalent.
+            // - Preserves the query string.
+            // - Collapses any redundant slashes (e.g., "//" becomes "/").
             uiShared.app.use((req, res, next) => {
                 // Skip if not a GET or HEAD request
                 if (!(req.method === 'GET' || req.method === 'HEAD')) {
                     next()
                     return
                 }
-
+                // Check if someone is trying to open a page with with a / at the end
+                // If yes, redirect (with a 301 status) to the correct page without the trailing slash.
                 if (req.path.slice(-1) === '/' && req.path.length > 1) {
-                    const query = req.url.slice(req.path.length)
-                    const safePath = req.path.slice(0, -1).replace(/\/+/g, '/')
-                    res.redirect(301, safePath + query)
+                    const query = req.url.slice(req.path.length) // get the query string (if any)
+                    const safePath = req.path.slice(0, -1).replace(/\/+/g, '/') // remove trailing slash and make any double slashes single slashes
+                    res.redirect(301, safePath + query) // redirect to the safe path
                 } else {
                     next()
                 }


### PR DESCRIPTION
closes #1476

## Description

After some consideration, we will stick with slash-less URLs like /page1, and enforce that style with a 301 redirect middleware. 
It’s cleaner, SEO-friendly, backward-compatible, and avoids unnecessary rewrites.

## Related Issue(s)

#1476

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

