### PR TITLE
feat: add icons to tile gauges

### DIFF
--- a/cypress/fixtures/flows/dashboard-gauges.json
+++ b/cypress/fixtures/flows/dashboard-gauges.json
@@ -71,6 +71,7 @@
         "title": "Tile",
         "units": "",
         "icon": "home",
+        "iconPosition": "top",
         "prefix": "",
         "suffix": "%",
         "segments": [
@@ -286,5 +287,117 @@
         "x": 100,
         "y": 180,
         "wires": []
+    },
+    {
+        "id": "dashboard-ui-gauge-tile-update-icon",
+        "type": "ui-button",
+        "z": "node-red-tab-gauges",
+        "group": "dashboard-ui-group",
+        "name": "Update Tile Icon",
+        "label": "Update Tile Icon",
+        "order": 10,
+        "width": 0,
+        "height": 0,
+        "emulateClick": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 100,
+        "y": 240,
+        "wires": [
+            [
+                "dashboard-ui-gauge-tile-change-icon"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-gauge-tile-change-icon",
+        "type": "change",
+        "z": "node-red-tab-gauges",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "ui_update.icon",
+                "pt": "msg",
+                "to": "earth",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 320,
+        "y": 240,
+        "wires": [
+            [
+                "dashboard-ui-gauge-tile"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-gauge-tile-update-icon-pos",
+        "type": "ui-button",
+        "z": "node-red-tab-gauges",
+        "group": "dashboard-ui-group",
+        "name": "Update Tile Icon Position",
+        "label": "Update Tile Icon Position",
+        "order": 11,
+        "width": 0,
+        "height": 0,
+        "emulateClick": false,
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "iconPosition": "left",
+        "payload": "",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 100,
+        "y": 280,
+        "wires": [
+            [
+                "dashboard-ui-gauge-tile-change-icon-pos"
+            ]
+        ]
+    },
+    {
+        "id": "dashboard-ui-gauge-tile-change-icon-pos",
+        "type": "change",
+        "z": "node-red-tab-gauges",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "ui_update.iconPosition",
+                "pt": "msg",
+                "to": "left",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 320,
+        "y": 280,
+        "wires": [
+            [
+                "dashboard-ui-gauge-tile"
+            ]
+        ]
     }
 ]

--- a/cypress/tests/widgets/gauge-tile.spec.js
+++ b/cypress/tests/widgets/gauge-tile.spec.js
@@ -36,7 +36,7 @@ describe('Node-RED Dashboard 2.0 - Gauges - Tile', () => {
     })
     it('inject 100 should display Segment 5 (no label, white)', () => {
         cy.clickAndWait(cy.get('button').contains('button100'))
-        cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile > div > label').should('have.text', '') // no label is displayed
+        cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile > div > label').should('not.exist') // no label is displayed
         cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile > div').should('have.css', 'background-color', 'rgb(255, 255, 255)') // white
     })
 })

--- a/cypress/tests/widgets/gauge.spec.js
+++ b/cypress/tests/widgets/gauge.spec.js
@@ -12,4 +12,37 @@ describe('Node-RED Dashboard 2.0 - Gauges', () => {
         cy.get('#nrdb-ui-widget-dashboard-ui-gauge-battery').find('.nrdb-ui-gauge-battery').should('exist')
         cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tank').find('.nrdb-ui-gauge-tank').should('exist')
     })
+
+    it('renders the configured icon on the tile gauge', () => {
+        cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile').find('i.v-icon').should('have.class', 'mdi-home')
+    })
+
+    it('applies the configured iconPosition class on the tile gauge', () => {
+        cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile')
+            .find('.nrdb-ui-gauge-tile')
+            .should('have.class', 'nrdb-ui-gauge-tile--icon-top')
+    })
+})
+
+describe('Node-RED Dashboard 2.0 - Gauges (Dynamic Properties)', () => {
+    beforeEach(() => {
+        cy.deployFixture('dashboard-gauges')
+        cy.visit('/dashboard/page1')
+    })
+
+    it('updates the tile gauge "icon" via msg.ui_update', () => {
+        cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile').find('i.v-icon').should('have.class', 'mdi-home')
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile-update-icon'))
+        cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile').find('i.v-icon').should('have.class', 'mdi-earth')
+    })
+
+    it('updates the tile gauge "iconPosition" via msg.ui_update', () => {
+        cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile')
+            .find('.nrdb-ui-gauge-tile')
+            .should('have.class', 'nrdb-ui-gauge-tile--icon-top')
+        cy.clickAndWait(cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile-update-icon-pos'))
+        cy.get('#nrdb-ui-widget-dashboard-ui-gauge-tile')
+            .find('.nrdb-ui-gauge-tile')
+            .should('have.class', 'nrdb-ui-gauge-tile--icon-left')
+    })
 })

--- a/docs/de/nodes/widgets/ui-gauge.md
+++ b/docs/de/nodes/widgets/ui-gauge.md
@@ -34,7 +34,10 @@ props:
         description: Kleiner Text, der unter dem Wert in der Mitte des Messgeräts angezeigt wird. (nur anwendbar für 3/4 und Halb-Messgeräte)
         dynamic: true
     Symbol:
-        description: Symbol, das unter dem Wert in der Mitte des Messgeräts angezeigt wird. Verwendet <a href="https://pictogrammers.com/library/mdi/">Material Designs Icon</a>, das Präfix <code>mdi-</code> muss nicht enthalten sein. (nur anwendbar für 3/4 und Halb-Messgeräte)
+        description: Symbol, das im Messgerät angezeigt wird. Verwendet <a href="https://pictogrammers.com/library/mdi/">Material Designs Icon</a>, das Präfix <code>mdi-</code> muss nicht enthalten sein. Bei 3/4- und Halb-Messgeräten wird das Symbol unterhalb des Wertes angezeigt; bei Kachel-Messgeräten richtet sich die Position nach "Symbolposition".
+        dynamic: true
+    Symbolposition:
+        description: (nur anwendbar für Kachel-Messgeräte) Wo das Symbol relativ zum Segmenttext angezeigt wird. Eines von "top", "bottom", "left" oder "right". Standard ist "top".
         dynamic: true
     Größen (Messgerät): (px) Wie dick der Bogen und die Hintergrundkulisse des Messgeräts gerendert werden.
     Größen (Lücke): (px) Wie groß der Abstand/die Polsterung zwischen dem Messgerät und den "Segmenten" ist.
@@ -50,6 +53,10 @@ dynamic:
     Symbol:
         payload: msg.ui_update.icon
         structure: ["String"]
+    Symbolposition:
+        payload: msg.ui_update.iconPosition
+        structure: ["String"]
+        examples: ['top', 'bottom', 'left', 'right']
     Typ:
         payload: msg.ui_update.gtype
         structure: ["String"]

--- a/docs/en/nodes/widgets/ui-gauge.md
+++ b/docs/en/nodes/widgets/ui-gauge.md
@@ -40,7 +40,10 @@ props:
         description: Small text to be shown below the value in the middle of the gauge. (only applicable to for 3/4 and Half gauges)
         dynamic: true
     Icon:
-        description: Icon to be shown below the value in the middle of the gauge. Uses <a href="https://pictogrammers.com/library/mdi/">Material Designs Icon</a>, no need to include the <code>mdi-</code> prefix. (only applicable to for 3/4 and Half gauges)
+        description: Icon to be shown on the gauge. Uses <a href="https://pictogrammers.com/library/mdi/">Material Designs Icon</a>, no need to include the <code>mdi-</code> prefix. For 3/4 and Half gauges, the icon is rendered below the value; for Tile gauges, the icon is positioned according to "Icon Position".
+        dynamic: true
+    Icon Position:
+        description: (only applicable to Tile gauges) Where the icon is rendered relative to the segment text. One of "top", "bottom", "left", or "right". Defaults to "top".
         dynamic: true
     Sizes (Gauge): (px) How thick the arc and backdrop of the gauge are rendered.
     Sizes (Gap): (px) How big the gap/padding is between the Gauge and the "Segments"
@@ -56,6 +59,10 @@ dynamic:
     Icon:
         payload: msg.ui_update.icon
         structure: ["String"]
+    Icon Position:
+        payload: msg.ui_update.iconPosition
+        structure: ["String"]
+        examples: ['top', 'bottom', 'left', 'right']
     Type:
         payload: msg.ui_update.gtype
         structure: ["String"]

--- a/nodes/widgets/locales/de/ui_gauge.html
+++ b/nodes/widgets/locales/de/ui_gauge.html
@@ -69,7 +69,9 @@
         <dt class="optional">units <span class="property-type">array</span></dt>
         <dd>Steuert die "Einheit"-Anzeige unter dem Wert des Messgeräts für 3/4- und Halb-Messgeräte (nur anwendbar für 3/4- und Halb-Messgeräte)</dd>
         <dt class="optional">icon <span class="property-type">string</span></dt>
-        <dd>Ändern Sie, welches Symbol im Messgerät gerendert wird (muss ein Material Design-Symbol sein und nur anwendbar für 3/4- und Halb-Messgeräte)</dd>
+        <dd>Ändern Sie, welches Symbol im Messgerät gerendert wird (muss ein Material Design-Symbol sein, anwendbar für 3/4-, Halb- und Kachel-Messgeräte)</dd>
+        <dt class="optional">iconPosition <span class="property-type">string</span></dt>
+        <dd>Position des Symbols relativ zum Segmenttext bei einem Kachel-Messgerät. Eines von "top", "bottom", "left" oder "right".</dd>
         <dt class="optional">class <span class="property-type">string</span></dt>
         <dd>Fügen Sie zur Laufzeit eine oder mehrere CSS-Klassen zur Schaltfläche hinzu.</dd>
     </dl>

--- a/nodes/widgets/locales/de/ui_gauge.json
+++ b/nodes/widgets/locales/de/ui_gauge.json
@@ -29,6 +29,11 @@
             "class": "Klasse",
             "units": "Einheiten",
             "icon": "Symbol",
+            "iconPosition": "Symbolposition",
+            "top": "Oben",
+            "bottom": "Unten",
+            "left": "Links",
+            "right": "Rechts",
             "defaults": "Standards"
         },
         "errors": {

--- a/nodes/widgets/locales/en-US/ui_gauge.html
+++ b/nodes/widgets/locales/en-US/ui_gauge.html
@@ -84,7 +84,9 @@
         <dt class="optional">units <span class="property-type">array</span></dt>
         <dd>Controls the "unit" display underneath the gauge's value for 3/4 and Half gauges (only applicable to for 3/4 and Half gauges)</dd>
         <dt class="optional">icon <span class="property-type">string</span></dt>
-        <dd>Modify which icon is rendered within the gauge (must be a Material Design icon and only applicable to for 3/4 and Half gauges)</dd>
+        <dd>Modify which icon is rendered within the gauge (must be a Material Design icon, applicable to 3/4, Half, and Tile gauges)</dd>
+        <dt class="optional">iconPosition <span class="property-type">string</span></dt>
+        <dd>Where the icon is positioned relative to the segment text on a Tile gauge. One of "top", "bottom", "left", or "right".</dd>
         <dt class="optional">class <span class="property-type">string</span></dt>
         <dd>Add a CSS class, or more, to the Button at runtime.</dd>
     </dl>

--- a/nodes/widgets/locales/en-US/ui_gauge.json
+++ b/nodes/widgets/locales/en-US/ui_gauge.json
@@ -29,6 +29,11 @@
             "class": "Class",
             "units": "Units",
             "icon": "Icon",
+            "iconPosition": "Icon Position",
+            "top": "Top",
+            "bottom": "Bottom",
+            "left": "Left",
+            "right": "Right",
             "defaults": "Defaults",
             "value": "Value"
         },

