### PR TITLE
Chart: Fix stacking in lines & add "Area" chart type

### DIFF
--- a/nodes/widgets/locales/en-US/ui_chart.json
+++ b/nodes/widgets/locales/en-US/ui_chart.json
@@ -2,6 +2,7 @@
     "ui-chart": {
         "label": {
             "line": "Line",
+            "area": "Area",
             "bar": "Bar",
             "scatter": "Scatter",
             "pie": "Pie",

--- a/nodes/widgets/ui_chart.html
+++ b/nodes/widgets/ui_chart.html
@@ -206,6 +206,7 @@
 
                 // Allowable "X-Axis Type" choices for chart type
                 // line     : time, linear, categorical
+                // area     : time, linear
                 // bar      : categorical (or just hide)
                 // scatter  : time, linear
                 // pie      : radial
@@ -329,7 +330,7 @@
                     const interpolationWrapper = $('#interpolation-wrapper')
                     interpolationWrapper.hide()
 
-                    if (value === 'line' || value === 'scatter') {
+                    if (value === 'line' || value === 'scatter' || value === 'area') {
                         // for line and scatter
                         // types - time, linear
                         const xAxisTypeOptions = value === 'line' ? ['time', 'linear', 'category'] : ['time', 'linear']
@@ -540,6 +541,7 @@
             <label for="node-input-chartType"><i class="fa fa-bar-chart"></i> <span data-i18n="ui-chart.label.type"></span></label>
             <select id="node-input-chartType">
                 <option value="line" data-i18n="ui-chart.label.line"></option>
+                <option value="area" data-i18n="ui-chart.label.area"></option>
                 <option value="bar" data-i18n="ui-chart.label.bar"></option>
                 <option value="scatter" data-i18n="ui-chart.label.scatter"></option>
                 <option value="pie" data-i18n="ui-chart.label.pie"></option>

--- a/nodes/widgets/ui_chart.js
+++ b/nodes/widgets/ui_chart.js
@@ -85,6 +85,13 @@ module.exports = function (RED) {
             config.interpolation = 'linear'
         }
 
+        // if area chart, force stacking, otherwise no stacking if it's not a bar chart
+        if (config.chartType === 'area') {
+            config.stackSeries = true
+        } else if (config.chartType !== 'bar') {
+            config.stackSeries = false
+        }
+
         const evts = {
             // beforeSend will run before messages are sent client-side, as well as before sending on within Node-RED
             // here, we use it to pre-process chart data to format it ready for plotting

--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -236,7 +236,7 @@ export default {
                     },
                     tooltip: {
                         transitionDuration: 0,
-                        trigger: (this.chartType === 'line' || this.chartType === 'bar') ? 'axis' : 'item'
+                        trigger: (this.chartType === 'line' || this.chartType === 'bar' || this.chartType === 'area') ? 'axis' : 'item'
                     },
                     grid: {
                         left: '3%',
@@ -302,6 +302,15 @@ export default {
                     animationDurationUpdate: 0 // minimal animation on data update
                 }
 
+                // if an area chart, set the fill to true
+                if (this.chartType === 'area') {
+                    options.series.forEach(series => {
+                        series.areaStyle = {
+                            opacity: 1
+                        }
+                    })
+                }
+
                 // set timeseries formatting
                 if (this.xAxisType === 'time' && this.props.xAxisFormatType !== 'auto') {
                     const format = this.props.xAxisFormatType === 'custom' ? this.props.xAxisFormat : this.props.xAxisFormatType
@@ -334,6 +343,9 @@ export default {
             const options = this.chart.getOption()
             switch (this.chartType) {
             case 'line':
+                options.tooltip.trigger = 'axis'
+                break
+            case 'area':
                 options.tooltip.trigger = 'axis'
                 break
             case 'scatter':
@@ -484,7 +496,7 @@ export default {
                 // no payload
                 console.log('have no payload')
             }
-            if (this.chartType === 'line' || this.chartType === 'scatter') {
+            if (this.chartType === 'line' || this.chartType === 'area' || this.chartType === 'scatter') {
                 this.limitDataSize(options)
             }
             this.updateChart(options)
@@ -636,6 +648,13 @@ export default {
                         series.symbolSize = this.props.pointRadius || 4
                         series.symbol = chartJStoECharts.symbol(this.props.pointShape)
                         chartJStoECharts.setSmooth(series, this.interpolation)
+                    }
+
+                    // fill the line area if chart type is area
+                    if (this.chartType === 'area') {
+                        series.areaStyle = {
+                            opacity: 0.9
+                        }
                     }
 
                     options.series.push(series)

--- a/ui/src/widgets/ui-chart/helpers/chartJsToECharts.js
+++ b/ui/src/widgets/ui-chart/helpers/chartJsToECharts.js
@@ -33,6 +33,8 @@ export default {
         switch (chartType) {
         case 'line':
             return 'line'
+        case 'area':
+            return 'line'
         case 'bar':
         case 'histogram':
             return 'bar'


### PR DESCRIPTION
## Description

- Fixes the (unwanted) stacking in a line chart
- Adds a new "Area" chart type which does support stacking should users actually want this feature.

### After

<img width="1038" height="958" alt="Screenshot 2025-09-29 at 14 01 07" src="https://github.com/user-attachments/assets/9d936f2d-1b53-4dd1-a173-5d3845110fdd" />

## Related Issue(s)

Fixes #1847
