### PR TITLE
Chart: Be smarter about when we commit the update to the eChart options

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -646,7 +646,7 @@ export default {
         },
         /**
          * Update the chart given a set of eCharts Options
-         * @param options 
+         * @param options
          */
         updateChart (options) {
             this.updateYAxisLimits(options)


### PR DESCRIPTION
## Description

Down to ~70ms to render 1,000 data points (previously 8 seconds) with this change.

### Changes

- Use a temporary `options` variable to track required changes, and _then_ update the eCharts with `setOption` once we've processed all data received in a message. Previously, we were using the chart itself as the source of truth, and regularly reading/writing to it, which caused the performance bottleneck.

## Related Issue(s)

Closes #1819 