### PR TITLE
Tab Layout: Ensure we set default tab selection by ID, not index

### DIFF
--- a/ui/src/layouts/Tabs.vue
+++ b/ui/src/layouts/Tabs.vue
@@ -76,14 +76,14 @@ export default {
             if (vm.orderedGroups && vm.orderedGroups.length > 0) {
                 // Check if origin and destination pages are unique
                 if (to?.name !== from?.name) {
-                    vm.tab = 0
+                    vm.tab = vm.orderedGroups[0].id
                 }
             }
         })
     },
     data () {
         return {
-            tab: 0
+            tab: null
         }
     },
     computed: {
@@ -91,7 +91,7 @@ export default {
         ...mapState('data', ['properties']),
         ...mapGetters('ui', ['groupsByPage', 'widgetsByGroup', 'widgetsByPage']),
         orderedGroups: function () {
-            // get groups on this page
+            // get groups on this page - these are going to be rendered as the different tabs
             const groups = this.groupsByPage(this.$route.meta.id)
                 // only show hte groups that haven't had their "visible" property set to false
                 .filter((g) => {


### PR DESCRIPTION
## Description

The `v-tab` collection we rendered were index by `:key="t.id"`, but the default `tab` value on the `Tabs.vue` component was `0`. Whilst Vuetify seems to handle this itself in the first load, after that, our code, which set `vm.tab = 0` was then mis-aligned to the tabs already rendered, and therefore not selecting any of them.

Fix: Ensure `.tab` vairbale in the component was set to the tab/groups ID, and not generic index.

## Related Issue(s)

Closes #1784 