### PR TITLE
Chart: Disable tooltip delay/duration

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -237,6 +237,7 @@ export default {
                         }
                     },
                     tooltip: {
+                        transitionDuration: 0,
                         trigger: (this.chartType === 'line' || this.chartType === 'bar') ? 'axis' : 'item'
                     },
                     grid: {


### PR DESCRIPTION
## Description

- Removes `transition` from the tooltip

## Related Issue(s)

Closes #1853