### PR TITLE
Fix Chart node not showing historical data for single series using ["series"] syntax in Series field

### DIFF
--- a/nodes/widgets/ui_chart.js
+++ b/nodes/widgets/ui_chart.js
@@ -184,13 +184,10 @@ module.exports = function (RED) {
                             x = evaluateNodePropertyWithKey(node, msg, payload, config.xAxisProperty, config.xAxisPropertyType)
                         }
                         if (Array.isArray(series)) {
-                            if (series.length > 1) {
-                                y = series.map((s) => {
-                                    return getProperty(payload, s)
-                                })
-                            } else {
-                                y = getProperty(payload, series[0])
-                            }
+                            // if the series is an array then y should be an array too, even if only of length 1
+                            y = series.map((s) => {
+                                return getProperty(payload, s)
+                            })
                         } else {
                             if (config.categoryType === 'json') {
                                 // we are using the "series" as a key to get the y value from the payload


### PR DESCRIPTION
## Description

Fix issue causing chart node not to show historical data when Series is set to a JSON array of only one element.
Currently, in addToChart() this generates y values as numbers rather than an array of length one (one value for each series).  The front end expects an array and ignores the values passed.

## Related Issue(s)

Closes #1975 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

