### PR TITLE
Fix issue #1792 ui_spacer sizer not working

### DIFF
--- a/nodes/widgets/ui_spacer.html
+++ b/nodes/widgets/ui_spacer.html
@@ -77,19 +77,19 @@
     </div>
     <div class="form-row nr-db-ui-element-hide-in-subflow">
         <label><i class="fa fa-object-group"></i> <span data-i18n="ui-base.label.size">Size</label>
-        <button class="editor-button" id="node-input-size"></button>
+        <button class="editor-button" id="node-config-input-size"></button>
     </div>
     <div class="form-row nr-db-ui-element-show-in-subflow">
         <label><i class="fa fa-arrows-h"></i> <span data-i18n="ui-base.label.width">Width</label>
-        <input type="hidden" id="node-input-width">
+        <input type="hidden" id="node-config-input-width">
     </div>
     <div class="form-row nr-db-ui-element-show-in-subflow">
         <label><i class="fa fa-arrows-v"></i> <span data-i18n="ui-base.label.height">Height</label>
-        <input type="hidden" id="node-input-height">
+        <input type="hidden" id="node-config-input-height">
     </div>
     <div class="form-row nr-db-ui-element-show-in-subflow">
         <label><i class="fa fa-arrows"></i> <span data-i18n="ui-base.label.order">Order</label>
-        <input type="text" id="node-input-order">
+        <input type="text" id="node-input-config-order">
     </div>
     <div class="form-row">
         <label for="node-config-input-className"><i class="fa fa-code"></i> <span data-i18n="ui-spacer.label.class"></span></label>


### PR DESCRIPTION
## Description

Corrects element ids in ui_spacer.html, such that spacers can be resized

## Related Issue(s)

Closes #1792

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

