### PR TITLE
Fix page label clipping

### DIFF
--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -302,6 +302,10 @@ export default {
             }
         },
         getPageLabel (page) {
+            if (this.dashboard.navigationStyle === 'icon' && this.rail) {
+                return ''
+            }
+
             return page.name + (this.dashboard.showPathInSidebar ? ` (${page.path})` : '')
         },
         handleNavigationClick () {


### PR DESCRIPTION
## Description

Page label is omitted when the "Collapse to icon" Style is chosen. Text will still show when the drawer is expanded. See video for more information.

https://github.com/user-attachments/assets/14ce01bf-371c-4928-bb7f-86c50aea618c


## Related Issue(s)

Closes https://github.com/FlowFuse/node-red-dashboard/issues/1782
Closes https://github.com/FlowFuse/node-red-dashboard/issues/1801 (Duplicate)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

