### PR TITLE
Stop chart `dynamicChartOptions` array growing unrestricted

### DIFF
--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -188,13 +188,16 @@ export default {
             if (!updates) {
                 return
             }
+            // merge the updates into the chart
             if (updates.chartOptions) {
-                // merge the updates into the chart
                 if (this.chart) {
                     this.chart.setOption(updates.chartOptions)
+                    // consolidate the options applied this session
+                    this.dynamicChartOptions = [this.chart.getOption()]
+                } else {
+                    // add these options to the array of previous updates received this session
+                    this.dynamicChartOptions.push(updates.chartOptions)
                 }
-                // add these options to the array of previous updates received this session
-                this.dynamicChartOptions.push(updates.chartOptions)
             }
         },
         generateChartOptions () {


### PR DESCRIPTION
## Description

Consolidates dynamicChartOptions array into a singular row by calling `this.chart.getOption()`

## Related Issue(s)

closes #2012

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

