### PR TITLE
fix: ensure dashboard editor URL is correctly constructed when Node-RED is running with a custom httpNodeRoot setting

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -315,7 +315,7 @@ async function showDashboardWysiwygEditor (pageId, baseId) {
                     // construct the url to open the layout editor
                     const pathParts = []
                     const trimSlashes = (s) => s.replace(/^\/|\/$/g, '')
-                    const httpRoot = RED.settings.httpNodeRoot;
+                    const httpRoot = RED.settings.httpNodeRoot
                     if (httpRoot && typeof httpRoot === 'string' && httpRoot !== '/') {
                         pathParts.push(trimSlashes(httpRoot))
                     }


### PR DESCRIPTION
More info [here](https://github.com/FlowFuse/node-red-dashboard/issues/1927#issuecomment-3522127843)

