### PR TITLE
Fix typo in ui_table.html that stops the class field from working

### DIFF
--- a/nodes/widgets/ui_table.html
+++ b/nodes/widgets/ui_table.html
@@ -115,7 +115,7 @@
                     // The behaviour in existing nodes was to deselect all items
                     $('#node-input-deselect').prop('checked', true)
                 }
-                // if this groups parent is a subflow template, set the node-config-input-width and node-config-input-height up
+                // if this groups parent is a subflow template, set the node-input-width and node-input-height up
                 // as typedInputs and hide the elementSizer (as it doesn't make sense for subflow templates)
                 if (RED.nodes.subflow(this.z)) {
                     // change inputs from hidden to text & display them
@@ -347,8 +347,8 @@
         <input type="text" id="node-input-label" data-i18n="[placeholder]ui-table.label.optionalTableTitle">
     </div>
     <div class="form-row" id="text-row-class">
-        <label for="node-config-input-className"><i class="fa fa-code"></i> <span data-i18n="ui-table.label.className"></span></label>
-        <input type="text" id="node-config-input-className" data-i18n="[placeholder]ui-table.label.classNamePlaceholder"/>
+        <label for="node-input-className"><i class="fa fa-code"></i> <span data-i18n="ui-table.label.className"></span></label>
+        <input type="text" id="node-input-className" data-i18n="[placeholder]ui-table.label.classNamePlaceholder"/>
     </div>
     <div class="form-row">
         <label for="node-input-maxrows"><i class="fa fa-tag"></i> <span data-i18n="ui-table.label.maxRows"></label>


### PR DESCRIPTION
## Description

Fix probably copy/paste error that stops the class name field from working

## Related Issue(s)

Closes #1961

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

