### PR TITLE
Chart: Set default value for xAxis.min to "dataMin"

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -252,6 +252,7 @@ export default {
                         nameTextStyle: {
                             color: textColor // label color
                         },
+                        min: 'dataMin',
                         splitLine: {
                             show: true,
                             lineStyle: {


### PR DESCRIPTION
## Description

- After the migration it had been noted that eCharts defaults `xMin` to `0`, whereas ChartJs` used a rounded number closer to the minimum x-value. Whilst the rounded nature of this is a little more work, a very quick win is to use "dataMin" ([docs](https://echarts.apache.org/en/option.html#xAxis.min)) which will align it to the smallest x-value found in the provided dataset

### Before

<img width="953" height="440" alt="Screenshot 2025-09-12 at 10 57 04" src="https://github.com/user-attachments/assets/a6497a35-2196-4ad7-9726-aacdddc2643e" />

### After

<img width="952" height="470" alt="Screenshot 2025-09-12 at 10 49 19" src="https://github.com/user-attachments/assets/5c719c49-22e8-4a27-891e-38a2e76a63c7" />

## Related Issue(s)

Forum Post: https://discourse.nodered.org/t/first-impressions-of-dashboard-2-charts-v1-27-0/99012