### PR TITLE
Guard call to `wNode.send` to avoid unhandled exceptions when ui-control is removed

### DIFF
--- a/nodes/widgets/ui_control.js
+++ b/nodes/widgets/ui_control.js
@@ -364,21 +364,25 @@ module.exports = function (RED) {
                 connection: function (conn) {
                     if (config.events === 'all' || config.events === 'connect') {
                         const wNode = RED.nodes.getNode(node.id)
-                        let msg = {
-                            payload: 'connect'
+                        if (wNode && typeof wNode.send === 'function') {
+                            let msg = {
+                                payload: 'connect'
+                            }
+                            msg = addConnectionCredentials(RED, msg, conn, ui)
+                            wNode.send(msg)
                         }
-                        msg = addConnectionCredentials(RED, msg, conn, ui)
-                        wNode.send(msg)
                     }
                 },
                 disconnect: function (conn) {
                     if (config.events === 'all' || config.events === 'connect') {
                         const wNode = RED.nodes.getNode(node.id)
-                        let msg = {
-                            payload: 'lost'
+                        if (wNode && typeof wNode.send === 'function') {
+                            let msg = {
+                                payload: 'lost'
+                            }
+                            msg = addConnectionCredentials(RED, msg, conn, ui)
+                            wNode.send(msg)
                         }
-                        msg = addConnectionCredentials(RED, msg, conn, ui)
-                        wNode.send(msg)
                     }
                 },
                 'ui-control': function (conn, id, evt, payload) {


### PR DESCRIPTION

## Description

Guard call to `wNode.send` to avoid unhandled exceptions when ui-control is removed

## Related Issue(s)

closes #1079

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

