### PR TITLE
Don't save message in datastore unnecessarily

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -32,7 +32,7 @@ function hasProperty (obj, prop) {
  * @param {*} msg
  * @returns true if other properties found
  */
-function hasExtraProps(message) {
+function hasExtraProps (message) {
     const allowed = ['_msgid', 'ui_update', 'class', 'visible', 'enabled']
     const keys = Object.keys(message).filter(key => message[key] !== undefined)
 


### PR DESCRIPTION
## Description

In ui_base.js onInput() each message is stored in the datastore before being sent to the client. This causes a problem if the message contains only msg.ui_update, msg.enabled, or msg.visible, so does not contain a msg.payload value for display.  In those cases, if the message is stored and then the browser is refreshed, the empty payload is sent to the client, causing the display value to be cleared.  Note that ui_update, enabled and visible are handled separately via the state store so do not need to be replayed.

This PR simply prevents the message with no payload from being stored in the data store.

I have looked through all the node types and cannot see any situations in which an empty payload should be replayed, apart from the Chart node, which supplies its own onInput() method which is run first, so the payload will no be empty by the time this code is run.

However, I cannot be certain that there will be no side effects of this change.

## Related Issue(s)

#1892

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

