### PR TITLE
Reduce font size for label (title) to 12.5 for compatibility with chartjs version

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -231,7 +231,7 @@ export default {
                         text: this.props.label,
                         textStyle: {
                             color: textColor,
-                            fontSize: 14 // taken from ChartJS default
+                            fontSize: 12.5
                         }
                     },
                     tooltip: {


### PR DESCRIPTION
## Description

Version 1.28.0 has the font size for the label (title in eCharts) set to 14. This gives a font size larger than in the previous chartjs version, leading to problems such as that in #1885 where the label is too long to fit the space.  This PR reduces the font to 12.5 which appears to that which was used by chartjs.

## Related Issue(s)

Partially fixes #1885

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

