### PR TITLE
Vertically align the progress bar in widget row

### DIFF
--- a/ui/src/widgets/ui-progress/UIProgress.vue
+++ b/ui/src/widgets/ui-progress/UIProgress.vue
@@ -52,4 +52,10 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style lang="scss">
+// class auto-added by the layout engine
+.nrdb-ui-progress {
+    display: flex;
+    align-items: center;
+}
+</style>


### PR DESCRIPTION
## Description

- Forgot to commit some local changes before merging #1736 
- This makes sure the progress bar is vertically aligned within the height fo the widget row.

## Related Issue(s)

#1736