### PR TITLE
Correct payloads to payload in ui_text.html

### DIFF
--- a/nodes/widgets/ui_text.html
+++ b/nodes/widgets/ui_text.html
@@ -99,7 +99,7 @@
                 color: { value: '#717171' },
                 wrapText: { value: false },
                 className: { value: '' },
-                value: { value: 'payloads', required: false },
+                value: { value: 'payload', required: false },
                 valueType: { value: 'msg' }
             },
             inputs: 1,


### PR DESCRIPTION
## Description

Trivial typo fix to change "payloads" to "payload" in the Value property on the "Edit text node" dialog.

## Related Issue(s)

#1923

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

