### PR TITLE
Add `class` to ui-table

### DIFF
--- a/nodes/widgets/locales/en-US/ui_table.json
+++ b/nodes/widgets/locales/en-US/ui_table.json
@@ -25,7 +25,9 @@
             "append": "Append",
             "replace": "Replace",
             "deselect": "Deselect",
-            "deselectRows": "Deselect all rows when the table is filled"
+            "deselectRows": "Deselect all rows when the table is filled",
+            "className": "Class",
+            "classNamePlaceholder": "Optional CSS class name(s)"
         },
         "selection": {
             "none": "None",

--- a/nodes/widgets/locales/ja/ui_table.json
+++ b/nodes/widgets/locales/ja/ui_table.json
@@ -8,7 +8,9 @@
             "autoCalculateColumns": "列を自動判断",
             "key": "キー",
             "label": "ラベル",
-            "column": "列"
+            "column": "列",
+            "className": "クラス",
+            "classNamePlaceholder": "任意のCSSクラス名"
         }
     }
 }

--- a/nodes/widgets/ui_table.html
+++ b/nodes/widgets/ui_table.html
@@ -90,7 +90,8 @@
                 },
                 mobileBreakpoint: { value: 'sm' },
                 mobileBreakpointType: { value: 'defaults' },
-                action: { value: 'append' }
+                action: { value: 'append' },
+                className: { value: '' }
             },
             inputs: 1,
             outputs: 1,
@@ -344,6 +345,10 @@
     <div class="form-row">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> <span data-i18n="ui-table.label.label"></span></label>
         <input type="text" id="node-input-label" data-i18n="[placeholder]ui-table.label.optionalTableTitle">
+    </div>
+    <div class="form-row" id="text-row-class">
+        <label for="node-config-input-className"><i class="fa fa-code"></i> <span data-i18n="ui-table.label.className"></span></label>
+        <input type="text" id="node-config-input-className" data-i18n="[placeholder]ui-table.label.classNamePlaceholder"/>
     </div>
     <div class="form-row">
         <label for="node-input-maxrows"><i class="fa fa-tag"></i> <span data-i18n="ui-table.label.maxRows"></label>


### PR DESCRIPTION
## Description

Adds class field to ui-table to permit user customisation

## Related Issue(s)

closes #1775


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

