### PR TITLE
Docs: Add our own table for timestamp formatting

### DIFF
--- a/docs/en/nodes/widgets/ui-chart.md
+++ b/docs/en/nodes/widgets/ui-chart.md
@@ -138,6 +138,47 @@ Then, the last piece of the puzzle would be to set the `y` property would be one
 
 Note: Timestamps must be in milliseconds (ms). This follows the JavaScript standard for representing time as the number of milliseconds elapsed since the Unix epoch (January 1, 1970, 00:00:00 UTC).
 
+##### Formatting Timestamps
+
+You can set a formatting option on the x-axis when using timeseries data. Included, as defaults, are:
+
+- `{HH}:{mm}:{ss}`: e.g. 12:00:00
+- `{HH}:{mm}`: e.g. 12:00
+- `{yyyy}-{M}-{d}`: e.g. 2020-01-01
+- `{d}/{M}`: e.g. 01/01
+- `{ee} {HH}:{mm}`: e.g. Sun 12:00
+
+You can also choose "Custom" option and provide your own formatting string, using the following tokens:
+
+| Group | Template | Value (EN) |
+|-------|----------|------------|
+| Year | `{yyyy}` | e.g. 2020, 2021, ... |
+| | `{yy}` | 00-99 |
+| Quarter | `{Q}` | 1, 2, 3, 4 |
+| Month | `{MMMM}` | e.g. January, February, ... |
+| | `{MMM}` | e.g. Jan, Feb, ... |
+| | `{MM}` | 01-12 |
+| | `{M}` | 1-12 |
+| Day of Month | `{dd}` | 01-31 |
+| | `{d}` | 1-31 |
+| Day of Week | `{eeee}` | Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday |
+| | `{ee}` | Sun, Mon, Tues, Wed, Thu, Fri, Sat |
+| | `{e}` | 1-54 |
+| Hour | `{HH}` | 00-23 |
+| | `{H}` | 0-23 |
+| | `{hh}` | 01-12 |
+| | `{h}` | 1-12 |
+| Minute | `{mm}` | 00-59 |
+| | `{m}` | 0-59 |
+| Second | `{ss}` | 00-59 |
+| | `{s}` | 0-59 |
+| Millisecond | `{SSS}` | 000-999 |
+| | `{S}` | 0-999 |
+
+The above table is taken from the [eCharts documentation](https://echarts.apache.org/en/option.html#xAxis.axisLabel.formatter).
+
+For any versions below, and including, `1.26.0`, FlowFuse Dashboard used ChartJS for formatting timestamps. This has been migrated to eCharts in `1.27.0`. For documentation on ChartJS timestamps, see the [ChartJS documentation](https://www.chartjs.org/docs/latest/axes/cartesian/time.html#time-axis-specific-options).
+
 #### Interpolation Methods for Line Charts
 
 Interpolation defines how the line is drawn between data points on a line chart. In Dashboard, you can choose between several interpolation methods to suit your data visualization needs:

--- a/nodes/widgets/locales/en-US/ui_chart.html
+++ b/nodes/widgets/locales/en-US/ui_chart.html
@@ -29,7 +29,7 @@
         </dd>
         <dt>X-Axis Format <span class="property-type">{HH}:{mm}:{ss} | {HH}:{mm} | {yyyy}-{M}-{d} | {d}/{M} | {ee} {HH}:{mm} | custom | auto</span></dt>
         <dd>Defines how the values are displayed on the axis, when X-Axis type is <code>'timescale'</code>.
-            See <a target="_blank" href="https://echarts.apache.org/en/option.html#xAxis.axisLabel.formatter">here</a> for an overview of the available format types.  
+            See <a target="_blank" href="https://dashboard.flowfuse.com/nodes/widgets/ui-chart#formatting-timestamps">here</a> for an overview of the available format types.  
         </dd>
         <dt>Properties <span class="property-type">string</span></dt>
         <dd>


### PR DESCRIPTION
## Description

The eCharts docs doesn't have a nice header-based link for us to point to the timestamp formatting tokens, as such, we've made our own table.

## Related Issue(s)

Discussed in https://github.com/FlowFuse/node-red-dashboard/pull/1838#issuecomment-3292234767