### PR TITLE
Bump package dependencies and patch version to 1.30.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4706,9 +4706,9 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "13.0.5",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-            "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.0.tgz",
+            "integrity": "sha512-cqfapCxwTGsrR80FEgOoPsTonoefMBY7dnUEbQ+GRcved0jvkJLzvX6F4WtN+HBqbPX/SiFsIRUp+IrCW/2I2w==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -8865,10 +8865,11 @@
             }
         },
         "node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -14112,9 +14113,9 @@
             }
         },
         "node_modules/preact": {
-            "version": "10.27.2",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
-            "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+            "version": "10.28.2",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
+            "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -15352,16 +15353,16 @@
             "dev": true
         },
         "node_modules/sinon": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.0.tgz",
-            "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.1.tgz",
+            "integrity": "sha512-Z0NVCW45W8Mg5oC/27/+fCqIHFnW8kpkFOq0j9XJIev4Ld0mKmERaZv5DMLAb9fGCevjKwaEeIQz5+MBXfZcDw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@sinonjs/commons": "^3.0.1",
-                "@sinonjs/fake-timers": "^13.0.5",
-                "@sinonjs/samsam": "^8.0.1",
-                "diff": "^7.0.0",
+                "@sinonjs/fake-timers": "^15.1.0",
+                "@sinonjs/samsam": "^8.0.3",
+                "diff": "^8.0.2",
                 "supports-color": "^7.2.0"
             },
             "funding": {
@@ -15370,9 +15371,9 @@
             }
         },
         "node_modules/sinon/node_modules/diff": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+            "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -16104,37 +16105,20 @@
             "license": "MIT"
         },
         "node_modules/tar": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-            "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
+            "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
                 "chownr": "^3.0.0",
                 "minipass": "^7.1.2",
-                "minizlib": "^3.0.1",
-                "mkdirp": "^3.0.1",
+                "minizlib": "^3.1.0",
                 "yallist": "^5.0.0"
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/tar/node_modules/mkdirp": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "dist/cjs/src/bin.js"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/tar/node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowfuse/node-red-dashboard",
-    "version": "1.30.1",
+    "version": "1.30.2",
     "description": "FlowFuse Dashboard - A collection of Node-RED nodes that provide functionality to build your own UI applications (inc. forms, buttons, charts).",
     "keywords": [
         "node-red"
@@ -167,6 +167,7 @@
         },
         "esbuild": ">=0.25.0",
         "cross-spawn": "~7.0.5",
-        "js-yaml": ">=4.1.1"
+        "js-yaml": ">=4.1.1",
+        "tar": ">=7.5.4"
     }
 }


### PR DESCRIPTION
## Description

Bumped version in preparation of release.

Updated dependencies to resolve high NPM vulnerabilities check:
before: 
```log
added 1286 packages, and audited 1287 packages in 6s
285 packages are looking for funding

13 vulnerabilities (3 low, 10 high)
```

After:
```log
added 1285 packages, and audited 1286 packages in 6s
284 packages are looking for funding

2 low severity vulnerabilities
```

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

