### PR TITLE
Ensure we overflow by default if child widget extends beyond widget's defined height

### DIFF
--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -144,7 +144,9 @@ main {
 .nrdb-ui-widget {
     min-height: var(--widget-row-height);
     position: relative;
+    overflow-y: auto;
 }
+
 /* to make input type widgets repect row heights */
 .nrdb-app .v-input--density-default {
     --v-input-control-height: var(--widget-row-height);


### PR DESCRIPTION
## Description

<img width="1062" alt="Screenshot 2025-04-25 at 21 00 33" src="https://github.com/user-attachments/assets/97de3d5e-fc47-4421-bb9b-927ba7781243" />

If we set a height on a `ui-template` that's ignored if the child content is taller. This change ensures that the content instead scrolls to ensure consistency in the rendering of row heights in a Dashboard.