### PR TITLE
Chart: Ensure bar/histogram charts without a series color by data index

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -631,6 +631,7 @@ export default {
                         name: label,
                         type: chartJStoECharts.seriesType(this.chartType),
                         stack: this.props.stackSeries ? 'total' : null,
+                        colorBy: this.props.categoryType === 'none' ? 'data' : 'series',
                         data: []
                     }
 
@@ -775,6 +776,7 @@ export default {
                     name: seriesLabel,
                     type: 'bar',
                     stack: this.props.stackSeries ? 'total' : null,
+                    colorBy: this.props.categoryType === 'none' ? 'data' : 'series',
                     data: []
                 }
                 if (this.props.xAxisType === 'bins') {


### PR DESCRIPTION
## Description

- Default in ChartJS was to color by the index/data point, such that each bar had a unique colour when the bar chart was specified to have "None" for it's series.
- In eCharts, the default behaviour is to colour by series, as such, the single series of data plotted was all rendered as the same colour.
- This PR overrides the default, as a function of the `categoryType` property (series) set on the chart widget.

### Before

<img width="975" height="452" alt="Screenshot 2025-09-12 at 11 14 13" src="https://github.com/user-attachments/assets/2f678c25-e60a-4fec-bc62-e20913b1e2a3" />

### After

<img width="955" height="448" alt="Screenshot 2025-09-12 at 11 13 41" src="https://github.com/user-attachments/assets/e233fbc3-ada8-4f8b-85e8-ddf630084407" />

## Related Issue(s)

https://discourse.nodered.org/t/first-impressions-of-dashboard-2-charts-v1-27-0/99012/