### PR TITLE
Chart: Set top/bottom in accordance to presence of legend and title

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -37,6 +37,9 @@ export default {
     },
     computed: {
         ...mapState('data', ['messages']),
+        hasTitle () {
+            return this.props.label !== ''
+        },
         chartType () {
             // eCharts supports histograms natively, but we still map for compatibility
             if (this.props.chartType === 'histogram') {
@@ -211,7 +214,7 @@ export default {
                     },
                     legend: {
                         show: showLegend,
-                        top: 40,
+                        top: this.hasTitle ? 40 : 0,
                         textStyle: {
                             color: textColor
                         }
@@ -235,11 +238,13 @@ export default {
                     },
                     grid: {
                         left: '3%',
-                        right: '4%'
+                        right: '4%',
+                        bottom: '0%',
+                        top: this.hasTitle ? (this.props.showLegend ? 70 : 40) : (this.props.showLegend ? 30 : 0)
                     },
                     legend: {
                         show: showLegend,
-                        top: 40,
+                        top: this.hasTitle ? 40 : 0,
                         textStyle: {
                             color: textColor
                         }
@@ -272,6 +277,7 @@ export default {
                         nameTextStyle: {
                             color: textColor
                         },
+                        min: 'dataMin',
                         axisLine: {
                             show: true
                         },
@@ -564,14 +570,14 @@ export default {
                         type: 'pie',
                         radius: this.chartType === 'doughnut' ? ['40%', '100%'] : '100%',
                         data: [],
-                        top: 40, // account for the title
+                        top: this.hasTitle ? 40 : 0, // account for the title
                         itemStyle: {
                             borderWidth: 2,
                             borderColor: '#fff'
                         }
                     }
                     if (this.props.showLegend) {
-                        series.top = 70 // accounts for the legend and the title
+                        series.top = this.hasTitle ? 70 : 30 // accounts for the legend and the title
                     }
                     sIndex = options.series.length
                     options.series.push(series)


### PR DESCRIPTION
## Description

### Problem

- Default eCharts hardcodes bottom and top such that there is extra padding either side of the chart. In Dashboard, this is particularly noticeable when smaller charts are rendered.
- Additionally, when a chart does not use a title, the chart doesn't automatically adjust it's y-position to fill the now available space.

### Solution

- Introduce manual calculations that better size the chart vertically based on the presence of a title and/or legend.

### Before

<img width="976" height="294" alt="Screenshot 2025-09-12 at 13 29 26" src="https://github.com/user-attachments/assets/92ba44eb-1321-4294-8a05-8715f96a64e9" />

### After

<img width="962" height="294" alt="Screenshot 2025-09-12 at 13 27 56" src="https://github.com/user-attachments/assets/305f0400-8965-4298-bdee-8f6b863980b6" />

## Related Issue(s)

https://discourse.nodered.org/t/first-impressions-of-dashboard-2-charts-v1-27-0/99012/18
