### PR TITLE
Allow basic widget ordering of widgets in a subflow

### DIFF
--- a/nodes/widgets/ui_audio.html
+++ b/nodes/widgets/ui_audio.html
@@ -38,12 +38,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -72,17 +72,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-audio.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-audio.label.size"></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-audio.label.width">Width</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-audio.label.height">Height</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-src"><i class="fa fa-globe"></i> <span data-i18n="ui-audio.label.source"></label>

--- a/nodes/widgets/ui_button.html
+++ b/nodes/widgets/ui_button.html
@@ -66,12 +66,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -158,17 +158,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-button.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-button.label.size"></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-button.label.width">Width</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-button.label.height">Height</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row form-row-flex">
         <label for="node-input-icon"><i class="fa fa-picture-o"></i> <span data-i18n="ui-button.label.icon"></label>

--- a/nodes/widgets/ui_button_group.html
+++ b/nodes/widgets/ui_button_group.html
@@ -51,12 +51,12 @@
                 // change inputs from hidden to text & display them
                 $('#node-input-width').attr('type', 'text')
                 $('#node-input-height').attr('type', 'text')
-                $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                $('div.form-row.nr-db-ui-manual-size-row').show()
+                $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                $('div.form-row.nr-db-ui-element-show-in-subflow').show()
             } else {
                 // not in a subflow, use the elementSizer
-                $('div.form-row.nr-db-ui-element-sizer-row').show()
-                $('div.form-row.nr-db-ui-manual-size-row').hide()
+                $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                 $('#node-input-size').elementSizer({
                     width: '#node-input-width',
                     height: '#node-input-height',
@@ -223,17 +223,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-button-group.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-button-group.label.size"></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-button-group.label.width">Width</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-button-group.label.height">Height</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-button-group.label.label"></span></label>

--- a/nodes/widgets/ui_chart.html
+++ b/nodes/widgets/ui_chart.html
@@ -183,12 +183,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -483,17 +483,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-chart.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-chart-group.label.size"></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-chart-group.label.width">Width</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-chart-group.label.height">Height</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-chart.label.label"></span></label>

--- a/nodes/widgets/ui_dropdown.html
+++ b/nodes/widgets/ui_dropdown.html
@@ -76,12 +76,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -181,17 +181,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-dropdown.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-dropdown.label.size"></span></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-dropdown.label.width"></span></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-dropdown.label.height"></span></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-tag"></i> <span data-i18n="ui-dropdown.label.label"></span></label>

--- a/nodes/widgets/ui_file_input.html
+++ b/nodes/widgets/ui_file_input.html
@@ -46,12 +46,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -82,11 +82,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-file-input.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-file-input.label.size"></span></label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-file-input.label.label"></span></label>

--- a/nodes/widgets/ui_form.html
+++ b/nodes/widgets/ui_form.html
@@ -72,12 +72,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -463,17 +463,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-form.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-form.label.size"></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-form.label.width"></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-form.label.height"></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-tag"></i> <span data-i18n="ui-form.label.label"></label>

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -181,12 +181,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -326,17 +326,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-gauge.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-gauge.label.size">Size</label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-gauge.label.width">Width</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-gauge.label.height">Height</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-gtype"><i class="fa fa-list"></i> <span data-i18n="ui-gauge.label.type"></span></label>

--- a/nodes/widgets/ui_markdown.html
+++ b/nodes/widgets/ui_markdown.html
@@ -46,12 +46,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -112,17 +112,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-markdown.label.group"></span></label>
         <input style="flex-grow:1" type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-markdown.label.size"></span></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-markdown.label.width"></span></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-markdown.label.height"></span></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-className"><i class="fa fa-code"></i> <span data-i18n="ui-markdown.label.class"></span></label>

--- a/nodes/widgets/ui_number_input.html
+++ b/nodes/widgets/ui_number_input.html
@@ -58,12 +58,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -131,17 +131,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-number-input.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
         <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
+    <div class="form-row nr-db-ui-element-show-in-subflow">
         <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
+    <div class="form-row nr-db-ui-element-show-in-subflow">
         <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row form-row-flex">
         <label for="node-input-icon"><i class="fa fa-picture-o"></i> <span data-i18n="ui-number-input.label.icon"></span></label>

--- a/nodes/widgets/ui_progress.html
+++ b/nodes/widgets/ui_progress.html
@@ -39,12 +39,12 @@
                 // change inputs from hidden to text & display them
                 $('#node-input-width').attr('type', 'text')
                 $('#node-input-height').attr('type', 'text')
-                $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                $('div.form-row.nr-db-ui-manual-size-row').show()
+                $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                $('div.form-row.nr-db-ui-element-show-in-subflow').show()
             } else {
                 // not in a subflow, use the elementSizer
-                $('div.form-row.nr-db-ui-element-sizer-row').show()
-                $('div.form-row.nr-db-ui-manual-size-row').hide()
+                $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                 $('#node-input-size').elementSizer({
                     width: '#node-input-width',
                     height: '#node-input-height',
@@ -64,17 +64,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> Size</label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> Width</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> Height</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> Label</label>

--- a/nodes/widgets/ui_radio_group.html
+++ b/nodes/widgets/ui_radio_group.html
@@ -58,12 +58,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -161,17 +161,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-radio-group.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-radio-group.label.size"></span></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-radio-group.label.width"></span></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-radio-group.label.height"></span></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-tag"></i> <span data-i18n="ui-radio-group.label.label"></span></label>

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -55,12 +55,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -125,18 +125,22 @@
             <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
             <input type="text" id="node-input-group">
         </div>
-        <div class="form-row nr-db-ui-element-sizer-row">
-            <label><i class="fa fa-object-group"></i> <span data-i18n="ui-slider.label.size">Size</label>
-            <button class="editor-button" id="node-input-size"></button>
-        </div>
-        <div class="form-row nr-db-ui-manual-size-row">
-            <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-slider.label.width">Width</label>
-            <input type="hidden" id="node-input-width">
-        </div>
-        <div class="form-row nr-db-ui-manual-size-row">
-            <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-slider.label.height">Height</label>
-            <input type="hidden" id="node-input-height">
-        </div>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
+        <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
+    </div>
         <div class="form-row">
             <label for="node-input-className"><i class="fa fa-code"></i> Class</label>
             <div style="display: inline;">

--- a/nodes/widgets/ui_spacer.html
+++ b/nodes/widgets/ui_spacer.html
@@ -41,12 +41,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-config-input-width').attr('type', 'text')
                     $('#node-config-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-config-input-size').elementSizer({
                         width: '#node-config-input-width',
                         height: '#node-config-input-height',
@@ -75,17 +75,21 @@
         <label for="node-config-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-spacer.label.group"></span></label>
         <input type="text" id="node-config-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-spacer.label.size"></span></label>
-        <button class="editor-button" id="node-config-input-size"></button>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
+        <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-spacer.label.width"></span></label>
-        <input type="hidden" id="node-config-input-width">
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
+        <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-spacer.label.height"></span></label>
-        <input type="hidden" id="node-config-input-height">
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
+        <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-config-input-className"><i class="fa fa-code"></i> <span data-i18n="ui-spacer.label.class"></span></label>

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -61,12 +61,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -171,17 +171,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-switch.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-switch.label.size"></span></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-switch.label.width"></span></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-switch.label.height"></span></label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-switch.label.label"></span></label>
@@ -346,9 +350,6 @@
         box-shadow: inset 0px 0px 0px 2px #fff;
         background: #333;
         border-color: #333;
-    }
-    .nr-db-ui-manual-size-row {
-        display: none;
     }
 
 </style>

--- a/nodes/widgets/ui_table.html
+++ b/nodes/widgets/ui_table.html
@@ -120,12 +120,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -325,17 +325,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-table.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-table.label.size">Size</label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-table.label.width">Width</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-table.label.height">Height</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-table.label.label"></span></label>

--- a/nodes/widgets/ui_template.html
+++ b/nodes/widgets/ui_template.html
@@ -189,12 +189,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -385,17 +385,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-template.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-template.label.size">Size</label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-template.label.width">Width</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-template.label.height">Height</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <!--<div class="form-row" id="template-row-size">
         <label><i class="fa fa-object-group"></i> <span data-i18n="ui-template.label.size"></span></label>

--- a/nodes/widgets/ui_text.html
+++ b/nodes/widgets/ui_text.html
@@ -114,12 +114,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -227,17 +227,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-text.label.group"></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
-        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-text.label.size"></label>
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-text.label.width">Width</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
-        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-text.label.height">Height</label>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-text.label.label"></label>
@@ -381,9 +385,6 @@
         box-shadow: inset 0px 0px 0px 2px #fff;
         background: #333;
         border-color: #333;
-    }
-    .nr-db-ui-manual-size-row {
-        display: none;
     }
 
 </style>

--- a/nodes/widgets/ui_text_input.html
+++ b/nodes/widgets/ui_text_input.html
@@ -56,12 +56,12 @@
                     // change inputs from hidden to text & display them
                     $('#node-input-width').attr('type', 'text')
                     $('#node-input-height').attr('type', 'text')
-                    $('div.form-row.nr-db-ui-element-sizer-row').hide()
-                    $('div.form-row.nr-db-ui-manual-size-row').show()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').hide()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').show()
                 } else {
                     // not in a subflow, use the elementSizer
-                    $('div.form-row.nr-db-ui-element-sizer-row').show()
-                    $('div.form-row.nr-db-ui-manual-size-row').hide()
+                    $('div.form-row.nr-db-ui-element-hide-in-subflow').show()
+                    $('div.form-row.nr-db-ui-element-show-in-subflow').hide()
                     $('#node-input-size').elementSizer({
                         width: '#node-input-width',
                         height: '#node-input-height',
@@ -125,17 +125,21 @@
         <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui-text-input.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row nr-db-ui-element-sizer-row">
+    <div class="form-row nr-db-ui-element-hide-in-subflow">
         <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
+    <div class="form-row nr-db-ui-element-show-in-subflow">
         <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
         <input type="hidden" id="node-input-width">
     </div>
-    <div class="form-row nr-db-ui-manual-size-row">
+    <div class="form-row nr-db-ui-element-show-in-subflow">
         <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
         <input type="hidden" id="node-input-height">
+    </div>
+    <div class="form-row nr-db-ui-element-show-in-subflow">
+        <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
+        <input type="text" id="node-input-order">
     </div>
     <div class="form-row form-row-flex">
         <label for="node-input-icon"><i class="fa fa-picture-o"></i> <span data-i18n="ui-text-input.label.icon"></span></label>


### PR DESCRIPTION
## NOTE
This PR merges into an earlier fix branch so to minimise review confusion, the simple fix in PR https://github.com/FlowFuse/node-red-dashboard/pull/1758 whould be reviewed and merged first.

## Description

Allow user to manually enter sorting order when a widget is in a subflow (similar to how width and height are handled)

### Screenshot examples:

#### Number
<img width="512" height="390" alt="image" src="https://github.com/user-attachments/assets/d50b3d36-bb5d-4f30-9d18-fd541bf8c87a" />

#### Chart

<img width="830" height="450" alt="image" src="https://github.com/user-attachments/assets/6a77a9c0-8009-4f73-aa14-831cc15263ac" />


#### Other Nodes
They all follow same pattern



## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

