### PR TITLE
widget: Introduce the Progress Bar

### DIFF
--- a/nodes/widgets/locales/en-US/ui_progress.json
+++ b/nodes/widgets/locales/en-US/ui_progress.json
@@ -1,0 +1,12 @@
+{
+    "ui-progress": {
+        "label": {
+            "progress": "Progress",
+            "group": "Group",
+            "name": "Name",
+            "label": "Label",
+            "color": "Color",
+            "className": "Class"
+        }
+    }
+}

--- a/nodes/widgets/ui_progress.html
+++ b/nodes/widgets/ui_progress.html
@@ -1,0 +1,91 @@
+<script type="text/javascript">
+    RED.nodes.registerType('ui-progress', {
+        category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+        color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
+        defaults: {
+            group: { type: 'ui-group', required: true },
+            name: { value: '' },
+            label: { value: 'Progress' },
+            order: { value: 0 },
+            width: {
+                value: 0,
+                validate: function (v) {
+                    const width = v || 0
+                    const currentGroup = $('#node-input-group').val() || this.group
+                    const groupNode = RED.nodes.node(currentGroup)
+                    const valid = !groupNode || +width >= 0
+                    $('#node-input-size').toggleClass('input-error', !valid)
+                    return valid
+                }
+            },
+            height: { value: 0 },
+            color: { value: '' },
+            className: { value: '' }
+        },
+        inputs: 1,
+        outputs: 0,
+        icon: 'font-awesome/fa-percent',
+        paletteLabel: 'progress',
+        label: function () { 
+            return this.name || this.label || 'progress'
+        },
+        labelStyle: function () { 
+            return this.name ? 'node_label_italic' : '' 
+        },
+        oneditprepare: function () {
+            // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+            // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
+            if (RED.nodes.subflow(this.z)) {
+                // change inputs from hidden to text & display them
+                $('#node-input-width').attr('type', 'text')
+                $('#node-input-height').attr('type', 'text')
+                $('div.form-row.nr-db-ui-element-sizer-row').hide()
+                $('div.form-row.nr-db-ui-manual-size-row').show()
+            } else {
+                // not in a subflow, use the elementSizer
+                $('div.form-row.nr-db-ui-element-sizer-row').show()
+                $('div.form-row.nr-db-ui-manual-size-row').hide()
+                $('#node-input-size').elementSizer({
+                    width: '#node-input-width',
+                    height: '#node-input-height',
+                    group: '#node-input-group'
+                })
+            }
+        }
+    })
+</script>
+
+<script type="text/html" data-template-name="ui-progress">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
+        <input type="text" id="node-input-group">
+    </div>
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> Size</label>
+        <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> Height</label>
+        <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row">
+        <label for="node-input-label"><i class="fa fa-i-cursor"></i> Label</label>
+        <input type="text" id="node-input-label" placeholder="Progress">
+    </div>
+    <div class="form-row">
+        <label for="node-input-color"><i class="fa fa-tint"></i> Color</label>
+        <input type="text" id="node-input-color" placeholder="primary">
+    </div>
+    <div class="form-row">
+        <label for="node-input-className"><i class="fa fa-code"></i> Class</label>
+        <input type="text" id="node-input-className" placeholder="Optional CSS class names">
+    </div>
+</script>

--- a/nodes/widgets/ui_progress.js
+++ b/nodes/widgets/ui_progress.js
@@ -1,0 +1,35 @@
+const statestore = require('../store/state.js')
+
+module.exports = function (RED) {
+    function ProgressNode (config) {
+        RED.nodes.createNode(this, config)
+        const node = this
+
+        // which group are we rendering this widget
+        const group = RED.nodes.getNode(config.group)
+
+        const beforeSend = function (msg) {
+            // Handle dynamic properties
+            const updates = msg.ui_update
+            if (updates) {
+                if (typeof updates.label !== 'undefined') {
+                    statestore.set(group.getBase(), node, msg, 'label', updates.label)
+                }
+                if (typeof updates.color !== 'undefined') {
+                    statestore.set(group.getBase(), node, msg, 'color', updates.color)
+                }
+            }
+            return msg
+        }
+
+        // inform the dashboard UI that we are adding this node
+        if (group) {
+            group.register(node, config, {
+                beforeSend
+            })
+        } else {
+            node.error('No group configured')
+        }
+    }
+    RED.nodes.registerType('ui-progress', ProgressNode)
+}

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
             "ui-markdown": "nodes/widgets/ui_markdown.js",
             "ui-template": "nodes/widgets/ui_template.js",
             "ui-event": "nodes/widgets/ui_event.js",
