### PR TITLE
Improve chart legend and title layout

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -244,11 +244,11 @@ export default {
                         left: '3%',
                         right: '4%',
                         bottom: '0%',
-                        top: this.hasTitle ? (this.props.showLegend ? 70 : 30) : (this.props.showLegend ? 40 : 0)
+                        top: this.hasTitle ? (this.props.showLegend ? 70 : 30) : (this.props.showLegend ? 45 : 0)
                     },
                     legend: {
                         show: showLegend,
-                        top: this.hasTitle ? 30 : 0,
+                        top: this.hasTitle ? 20 : 0,
                         textStyle: {
                             color: textColor
                         }


### PR DESCRIPTION
## Description

Minor further tweaks following PR #1888 
Provides a few more pixels below the legend to prevent it impinging on the scale numbers.
Sorry Steve, you merged the original PR literally two minutes before I tried to push these to it.

The chart giving the problems in #1885 now looks like this.
<img width="459" height="371" alt="image" src="https://github.com/user-attachments/assets/e27f9fbe-a48d-443e-be85-fc32b2a647b5" />


## Related Issue(s)

Closes #1885 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

