### PR TITLE
Fix linting error in gauge.html

### DIFF
--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -123,7 +123,7 @@
                 name: { value: '' },
                 group: { type: 'ui-group', required: true },
                 order: { value: 0 },
-                value: { value: 'payload', required: false},
+                value: { value: 'payload', required: false },
                 valueType: { value: 'msg' },
                 width: {
                     value: 3,


### PR DESCRIPTION
## Description

Merge crossovers meant a linting error got into the production code. This fixes it.