### PR TITLE
Reduce padding on Text In, Number and Dropdown widgets to make room in Compact theme

### DIFF
--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -159,6 +159,12 @@ main {
     --v-input-control-height: var(--widget-row-height);
 }
 
+/* Minimal padding for the Text In and Dropdown nodes in order to leave room for the text in compact theme */
+.nrdb-app .v-field--variant-outlined {
+    --v-field-input-padding-top: 2px;
+    --v-field-input-padding-bottom: 2px;
+}
+
 /**
 * Widget: Button
 */


### PR DESCRIPTION
## Description

Reduce padding above and below the text in Number Input, Text Input  and Dropdown nodes (from default 12) so that when Compact (32px) Row Height is selected in theme the bounding box is not expanded larger than the 32px to make room for the text and padding.
The reduced padding does not affect the text placement when larger row height is specified as the text is centred vertically.

## Related Issue(s)

Closes #1935 and #1863

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

