### PR TITLE
Prevent chart x axis label overlap

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -268,6 +268,7 @@ export default {
                             }
                         },
                         axisLabel: {
+                            hideOverlap: true, // hide labels that would overlap adjacent label
                             color: textColor
                         },
                         minorSplitLine: {


### PR DESCRIPTION
## Description

Set `xAxis.axisLabel.hideOverlap` true to prevent overlapping labels

## Related Issue(s)

Closes #1842

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

