### PR TITLE
Add opt-in inactivity expiry for ui-chart series/topics

### DIFF
--- a/nodes/widgets/ui_chart.html
+++ b/nodes/widgets/ui_chart.html
@@ -123,6 +123,8 @@
                 removeOlder: { value: 1, validate: RED.validators.number(), required: true },
                 removeOlderUnit: { value: '3600', required: true },
                 removeOlderPoints: { value: '', validate: function (value) { return numberValidator(value, true) } },
+                removeInactive: { value: false },
+                removeInactiveAfter: { value: 60, validate: RED.validators.number(), required: true },
                 colors: { value: ['#0095FF', '#FF0000', '#FF7F0E', '#2CA02C', '#A347E1', '#D62728', '#FF9896', '#9467BD', '#C5B0D5'] },
                 textColor: { value: ['#666666'] },
                 textColorDefault: { value: true },
@@ -460,6 +462,13 @@
                 } else {
                     $('#node-input-interpolation').val('linear')
                 }
+
+                const toggleRemoveInactiveAfter = function () {
+                    $('#node-input-removeInactiveAfter').prop('disabled', !$('#node-input-removeInactive').prop('checked'))
+                }
+
+                $('#node-input-removeInactive').on('change', toggleRemoveInactiveAfter)
+                toggleRemoveInactiveAfter()
             },
             oneditsave: function () {
                 // Stack By - convert from string values to bool
@@ -576,6 +585,13 @@
             <option value="append" data-i18n="ui-chart.label.append"></option>
             <option value="replace" data-i18n="ui-chart.label.replace"></option>
         </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-removeInactive"><i class="fa fa-clock-o"></i> Remove Inactive Series</label>
+        <input type="checkbox" id="node-input-removeInactive" style="display: inline-block; width: auto; margin: 0px 0px 0px 4px;">
+        <label for="node-input-removeInactiveAfter" style="width:auto; margin-left:12px;">after</label>
+        <input type="number" id="node-input-removeInactiveAfter" style="width:80px;" min="1">
+        <span style="margin-left:5px;">seconds</span>
     </div>
     <div class="form-row form-row-flex" id="point-radius-show">
         <label for="node-input-pointRadius" data-i18n="ui-chart.label.pointStyle"></label>

--- a/nodes/widgets/ui_chart.js
+++ b/nodes/widgets/ui_chart.js
@@ -24,6 +24,9 @@ module.exports = function (RED) {
         if (typeof config.xmax !== 'undefined') {
             config.xmax = parseFloat(config.xmax)
         }
+        if (typeof config.removeInactiveAfter !== 'undefined') {
+            config.removeInactiveAfter = parseFloat(config.removeInactiveAfter)
+        }
 
         node.clearHistory = function () {
             const empty = []
@@ -50,6 +53,86 @@ module.exports = function (RED) {
                 }
             })
             return value
+        }
+
+        function getSeriesKey (series) {
+            return JSON.stringify(series)
+        }
+
+        function getSeriesTimestamp (msg, fallback = Date.now()) {
+            if (typeof msg?._uiChartReceivedAt === 'number' && Number.isFinite(msg._uiChartReceivedAt)) {
+                return msg._uiChartReceivedAt
+            }
+
+            const timestamp = msg?._datapoint?.x
+            if (typeof timestamp === 'number' && Number.isFinite(timestamp)) {
+                return timestamp
+            }
+            if (typeof timestamp === 'string') {
+                const parsed = (new Date(timestamp)).getTime()
+                if (!Number.isNaN(parsed)) {
+                    return parsed
+                }
+            }
+
+            return fallback
+        }
+
+        function collectActiveSeries (datapoints) {
+            const activeSeries = new Set()
+            const points = Array.isArray(datapoints) ? datapoints : [datapoints]
+
+            points.forEach((point) => {
+                const category = point?.category
+                if (category !== null && typeof category !== 'undefined') {
+                    activeSeries.add(getSeriesKey(category))
+                }
+            })
+
+            return activeSeries
+        }
+
+        function clearInactiveSeries (activeSeries = new Set()) {
+            if (!config.removeInactive || !(config.removeInactiveAfter > 0)) {
+                return
+            }
+
+            const cutOff = Date.now() - (config.removeInactiveAfter * 1000)
+            const points = datastore.get(node.id) || []
+            const latestBySeries = new Map()
+
+            points.forEach((point) => {
+                const category = point?._datapoint?.category
+                if (category === null || typeof category === 'undefined') {
+                    return
+                }
+
+                const key = getSeriesKey(category)
+                const timestamp = getSeriesTimestamp(point)
+                const latest = latestBySeries.get(key)
+
+                if (!latest || latest < timestamp) {
+                    latestBySeries.set(key, timestamp)
+                }
+            })
+
+            const inactiveSeries = new Set()
+            latestBySeries.forEach((timestamp, key) => {
+                if (timestamp <= cutOff && !activeSeries.has(key)) {
+                    inactiveSeries.add(key)
+                }
+            })
+
+            if (inactiveSeries.size > 0) {
+                datastore.filter(base, node, (point) => {
+                    const category = point?._datapoint?.category
+                    if (category === null || typeof category === 'undefined') {
+                        return true
+                    }
+
+                    return !inactiveSeries.has(getSeriesKey(category))
+                })
+            }
         }
 
         /**
@@ -235,6 +318,7 @@ module.exports = function (RED) {
                         // clear history
                         datastore.save(base, node, [])
                     } else {
+                        const receivedAt = Date.now()
                         // delete old data if a replace is being performed.
                         // This is the case if msg.action is replace
                         // or the node is configured for replace and this is not being overriden by msg.action set to append
@@ -245,7 +329,8 @@ module.exports = function (RED) {
                         if (!Array.isArray(msg.payload)) {
                             // quick clone of msg, and store in history
                             datastore.append(base, node, {
-                                ...msg
+                                ...msg,
+                                _uiChartReceivedAt: receivedAt
                             })
                         } else {
                             // we have an array in msg.payload, let's split them
@@ -255,7 +340,8 @@ module.exports = function (RED) {
                                 const m = {
                                     ...msg,
                                     payload,
-                                    _datapoint: d
+                                    _datapoint: d,
+                                    _uiChartReceivedAt: receivedAt
                                 }
                                 datastore.append(base, node, m)
                             })
@@ -301,6 +387,8 @@ module.exports = function (RED) {
                             // each category in each series
                             clearOldCategoricalPoints()
                         }
+
+                        clearInactiveSeries(collectActiveSeries(msg._datapoint))
                     }
                 }
 

--- a/ui/src/store/data.mjs
+++ b/ui/src/store/data.mjs
@@ -45,6 +45,21 @@ const mutations = {
             state.messages[widgetId].push(data.msg)
         }
     },
+    deleteSeriesMessages (state, data) {
+        const widgetId = data.widgetId
+        const seriesKey = JSON.stringify(data.series)
+
+        if (Array.isArray(state.messages[widgetId])) {
+            state.messages[widgetId] = state.messages[widgetId].filter((msg) => {
+                const msgSeries = msg.series ?? msg._datapoint?.category
+                return JSON.stringify(msgSeries) !== seriesKey
+            })
+
+            if (state.messages[widgetId].length === 0) {
+                delete state.messages[widgetId]
+            }
+        }
+    },
     /**
      *
      * @param {*} state

--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -35,7 +35,9 @@ export default {
             chartUpdateDebounceTimeout: null,
             tooltipDataset: [],
             dynamicChartOptions: [], // an array of chart options updates received this session
-            resizeObserver: null
+            resizeObserver: null,
+            inactiveSeriesTimers: {},
+            seriesActivity: {}
         }
     },
     computed: {
@@ -128,6 +130,7 @@ export default {
         }
     },
     beforeUnmount () {
+        this.clearInactiveSeriesTimers()
         // Cleanup resize observer
         if (this.resizeObserver) {
             this.resizeObserver.disconnect()
@@ -474,7 +477,156 @@ export default {
         clearDataStore () {
             this.$store.commit('data/deleteMessages', { widgetId: this.id })
         },
+        getSeriesKey (label) {
+            return JSON.stringify(label)
+        },
+        getMessageTimestamp (msg) {
+            if (typeof msg?._uiChartReceivedAt === 'number' && Number.isFinite(msg._uiChartReceivedAt)) {
+                return msg._uiChartReceivedAt
+            }
+
+            return Date.now()
+        },
+        isInactiveSeriesRemovalEnabled () {
+            const timeout = parseFloat(this.props.removeInactiveAfter)
+            return this.props.removeInactive === true && Number.isFinite(timeout) && timeout > 0
+        },
+        getInactiveSeriesTimeout () {
+            return parseFloat(this.props.removeInactiveAfter) * 1000
+        },
+        clearInactiveSeriesTimers () {
+            Object.values(this.inactiveSeriesTimers).forEach((timer) => {
+                clearTimeout(timer)
+            })
+            this.inactiveSeriesTimers = {}
+            this.seriesActivity = {}
+        },
+        clearInactiveSeriesTimer (seriesKey) {
+            if (this.inactiveSeriesTimers[seriesKey]) {
+                clearTimeout(this.inactiveSeriesTimers[seriesKey])
+                delete this.inactiveSeriesTimers[seriesKey]
+            }
+        },
+        updateSeriesActivity (label, receivedAt) {
+            if (!this.isInactiveSeriesRemovalEnabled()) {
+                return
+            }
+
+            const seriesKey = this.getSeriesKey(label)
+            this.seriesActivity[seriesKey] = {
+                label,
+                lastSeen: receivedAt
+            }
+            this.scheduleInactiveSeriesRemoval(label)
+        },
+        scheduleInactiveSeriesRemoval (label) {
+            if (!this.isInactiveSeriesRemovalEnabled()) {
+                return
+            }
+
+            const seriesKey = this.getSeriesKey(label)
+            const activity = this.seriesActivity[seriesKey]
+            if (!activity) {
+                return
+            }
+
+            this.clearInactiveSeriesTimer(seriesKey)
+
+            const timeout = this.getInactiveSeriesTimeout()
+            const delay = Math.max(0, timeout - (Date.now() - activity.lastSeen))
+
+            this.inactiveSeriesTimers[seriesKey] = setTimeout(() => {
+                const latestActivity = this.seriesActivity[seriesKey]
+                if (!latestActivity) {
+                    return
+                }
+
+                if ((Date.now() - latestActivity.lastSeen) >= this.getInactiveSeriesTimeout()) {
+                    this.removeSeries(label)
+                } else {
+                    this.scheduleInactiveSeriesRemoval(latestActivity.label)
+                }
+            }, delay)
+        },
+        pruneInactiveSeries () {
+            if (!this.isInactiveSeriesRemovalEnabled()) {
+                return
+            }
+
+            const now = Date.now()
+            const timeout = this.getInactiveSeriesTimeout()
+
+            Object.values(this.seriesActivity).forEach((activity) => {
+                if ((now - activity.lastSeen) >= timeout) {
+                    this.removeSeries(activity.label)
+                }
+            })
+        },
+        updateRadialSeriesAppearance (options) {
+            options.series.forEach((series, index) => {
+                series.radius = pieCharts.getRadius(this.props.chartType, index, options.series.length)
+                if (index !== options.series.length - 1) {
+                    series.label = {
+                        show: false
+                    }
+                    series.emphasis = {
+                        label: {
+                            show: false
+                        }
+                    }
+                } else {
+                    series.label = {
+                        show: true
+                    }
+                    series.emphasis = {
+                        label: {
+                            show: true
+                        }
+                    }
+                }
+            })
+        },
+        removeSeries (label) {
+            const seriesKey = this.getSeriesKey(label)
+            this.clearInactiveSeriesTimer(seriesKey)
+            delete this.seriesActivity[seriesKey]
+
+            const options = this.chart.getOption()
+            const seriesIndex = options.series.findIndex((series) => this.getSeriesKey(series.name) === seriesKey)
+
+            if (seriesIndex === -1) {
+                return
+            }
+
+            options.series.splice(seriesIndex, 1)
+
+            if (this.props.chartType === 'histogram') {
+                this.histogram.bins.splice(seriesIndex, 1)
+            }
+
+            this.$store.commit('data/deleteSeriesMessages', {
+                widgetId: this.id,
+                series: label
+            })
+
+            if (options.series.length === 0) {
+                this.clearChart()
+                return
+            }
+
+            if (this.props.xAxisType === 'radial') {
+                this.updateRadialSeriesAppearance(options)
+            }
+
+            this.hasData = options.series.some((series) => Array.isArray(series.data) && series.data.length > 0)
+            this.chart.setOption(options, {
+                notMerge: true,
+                lazyUpdate: true,
+                silent: true
+            })
+        },
         clearChart () {
+            this.clearInactiveSeriesTimers()
             const option = this.chart.getOption()
             if (this.props.xAxisType === 'radial') {
                 option.series.forEach(s => {
@@ -504,6 +656,7 @@ export default {
          */
         add (msg) {
             const payload = msg.payload
+            const receivedAt = this.getMessageTimestamp(msg)
 
             const options = this.chart.getOption()
             // determine what type of msg we have
@@ -514,7 +667,7 @@ export default {
                     const d = m._datapoint // server-side we compute a chart friendly format
                     const label = d.category
                     if (label !== null && label !== undefined) {
-                        this.addPoints(p, d, label, options)
+                        this.addPoints(p, d, label, options, this.getMessageTimestamp(m))
                     }
                 })
             } else if (Array.isArray(payload) && msg.payload.length > 0) {
@@ -524,7 +677,7 @@ export default {
                     const d = msg._datapoint ? msg._datapoint[i] : null // server-side we compute a chart friendly format where required
                     const label = d.category
                     if (label !== null && label !== undefined) {
-                        this.addPoints(p, d, label, options)
+                        this.addPoints(p, d, label, options, receivedAt)
                     }
                 })
             } else if (payload !== null && payload !== undefined) {
@@ -534,14 +687,14 @@ export default {
                     msg._datapoint.forEach((d) => {
                         const label = d.category
                         if (label !== null && label !== undefined) {
-                            this.addPoints(msg.payload, d, label, options)
+                            this.addPoints(msg.payload, d, label, options, receivedAt)
                         }
                     })
                 } else {
                     const d = msg._datapoint // server-side we compute a chart friendly format
                     const label = d.category
                     if (label !== null && label !== undefined) {
-                        this.addPoints(msg.payload, d, label, options)
+                        this.addPoints(msg.payload, d, label, options, receivedAt)
                     }
                 }
             } else {
@@ -556,6 +709,7 @@ export default {
                 this.limitDataSize(options)
             }
             this.updateChart(options)
+            this.pruneInactiveSeries()
         },
         /**
          * Add points to the chart
@@ -564,7 +718,7 @@ export default {
          * @param {*} label
          * @param {*} options - existing eChart options object
          */
