### PR TITLE
fix: let browser handle navigation requests to support auth proxies

### DIFF
--- a/ui/src/sw.js
+++ b/ui/src/sw.js
@@ -1,37 +1,26 @@
 /// <reference lib="webworker" />
 import { clientsClaim } from 'workbox-core'
-import { cleanupOutdatedCaches, createHandlerBoundToURL, precacheAndRoute } from 'workbox-precaching'
-import { NavigationRoute, registerRoute } from 'workbox-routing'
+import { cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching'
 
-// self.__WB_MANIFEST is the default injection point
-precacheAndRoute(self.__WB_MANIFEST)
+// Navigation requests (request.mode === 'navigate') are intentionally NOT
+// handled by the Service Worker. This lets the browser perform normal network
+// navigation, which is critical when the dashboard sits behind an
+// authentication proxy (Cloudflare Access, OAuth2 Proxy, Authelia, etc.).
+// Without this, the SW would serve a cached index.html, preventing the browser
+// from following HTTP redirects to the login page when the auth session expires.
+//
+// directoryIndex and cleanURLs are disabled so that precacheAndRoute does not
+// implicitly serve index.html for navigation requests to '/dashboard/'.
+// Static assets (JS, CSS, fonts, images) are still served from the precache
+// via exact URL match, so page loads remain fast.
+precacheAndRoute(self.__WB_MANIFEST, {
+    directoryIndex: null,
+    cleanURLs: false
+})
 
 // clean old assets
 cleanupOutdatedCaches()
 
-/** @type {RegExp[] | undefined} */
-const denylist = []
-
-// in dev mode, do not precache anything
-if (import.meta.env.DEV) {
-    // don't precache anything
-    console.log('Development mode, not pre-caching anything')
-    denylist.push(/.*/)
-} else {
-    // don't precache anything where the urls pathname ends with a slash (including times when the url has a query string)
-    // this permits the request to be handled by the server which will do a redirect as required
-    const configPath = self.location.pathname.split('/')[1]
-    denylist.push(new RegExp(`/${configPath}/[^?]*/(\\?.*)*$`))
-}
-
-// to allow work offline for allowed routes only
-registerRoute(new NavigationRoute(
-    createHandlerBoundToURL('index.html'),
-    { denylist }
-))
-
 self.skipWaiting()
 // https://developer.mozilla.org/en-US/docs/Web/API/Clients/claim
 clientsClaim()
-
-// Add custom service worker code here


### PR DESCRIPTION
## Description

When the dashboard is deployed behind an authentication proxy (Cloudflare Access, OAuth2 Proxy, Authelia, etc.), the service worker intercepts all navigation requests and serves a cached `index.html`. This prevents the browser from following the proxy's HTTP redirect to the login page when the auth session expires, resulting in "There was an error loading the Dashboard."

Remove the `NavigationRoute` registration so the service worker never handles navigation requests. The browser performs normal network navigation and can follow auth redirects naturally.
To prevent `precacheAndRoute` from implicitly serving `index.html` for navigation requests (via its `directoryIndex` and `cleanURLs` defaults), both options are explicitly disabled.
Static asset requests (JS, CSS, fonts, images) are unaffected, they are not navigation requests and continue to be served from the precache via exact URL match.

## Testing
Tested behind Cloudflare Access (Zero Trust) with Google IdP:
- Auth session expiry → browser redirects to login page → re-authentication returns to dashboard
- Static assets still served from precache

## Related Issue(s)

Fixes #2068

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass 
 Unsure how we would write tests for the service worker.
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

