### PR TITLE
Remove wasted space above chart title and adjust legend and grid

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -206,6 +206,7 @@ export default {
                 const options = {
                     title: {
                         text: this.props.label,
+                        top: 0,
                         textStyle: {
                             color: textColor
                         }
@@ -215,7 +216,7 @@ export default {
                     },
                     legend: {
                         show: showLegend,
-                        top: this.hasTitle ? 40 : 0,
+                        top: this.hasTitle ? 30 : 0,
                         textStyle: {
                             color: textColor
                         }
@@ -229,6 +230,7 @@ export default {
                 const options = {
                     title: {
                         text: this.props.label,
+                        top: 0,
                         textStyle: {
                             color: textColor,
                             fontSize: 14 // taken from ChartJS default
@@ -242,11 +244,11 @@ export default {
                         left: '3%',
                         right: '4%',
                         bottom: '0%',
-                        top: this.hasTitle ? (this.props.showLegend ? 70 : 40) : (this.props.showLegend ? 30 : 0)
+                        top: this.hasTitle ? (this.props.showLegend ? 70 : 30) : (this.props.showLegend ? 40 : 0)
                     },
                     legend: {
                         show: showLegend,
-                        top: this.hasTitle ? 40 : 0,
+                        top: this.hasTitle ? 30 : 0,
                         textStyle: {
                             color: textColor
                         }


### PR DESCRIPTION
## Description

Currently (1.28.0) there is a gap above the chart title (label).  This moves the title to the top of the container.

If there is a title but no legend then the grid top is moved up 10px to take advantage of the space.

If there is a legend  and a title then the legend is moved up 10px, but the grid is left where it is, there is then enough space for two rows of legend, which is at least an improvement over the current situation where a second rows overlaps the top of the chart.

If there is a legend but no title, then the grid is shrunk down by 10px to allow room for a second row of legend.

Ideally we should somehow calculate how many rows of legend are needed and adjust the chart top accordingly, whether this is practical I don't know, but this PR does at least allow a second row to be fitted in.

## Related Issue(s)

This is a partial fix of #1885

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