-            "ui-control": "nodes/widgets/ui_control.js"
+            "ui-control": "nodes/widgets/ui_control.js",
+            "ui-progress": "nodes/widgets/ui_progress.js"
         }
     },
     "overrides": {

--- a/test/nodes/widgets/ui_progress.spec.js
+++ b/test/nodes/widgets/ui_progress.spec.js
@@ -1,0 +1,151 @@
+const helper = require('node-red-node-test-helper')
+const should = require('should') // eslint-disable-line no-unused-vars
+const sinon = require('sinon/lib/sinon.js')
+
+// load test 1 standard test data (base, page, group, theme, progress)
+const { testData1 } = require('../fixtures/index.js')
+const { verifyFlowLoaded } = require('../utils.js')
+const testFlow1 = testData1.flows
+const nodeImports = testData1.getImports(null, ['ui_progress'])
+
+helper.init(require.resolve('node-red'))
+
+describe('ui-progress node', function () {
+    beforeEach(function (done) {
+        helper.startServer(done)
+    })
+
+    afterEach(function (done) {
+        helper.unload()
+        helper.stopServer(done)
+    })
+
+    const flow = [
+        {
+            id: 'node-ui-progress',
+            type: 'ui-progress',
+            z: 'tab-id',
+            group: 'config-ui-group',
+            name: '',
+            label: 'Progress',
+            order: 0,
+            width: 0,
+            height: 0,
+            color: 'primary',
+            className: '',
+            x: 290,
+            y: 180,
+            wires: []
+        },
+        {
+            id: 'helper-node',
+            type: 'helper'
+        },
+        ...testFlow1
+    ]
+
+    it('should be loaded', async function () {
+        await helper.load(nodeImports, flow)
+        verifyFlowLoaded(helper, flow)
+        const progress = helper.getNode('node-ui-progress')
+        should(progress).be.an.Object()
+    })
+
+    it('should be registered with the ui-base', async function () {
+        await helper.load(nodeImports, flow)
+        verifyFlowLoaded(helper, flow)
+        const base = helper.getNode('config-ui-base')
+        should(base).be.an.Object()
+        base.should.have.property('ui')
+        base.ui.should.have.property('widgets')
+        base.ui.widgets.has('node-ui-progress').should.be.true()
+    })
+
+    it('should be registered with the ui-base with the correct defaults', async function () {
+        await helper.load(nodeImports, flow)
+        verifyFlowLoaded(helper, flow)
+        const base = helper.getNode('config-ui-base')
+        const widget = base.ui.widgets.get('node-ui-progress')
+
+        // base config should be correct
+        widget.id.should.equal('node-ui-progress')
+        widget.type.should.equal('ui-progress')
+
+        // default UI component state
+        widget.should.have.property('state')
+        widget.state.should.have.property('enabled', true)
+        widget.state.should.have.property('visible', true)
+
+        // check we have our properties set correctly
+        widget.should.have.property('props')
+        widget.props.should.have.property('label', flow[0].label)
+        widget.props.should.have.property('color', flow[0].color)
+    })
+
+    it('should handle dynamic property updates via ui_update', async function () {
+        await helper.load(nodeImports, flow)
+        verifyFlowLoaded(helper, flow)
+        const progress = helper.getNode('node-ui-progress')
+
+        // spy on the statestore.set method to verify dynamic properties are set
+        const statestore = require('../../../nodes/store/state.js')
+        const setSpy = sinon.spy(statestore, 'set')
+
+        // send message with ui_update for dynamic properties
+        progress.receive({
+            payload: 50,
+            ui_update: {
+                label: 'New Label',
+                color: 'red'
+            }
+        })
+
+        // verify the statestore.set was called for each dynamic property
+        setSpy.callCount.should.equal(2)
+
+        // check the first call (label update)
+        const firstCall = setSpy.getCall(0)
+        firstCall.args[3].should.equal('label')
+        firstCall.args[4].should.equal('New Label')
+
+        // check the second call (color update)
+        const secondCall = setSpy.getCall(1)
+        secondCall.args[3].should.equal('color')
+        secondCall.args[4].should.equal('red')
+
+        setSpy.restore()
+    })
+
+    it('should error if no group is configured', async function () {
+        const flowWithoutGroup = [
+            {
+                id: 'node-ui-progress-no-group',
+                type: 'ui-progress',
+                z: 'tab-id',
+                name: '',
+                label: 'Progress',
+                order: 0,
+                width: 0,
+                height: 0,
+                color: 'primary',
+                className: '',
+                x: 290,
+                y: 180,
+                wires: []
+            },
+            ...testFlow1
+        ]
+
+        await helper.load(nodeImports, flowWithoutGroup)
+        const progress = helper.getNode('node-ui-progress-no-group')
+        should(progress).be.an.Object()
+
+        // node should have logged an error about missing group
+        const logEvents = helper.log().args.filter(args =>
+            args[0].level === helper.log().ERROR &&
+            args[0].id === 'node-ui-progress-no-group'
+        )
+        logEvents.should.have.length(1)
+        logEvents[0][0].msg.should.equal('No group configured')
+    })
+})

--- a/ui/src/widgets/index.mjs
+++ b/ui/src/widgets/index.mjs
@@ -11,6 +11,7 @@ import UIGauge from './ui-gauge/UIGauge.vue'
 import UIMarkdown from './ui-markdown/UIMarkdown.vue'
 import UINotification from './ui-notification/UINotification.vue'
 import UINumberInput from './ui-number-input/UINumberInput.vue'
+import UIProgress from './ui-progress/UIProgress.vue'
 import UIRadioGroup from './ui-radio-group/UIRadioGroup.vue'
 import UISlider from './ui-slider/UISlider.vue'
 import UISpacer from './ui-spacer/UISpacer.vue'
@@ -35,6 +36,7 @@ export {
     UIMarkdown,
     UINotification,
     UINumberInput,
+    UIProgress,
     UIRadioGroup,
     UISlider,
     UISpacer,
@@ -63,6 +65,7 @@ export default {
     'ui-markdown': UIMarkdown,
     'ui-notification': UINotification,
     'ui-number-input': UINumberInput,
+    'ui-progress': UIProgress,
     'ui-radio-group': UIRadioGroup,
     'ui-slider': UISlider,
     'ui-spacer': UISpacer,

--- a/ui/src/widgets/ui-progress/UIProgress.vue
+++ b/ui/src/widgets/ui-progress/UIProgress.vue
@@ -1,0 +1,55 @@
+<template>
+    <v-progress-linear
+        v-model="value"
+        :disabled="!state.enabled"
+        :class="className"
+        :color="color || 'primary'"
+        height="20"
+    >
+        <template v-if="label" #default="{ value: progressValue }">
+            <strong>{{ label }}: {{ Math.ceil(progressValue) }}%</strong>
+        </template>
+    </v-progress-linear>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+    name: 'DBUIProgress',
+    inject: ['$socket', '$dataTracker'],
+    props: {
+        id: { type: String, required: true },
+        props: { type: Object, default: () => ({}) },
+        state: { type: Object, default: () => ({}) }
+    },
+    computed: {
+        ...mapState('data', ['messages']),
+        value: function () {
+            const payload = this.messages[this.id]?.payload
+            return typeof payload === 'number' ? payload : 0
+        },
+        label: function () {
+            return this.getProperty('label')
+        },
+        color: function () {
+            return this.getProperty('color')
+        }
+    },
+    created () {
+        this.$dataTracker(this.id, null, null, this.onDynamicProperties)
+    },
+    methods: {
+        onDynamicProperties (msg) {
+            const updates = msg.ui_update
+            if (!updates) {
+                return
+            }
+            this.updateDynamicProperty('label', updates.label)
+            this.updateDynamicProperty('color', updates.color)
+        }
+    }
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
Through Vuetify a progress bar was already available, but it wasn't great to use and a bit mystical. With this change I'm trying to implement the widget in the _smallest_ way possible, so it can be extended later without backwards compat issues.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

