### PR TITLE
Contain overflow handling to template widgets

### DIFF
--- a/ui/src/layouts/Grid.vue
+++ b/ui/src/layouts/Grid.vue
@@ -115,7 +115,6 @@ export default {
         }
     },
     mounted () {
-        console.log('grid layout mounted')
         if (this.editMode) { // mixin property
             this.updateEditStateObjects()
             this.initializeEditTracking() // Mixin method

--- a/ui/src/layouts/Group.vue
+++ b/ui/src/layouts/Group.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="nrdb-layout-group--grid" :style="`grid-template-columns: repeat(min(${ columns }, var(--layout-columns)), 1fr); grid-template-rows: repeat(${group.height}, var(--widget-row-height)); `">
+    <div class="nrdb-layout-group--grid" :style="`grid-template-columns: repeat(min(${ columns }, var(--layout-columns)), 1fr); `">
         <div
             v-if="resizable" ref="group-resize-view" class="nrdb-resizable" :class="{'resizing': groupResizing.active}"
             :style="{ 'width': groupResizing.current.width ? `${groupResizing.current.width}px` : null, 'z-index': 99 }"

--- a/ui/src/layouts/Group.vue
+++ b/ui/src/layouts/Group.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="nrdb-layout-group--grid" :style="`grid-template-columns: repeat(min(${ columns }, var(--layout-columns)), 1fr); grid-template-rows: repeat(${group.height}, minmax(var(--widget-row-height), auto)); `">
+    <div class="nrdb-layout-group--grid" :style="`grid-template-columns: repeat(min(${ columns }, var(--layout-columns)), 1fr); grid-template-rows: repeat(${group.height}, var(--widget-row-height)); `">
         <div
             v-if="resizable" ref="group-resize-view" class="nrdb-resizable" :class="{'resizing': groupResizing.active}"
             :style="{ 'width': groupResizing.current.width ? `${groupResizing.current.width}px` : null, 'z-index': 99 }"
@@ -25,7 +25,7 @@
             :draggable="resizable"
             class="nrdb-ui-widget"
             :class="getWidgetClass(w)"
-            :style="[{display: 'grid', 'grid-template-columns': 'minmax(0, 1fr)'}, widgetStyles(w)]"
+            :style="[{display: 'grid', 'grid-template-columns': 'minmax(0, 1fr)', 'gap': 'var(--widget-gap)'}, widgetStyles(w)]"
             @dragstart="!resizable ? null : onWidgetDragStart($event, $index, w)"
             @dragover="!resizable ? null : onWidgetDragOver($event, $index, w)"
             @dragend="!resizable ? null : onWidgetDragEnd($event, $index, w)"
@@ -34,7 +34,7 @@
             @dragenter.prevent
         >
             <!-- <div style="font-size: small; background-color: aquamarine;">w.props.height: {{ w.props.height }}</div> -->
-            <component :is="w.component" :id="w.id" :props="w.props" :state="w.state" :style="`grid-row-end: span ${w.props.height}`" />
+            <component :is="w.component" :id="w.id" ref="widget-content" :props="w.props" :state="w.state" :style="`grid-row-end: span ${w.props.height}`" />
             <div
                 v-if="resizable && !groupDragging" ref="widget-resize-view"
                 class="nrdb-resizable nrdb-resizable-widget"
@@ -117,10 +117,17 @@ export default {
         widgetStyles () {
             return (widget) => {
                 const styles = {}
-                const height = widget.props.height
+                let height = widget.props.height
                 const width = widget.props.width
+                if (widget.type === 'ui-form') {
+                    // form is unique in that height is defined by the number of fields
+                    // so, if the size is set to "auto", we need to set the height/rows to the number of fields, +2 for label and submission buttons
+                    if (height === null || height === 0) {
+                        height = (widget.props.options.length / (widget.props.splitLayout ? 2 : 1)) + 2
+                    }
+                }
                 styles['grid-row-end'] = `span ${height}`
-                styles['grid-template-rows'] = `repeat(${height}, minmax(var(--widget-row-height), auto))`
+                styles['grid-template-rows'] = `repeat(${height}, var(--widget-row-height))`
                 styles['grid-column-end'] = `span min(${this.getWidgetWidth(+width)}, var(--layout-columns))`
                 return styles
             }

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -147,6 +147,7 @@ main {
 }
 
 /* Ensure we overflow if template extends beyond widget's defined height */
+.nrdb-ui-widget.nrdb-ui-markdown,
 .nrdb-ui-widget.nrdb-ui-template {
     overflow-y: auto;
 }

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -149,6 +149,7 @@ main {
 /* Ensure we overflow if template extends beyond widget's defined height */
 .nrdb-ui-widget.nrdb-ui-markdown,
 .nrdb-ui-widget.nrdb-ui-form,
+.nrdb-ui-widget.nrdb-ui-button-group,
 .nrdb-ui-widget.nrdb-ui-template {
     overflow-y: auto;
 }

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -144,6 +144,10 @@ main {
 .nrdb-ui-widget {
     min-height: var(--widget-row-height);
     position: relative;
+}
+
+/* Ensure we overflow if template extends beyond widget's defined height */
+.nrdb-ui-widget.nrdb-ui-template {
     overflow-y: auto;
 }
 

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -148,6 +148,7 @@ main {
 
 /* Ensure we overflow if template extends beyond widget's defined height */
 .nrdb-ui-widget.nrdb-ui-markdown,
+.nrdb-ui-widget.nrdb-ui-form,
 .nrdb-ui-widget.nrdb-ui-template {
     overflow-y: auto;
 }

--- a/ui/src/widgets/ui-button-group/UIButtonGroup.vue
+++ b/ui/src/widgets/ui-button-group/UIButtonGroup.vue
@@ -134,8 +134,17 @@ export default {
     width: max-content;
     border-width: thin;
     border-color: rgba(var(--v-border-color), var(--v-border-opacity));
-    min-height: fit-content;
+    min-height: var(--widget-row-height);
+    max-height: 100%;
 }
+
+/* override opinionated Vuetify stylings */
+.v-btn-group--density-comfortable.v-btn-group,
+.v-btn-group--density-default.v-btn-group,
+.v-btn-group--density-compact.v-btn-group {
+    height: initial !important;
+}
+
 /* default styling for an unselected option */
 .nrdb-ui-button-group-wrapper .v-btn--variant-elevated {
    color: rgb(var(--v-theme-on-group-background));

--- a/ui/src/widgets/ui-form/UIForm.vue
+++ b/ui/src/widgets/ui-form/UIForm.vue
@@ -1,6 +1,6 @@
 <template>
     <label v-if="label" class="nrdb-ui-form-label">{{ label }}</label>
-    <v-form ref="form" v-model="isValid" :disabled="!state.enabled" validate-on="input" @submit.prevent="onSubmit">
+    <v-form ref="form" v-model="isValid" :disabled="!state.enabled" validate-on="input" :style="{'margin-top': label ? 0 : '0.5rem'}" @submit.prevent="onSubmit">
         <div class="nrdb-ui-form-rows" :class="{'nrdb-ui-form-rows--split': props.splitLayout}">
             <div v-for="row in options" :key="row.key" class="nrdb-ui-form-row" :data-form="`form-row-${row.key}`">
                 <v-checkbox

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -20,7 +20,7 @@
                 v-bind="activatorProps"
                 v-model="value" :disabled="!state.enabled" class="nrdb-ui-text-field nrdb-ui-textarea" :style="{ 'grid-row-end': `span ${props.height}` }"
                 :prepend-icon="prependIcon" :append-icon="appendIcon" :append-inner-icon="appendInnerIcon" :prepend-inner-icon="prependInnerIcon"
-                :clearable="clearable" variant="outlined" hide-details="auto" @update:model-value="onChange" @blur="send"
+                :clearable="clearable" variant="outlined" hide-details="auto" :rows="props.height || 1" @update:model-value="onChange" @blur="send"
                 @click:clear="onClear"
             >
                 <template #label>
@@ -186,6 +186,7 @@ export default {
     }
     textarea.v-field__input {
         height:100%;
+        resize: none;
     }
 }
 </style>


### PR DESCRIPTION
closes #1704

## Description

Contain overflow handling to template widgets (semi-reverts https://github.com/FlowFuse/node-red-dashboard/pull/1685)

## Related Issue(s)

#1704

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

