### PR TITLE
misc: Remove CJS deprecation warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,14 @@
             "extends": ["plugin:n/recommended"],
             "env": {
                 "commonjs": true,
-                "browser": false
+                "browser": false,
+                "node": true
+            },
+            "globals": {
+                "require": "readonly",
+                "module": "readonly",
+                "__dirname": "readonly",
+                "__filename": "readonly"
             },
             "rules": {
                 // plugin:n

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
         "url": "https://github.com/FlowFuse/node-red-dashboard.git"
     },
     "license": "Apache-2.0",
-    "type": "module",
     "author": {
         "name": "Joe Pavitt",
         "url": "https://github.com/joepavitt"
@@ -30,6 +29,7 @@
             "url": "https://flowfuse.com"
         }
     ],
+    "type": "module",
     "files": [
         "dist/*",
         "nodes/*"


### PR DESCRIPTION
When building docs, there was a deprecation warning, that was fixed following: https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