-        addPoints (payload, datapoint, label, options) {
+        addPoints (payload, datapoint, label, options, receivedAt) {
             const d = { ...datapoint, ...payload }
             if (!this.chart.config?.options?.parsing?.xAxisKey) {
                 d.x = datapoint.x // if there is no mapping key, ensure server side computed datapoint.x is used
@@ -582,21 +736,24 @@ export default {
                     dd.category = d.category[i]
                     dd.y = d.y[i]
                     options = this.addToChart(dd, label[i], options)
-                    this.commit(payload, dd, label[i])
+                    this.commit(payload, dd, label[i], receivedAt)
+                    this.updateSeriesActivity(label[i], receivedAt)
                 }
             } else {
                 options = this.addToChart(d, label, options)
-                this.commit(payload, datapoint, label)
+                this.commit(payload, datapoint, label, receivedAt)
+                this.updateSeriesActivity(label, receivedAt)
             }
         },
-        commit (payload, datapoint, label) {
+        commit (payload, datapoint, label, receivedAt) {
             // APPEND our latest data point to the store
             this.$store.commit('data/append', {
                 widgetId: this.id,
                 msg: {
                     payload,
                     _datapoint: datapoint,
-                    series: label
+                    series: label,
+                    _uiChartReceivedAt: receivedAt
                 }
             })
         },
@@ -658,31 +815,7 @@ export default {
                 options.series[sIndex].data = existingData
 
                 // update the radius for each series depending on the number of series
-                options.series.forEach((s, i) => {
-                    s.radius = pieCharts.getRadius(this.props.chartType, i, options.series.length)
-                    // only show the label on the outer series
-                    if (i !== options.series.length - 1) {
-                        // don't show the label on the inner series as they overlap with the outer series
-                        s.label = {
-                            show: false
-                        }
-                        s.emphasis = {
-                            label: {
-                                show: false
-                            }
-                        }
-                    } else {
-                        // make sure we're updating in case we have a new series, and now there is a new outer series
-                        s.label = {
-                            show: true
-                        }
-                        s.emphasis = {
-                            label: {
-                                show: true
-                            }
-                        }
-                    }
-                })
+                this.updateRadialSeriesAppearance(options)
             } else {
                 // Handle regular charts (line, bar, scatter)
                 const sLabels = options.series.map(s => s.name)


### PR DESCRIPTION
## Summary
- add an opt-in ui-chart setting to expire inactive series/topics after a configurable timeout
- remove only the inactive series from chart state so active series remain untouched
- preserve existing ui-chart behavior when the option is disabled

Refs issue #2090