### PR TITLE
Fix sizer elements when in subflow

### DIFF
--- a/nodes/widgets/ui_number_input.html
+++ b/nodes/widgets/ui_number_input.html
@@ -131,11 +131,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-number-input.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-number-input.label.size"></span></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row form-row-flex">
         <label for="node-input-icon"><i class="fa fa-picture-o"></i> <span data-i18n="ui-number-input.label.icon"></span></label>

--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -125,11 +125,17 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-text-input.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-text-input.label.size"></span></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-sizer-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-manual-size-row">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
     </div>
     <div class="form-row form-row-flex">
         <label for="node-input-icon"><i class="fa fa-picture-o"></i> <span data-i18n="ui-text-input.label.icon"></span></label>


### PR DESCRIPTION
## Description

2 widgets were not updated to show W/H fields when it is presented in a subflow

### Before
<img width="532" height="351" alt="image" src="https://github.com/user-attachments/assets/cd6d9013-8ea8-42e7-91d7-fb64a319da3e" />

<img width="528" height="362" alt="image" src="https://github.com/user-attachments/assets/2531fd92-b1d2-4f35-8cf3-f374c020574e" />

### After
<img width="492" height="333" alt="image" src="https://github.com/user-attachments/assets/b5cc700a-861e-404a-a86e-097422a2167c" />
<img width="499" height="333" alt="image" src="https://github.com/user-attachments/assets/37f9bb2a-691c-4777-944b-8ccacc6b105a" />




## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

