### PR TITLE
Chart: Remote animation when updating data

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -221,9 +221,7 @@ export default {
                         }
                     },
                     color: this.props.colors,
-                    series: [],
-                    animationDuration: 300, // minimal animation on inital data load
-                    animationDurationUpdate: 50 // minimal animation on data update
+                    series: []
                 }
                 return options
             } else {
@@ -300,7 +298,7 @@ export default {
                     },
                     series: [],
                     animationDuration: 300, // minimal animation on inital data load
-                    animationDurationUpdate: 50 // minimal animation on data update
+                    animationDurationUpdate: 0 // minimal animation on data update
                 }
 
                 // set timeseries formatting
@@ -561,6 +559,8 @@ export default {
                         radius: this.chartType === 'doughnut' ? ['40%', '100%'] : '100%',
                         data: [],
                         top: this.hasTitle ? 40 : 0, // account for the title
+                        animationDuration: 300, // minimal animation on inital data load
+                        animationDurationUpdate: 0, // minimal animation on data update
                         itemStyle: {
                             borderWidth: 2,
                             borderColor: '#fff'


### PR DESCRIPTION
## Description

- Sets `animationDuration` on the `series` of the `pie` charts, as for some reason eCharts doesn't pass the top-level property down for pie charts
- Set the value of the `animationDurationUpdate` to `0` so that when data is appended to the chart (after the first batch) no animation takes place.

## Related Issue(s)

Closes #1853