### PR TITLE
Improve sizing and appearance of the progress widget

### DIFF
--- a/ui/src/widgets/ui-progress/UIProgress.vue
+++ b/ui/src/widgets/ui-progress/UIProgress.vue
@@ -1,15 +1,17 @@
 <template>
-    <v-progress-linear
-        v-model="value"
-        :disabled="!state.enabled"
-        :class="className"
-        :color="color || 'primary'"
-        height="20"
-    >
-        <template v-if="label" #default="{ value: progressValue }">
-            <strong>{{ label }}: {{ Math.ceil(progressValue) }}%</strong>
-        </template>
-    </v-progress-linear>
+    <div class="nrdb-ui-progress-wrapper" :style="{ 'border-color': color ? color : 'rgb(var(--v-theme-primary))' }">
+        <v-progress-linear
+            v-model="value"
+            :disabled="!state.enabled"
+            :class="className"
+            :color="color || 'primary'"
+            :height="'100%'"
+        >
+            <template v-if="label" #default="{ value: progressValue }">
+                <strong>{{ label }}: {{ Math.ceil(progressValue) }}%</strong>
+            </template>
+        </v-progress-linear>
+    </div>
 </template>
 
 <script>
@@ -53,9 +55,19 @@ export default {
 </script>
 
 <style lang="scss">
+.nrdb-ui-progress-wrapper {
+    height: 100%;
+    padding: 3px;
+    border-radius: 3px;
+    border-style: solid;
+    border-width: 1px;
+}
 // class auto-added by the layout engine
 .nrdb-ui-progress {
     display: flex;
     align-items: center;
+}
+.nrdb-ui-progress .v-progress-linear {
+    height: 100% !important;
 }
 </style>


### PR DESCRIPTION
## Description

The progress widget feels out of place to the other widgets, in particular because it doesn't fill the space of a row. As such, I've increased the size/height to support that. I've also added a little border and padding to make it blender with the UI more, as a solid block looked a little too amateur.

### Before

<img width="650" height="262" alt="Screenshot 2025-07-15 at 16 12 35" src="https://github.com/user-attachments/assets/3de1ea96-d805-4959-9eed-58247bc12ee1" />

### After

<img width="647" height="262" alt="Screenshot 2025-07-15 at 16 32 34" src="https://github.com/user-attachments/assets/c81084c3-30e8-4c61-9f58-1f5d8696fb60" />
