### PR TITLE
fix slider reversal

### DIFF
--- a/cypress/fixtures/flows/dashboard-slider.json
+++ b/cypress/fixtures/flows/dashboard-slider.json
@@ -102,7 +102,7 @@
         "topic": "topic",
         "topicType": "str",
         "thumbLabel": true,
-        "min": 0,
+        "min": "20",
         "max": "100",
         "step": 1,
         "className": "",

--- a/cypress/tests/widgets/slider.spec.js
+++ b/cypress/tests/widgets/slider.spec.js
@@ -4,6 +4,17 @@ describe('Node-RED Dashboard 2.0 - Slider', () => {
         cy.visit('/dashboard/page1')
     })
 
+    it('is loaded correctly', () => {
+        cy.get('#nrdb-ui-widget-dashboard-ui-slider').contains('My Slider')
+        cy.get('#nrdb-ui-widget-dashboard-ui-slider').find('.v-slider-thumb').should('have.attr', 'aria-valuemin', '20')
+        cy.get('#nrdb-ui-widget-dashboard-ui-slider').find('.v-slider-thumb').should('have.attr', 'aria-valuemax', '100')
+        // upon first load, the slider should be at its minimum value
+        cy.get('#nrdb-ui-widget-dashboard-ui-slider').find('.v-slider-thumb').should('have.attr', 'aria-valuenow', '20')
+        // to verify the slider orientation, with the slider being horizontal, the thumb should be on the left side
+        // which is denoted by style="--v-slider-thumb-position: 0%""
+        cy.get('#nrdb-ui-widget-dashboard-ui-slider').find('.v-slider-thumb').should('have.attr', 'style', '--v-slider-thumb-position: 0%; --v-slider-thumb-size: 20px;')
+    })
+
     it('is labelled correctly', () => {
         cy.get('#nrdb-ui-widget-dashboard-ui-slider').contains('My Slider')
     })
@@ -17,8 +28,8 @@ describe('Node-RED Dashboard 2.0 - Slider', () => {
     it('emits a value, and updates, when clicked', () => {
         cy.resetContext()
         cy.clickAndWait(cy.get('.v-slider__container'))
-        cy.get('#nrdb-ui-widget-dashboard-ui-slider').find('.v-slider-thumb').should('have.attr', 'aria-valuenow', 50)
-        cy.checkOutput('msg.payload', 50)
+        cy.get('#nrdb-ui-widget-dashboard-ui-slider').find('.v-slider-thumb').should('have.attr', 'aria-valuenow', 60) // halfway between 20 and 100
+        cy.checkOutput('msg.payload', 60)
     })
 })
 
@@ -29,11 +40,16 @@ describe('Node-RED Dashboard 2.0 - Slider (Dynamic Properties)', () => {
     })
 
     it('include "labels"', () => {
+        // first set the slider to a known value
+        cy.clickAndWait(cy.get('.v-slider__container'))
+        cy.get('#nrdb-ui-widget-dashboard-ui-slider').find('.v-slider-thumb').should('have.attr', 'aria-valuenow', 60) // halfway between 20 and 100
+        cy.checkOutput('msg.payload', 60)
+        // now change the label only
         cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-button-dynamic-label'))
         // check the label is updated
         cy.get('#nrdb-ui-widget-dashboard-ui-slider').contains('Dynamic Slider Label')
-        // shouldn't have changed hte value as we're only setting label
-        cy.checkOutput('msg.payload', 50)
+        // shouldn't have changed the value as we're only setting label
+        cy.checkOutput('msg.payload', 60)
     })
 
     it('include "min"', () => {

--- a/ui/src/widgets/ui-slider/UISlider.vue
+++ b/ui/src/widgets/ui-slider/UISlider.vue
@@ -77,16 +77,16 @@ export default {
             return this.getProperty('showTicks')
         },
         min: function () {
-            return Math.min(this.getProperty('min'), this.getProperty('max'))
+            return Math.min(+this.getProperty('min'), +this.getProperty('max'))
         },
         step: function () {
-            return this.getProperty('step')
+            return +this.getProperty('step')
         },
         max: function () {
-            return Math.max(this.getProperty('min'), this.getProperty('max'))
+            return Math.max(+this.getProperty('min'), +this.getProperty('max'))
         },
         isReverse: function () {
-            return this.getProperty('min') > this.getProperty('max')
+            return +this.getProperty('min') > +this.getProperty('max')
         },
         iconPrepend: function () {
             const icon = this.getProperty('iconPrepend')


### PR DESCRIPTION
closes #1720
## Description

* Ensure min and max (and step) values are numeric to avoid string comparison reversing slider
* Update e2e tests and fixture (to cause reversal on old src) and ensure reversal is not present in updated src (regression avoidance).

## Related Issue(s)

#1720

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

