### PR TITLE
Fix: keep existing url params during reload

### DIFF
--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -84,11 +84,13 @@ function forcePageReload (err) {
     console.log('redirecting to:', window.location.origin + '/dashboard')
 
     // Reloading dashboard without using cache by appending a cache-busting string to fully reload page to allow redirecting to auth
+    const currentParams = new URLSearchParams(window.location.search)
     const url = new URL(window.location.origin + '/dashboard')
-    url.searchParams.set('reloadTime', Date.now().toString() + Math.random())
+    currentParams.set('reloadTime', Date.now().toString() + Math.random())
     if (host.searchParams.has('edit-key')) {
-        url.searchParams.set('edit-key', host.searchParams.get('edit-key'))
+        currentParams.set('edit-key', host.searchParams.get('edit-key'))
     }
+    url.search = currentParams.toString()
     window.location.replace(url)
 }
 


### PR DESCRIPTION
## Description

Updates the reload logic ensure existing query parameters are preserved when forcing a page reload

* In `ui/src/main.mjs`, the `forcePageReload` function now copies all existing query parameters from the current URL to the rebuilt dashboard URL, adds a cache-busting `reloadTime` parameter, and preserves the `edit-key` parameter if present. This ensures that relevant parameters are not lost during the redirect.

## Related Issue(s)

#1807 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