--- a/nodes/widgets/ui_gauge.html
+++ b/nodes/widgets/ui_gauge.html
@@ -161,6 +161,7 @@
                 floatingTitlePosition: { value: 'top-left' },
                 units: { value: 'units' },
                 icon: { value: '' },
+                iconPosition: { value: 'top' },
                 prefix: { value: '' },
                 suffix: { value: '' },
                 segments: {
@@ -256,14 +257,17 @@
                         $('#node-input-container-label-extras').hide()
                         if (type === 'gauge-tile') {
                             $('#node-input-container-tile-options').show()
+                            $('#ui-gauge-icon').show()
                         } else {
                             $('#node-input-container-tile-options').hide()
+                            $('#ui-gauge-icon').hide()
                         }
                     } else {
                         $('#node-input-container-sizes').show()
                         $('#node-input-container-gstyle').show()
                         $('#node-input-container-label-extras').show()
                         $('#node-input-container-tile-options').hide()
+                        $('#ui-gauge-icon').show()
                     }
 
                     if (isInitialised && isChanging && isDefault(oldType)) {
@@ -482,10 +486,16 @@
                 <label for="node-input-units"><i class="fa fa-calculator"></i> <span data-i18n="ui-gauge.label.units"></span></label>
                 <input type="text" id="node-input-units" placeholder="Unit">
             </div>
-            <div class="form-row" id="ui-gauge-icon">
-                <label for="node-input-icon"><i class="fa fa-home"></i> <span data-i18n="ui-gauge.label.icon"></span></label>
-                <input type="text" id="node-input-icon" placeholder="Icon from mdi library, e.g. 'home'">
-            </div>
+        </div>
+        <div class="form-row" id="ui-gauge-icon">
+            <label for="node-input-icon"><i class="fa fa-home"></i> <span data-i18n="ui-gauge.label.icon"></span></label>
+            <input type="text" id="node-input-icon" style="width: calc(70% - 140px);" placeholder="Icon from mdi library, e.g. 'home'">
+            <select id="node-input-iconPosition" style="width: 130px; margin-left: 6px;">
+                <option value="top" data-i18n="ui-gauge.label.top"></option>
+                <option value="left" data-i18n="ui-gauge.label.left"></option>
+                <option value="right" data-i18n="ui-gauge.label.right"></option>
+                <option value="bottom" data-i18n="ui-gauge.label.bottom"></option>
+            </select>
         </div>
     </div>
     <div id="node-input-container-sizes">

--- a/nodes/widgets/ui_gauge.js
+++ b/nodes/widgets/ui_gauge.js
@@ -48,6 +48,10 @@ module.exports = function (RED) {
                         // dynamically set "icon" property
                         statestore.set(group.getBase(), node, msg, 'icon', updates.icon)
                     }
+                    if (typeof updates.iconPosition !== 'undefined') {
+                        // dynamically set "iconPosition" property
+                        statestore.set(group.getBase(), node, msg, 'iconPosition', updates.iconPosition)
+                    }
                     if (typeof updates.segments !== 'undefined') {
                         // dynamically set "segments" property
                         statestore.set(group.getBase(), node, msg, 'segments', updates.segments)

--- a/ui/src/widgets/ui-gauge/UIGauge.vue
+++ b/ui/src/widgets/ui-gauge/UIGauge.vue
@@ -55,6 +55,9 @@ export default {
         icon () {
             return this.getProperty('icon')
         },
+        iconPosition () {
+            return this.getProperty('iconPosition')
+        },
         segments () {
             return this.getProperty('segments')
         },
@@ -74,6 +77,7 @@ export default {
                 suffix: this.suffix,
                 units: this.units,
                 icon: this.icon,
+                iconPosition: this.iconPosition,
                 segments: this.segments,
                 min: this.min,
                 max: this.max
@@ -106,6 +110,7 @@ export default {
             this.updateDynamicProperty('suffix', updates.suffix)
             this.updateDynamicProperty('units', updates.units)
             this.updateDynamicProperty('icon', updates.icon)
+            this.updateDynamicProperty('iconPosition', updates.iconPosition)
             this.updateDynamicProperty('segments', updates.segments)
             this.updateDynamicProperty('min', updates.min)
             this.updateDynamicProperty('max', updates.max)

--- a/ui/src/widgets/ui-gauge/types/UIGaugeTile.vue
+++ b/ui/src/widgets/ui-gauge/types/UIGaugeTile.vue
@@ -1,6 +1,7 @@
 <template>
-    <div class="nrdb-ui-gauge-tile" :style="{'background-color': segment.color, 'color': segment.textColor}" @click="onClick">
-        <label>{{ segment.text }}</label>
+    <div class="nrdb-ui-gauge-tile" :class="`nrdb-ui-gauge-tile--icon-${iconPosition}`" :style="{'background-color': segment.color, 'color': segment.textColor}" @click="onClick">
+        <v-icon v-if="mdiIcon" class="nrdb-ui-gauge-tile-icon" :icon="mdiIcon" />
+        <label v-if="segment.text">{{ segment.text }}</label>
         <span v-if="props.alwaysShowTitle" class="nrdb-ui-gauge-tile-floating-label" :style="floatingPosition">{{ props.label }}</span>
     </div>
 </template>
@@ -40,6 +41,17 @@ export default {
                 textColor: segment?.textColor ?? 'var(--v-theme-on-primary)',
                 from: segment?.from ?? 0
             }
+        },
+        mdiIcon () {
+            const icon = this.props.icon
+            if (!icon) {
+                return ''
+            }
+            return 'mdi-' + icon.replace(/^mdi-/, '')
+        },
+        iconPosition () {
+            const allowed = ['top', 'bottom', 'left', 'right']
+            return allowed.includes(this.props.iconPosition) ? this.props.iconPosition : 'top'
         },
         floatingPosition () {
             const pos = this.props.floatingTitlePosition
@@ -93,6 +105,7 @@ export default {
     display: flex;
     justify-content: center;
     align-items: center;
+    gap: 2cqmin;
     container-type: size;
     font-weight: bold;
     transition: 0.15s background-color;
@@ -104,6 +117,17 @@ export default {
         font-size: min(16cqw, max(40cqmin, .5rem));
         line-height: normal;
     }
+}
+
+.nrdb-ui-gauge-tile--icon-top { flex-direction: column; }
+.nrdb-ui-gauge-tile--icon-bottom { flex-direction: column-reverse; }
+.nrdb-ui-gauge-tile--icon-left { flex-direction: row; }
+.nrdb-ui-gauge-tile--icon-right { flex-direction: row-reverse; }
+
+.nrdb-ui-gauge-tile-icon {
+    font-size: min(24cqw, max(50cqmin, 1rem)) !important;
+    width: auto;
+    height: auto;
 }
 
 .nrdb-ui-gauge-tile-floating-label {


### PR DESCRIPTION
## Description

The tile gauge currently does not render any icons – even though it makes a lot of sense to add icons to this gauge type.

<img width="495" height="634" alt="Screenshot 2026-04-25 at 23 37 02" src="https://github.com/user-attachments/assets/67537a78-7911-4ed5-a277-95429c9b6280" />
<img width="413" height="240" alt="Screenshot 2026-04-25 at 23 37 45" src="https://github.com/user-attachments/assets/8fad7723-1605-4d5d-adc7-45abf3bc943d" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

## AI Disclaimer
I did use AI (Claude Code Opus 4.7) to create these changes. However I am a competent JS developer and I've manually reviewed and tested the code. I do know what it does. This is not blind "vibecoding".

