### PR TITLE
Delete old chart data when replace mode active

### DIFF
--- a/nodes/widgets/ui_chart.js
+++ b/nodes/widgets/ui_chart.js
@@ -203,8 +203,8 @@ module.exports = function (RED) {
                     datastore.save(base, node, [])
                 } else {
                     // delete old data if a replace is being performed.
-                    // This is the case if msg.action is replace 
-                    // or the node is configured for replace and ths is not being overriden by msg.action set to append
+                    // This is the case if msg.action is replace
+                    // or the node is configured for replace and this is not being overriden by msg.action set to append
                     if (msg.action === 'replace' || (config.action === 'replace' && msg.action !== 'append')) {
                         // clear our data store as we are replacing data
                         datastore.save(base, node, [])


### PR DESCRIPTION
## Description

This change was missed off PR #1900
In the chart node, old data should be deleted when replace mode is active. This is true if msg.action is set to 'replace' or the configured action is replace, and this is not being overridden by msg.action

## Related Issue(s)

Completes fix of #1899

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

