### PR TITLE
[2008] ui-text-input partial rendering when set to text area (multi-line)  

### DIFF
--- a/cypress/fixtures/flows/dashboard-text-input.json
+++ b/cypress/fixtures/flows/dashboard-text-input.json
@@ -432,6 +432,38 @@
         ]
     },
     {
+        "id": "c1d2e3f4a5b60718",
+        "type": "ui-text-input",
+        "z": "f4f554a38c3ce158",
+        "g": "ecc44c4e975ac4e9",
+        "group": "cf67bdc7fbda3210",
+        "name": "",
+        "label": "Marking Notes",
+        "order": 2,
+        "width": 0,
+        "height": 3,
+        "topic": "topic",
+        "topicType": "msg",
+        "mode": "textarea",
+        "tooltip": "",
+        "delay": 300,
+        "passthru": true,
+        "sendOnDelay": false,
+        "sendOnBlur": true,
+        "sendOnEnter": true,
+        "className": "",
+        "clearable": false,
+        "sendOnClear": false,
+        "icon": "",
+        "iconPosition": "left",
+        "iconInnerPosition": "inside",
+        "x": 290,
+        "y": 120,
+        "wires": [
+            []
+        ]
+    },
+    {
         "id": "9387656b7b07aa72",
         "type": "function",
         "z": "f4f554a38c3ce158",

--- a/cypress/tests/widgets/text-input.spec.js
+++ b/cypress/tests/widgets/text-input.spec.js
@@ -22,12 +22,23 @@ describe('Node/-RED Dashboard 2.0 - Text Input Widget', () => {
         cy.get('#nrdb-ui-widget-c1d2e3f4a5b60718 .v-field__field label').should('contain', 'Marking Notes')
     })
 
-    // Regression test for #2008: textarea must keep its top padding so the
-    // floating label doesn't overlap the text (not collapsed to the global 2px).
-    it('keeps top padding in textarea mode so the label does not overlap the text', () => {
-        cy.get('#nrdb-ui-widget-c1d2e3f4a5b60718 textarea')
-            .parents('.v-field').first()
-            .find('.v-field__input')
-            .should('have.css', 'padding-top', '12px')
+    // Textarea padding is derived from the row height so the label clears the text
+    // without growing the row, scaling across densities (32/38/48px).
+    const densities = [
+        { name: 'compact (32px row)', cls: 'nrdb-view-density--compact', top: '4px', bottom: '0px' },
+        { name: 'comfortable (38px row)', cls: 'nrdb-view-density--comfortable', top: '7px', bottom: '3px' },
+        { name: 'default (48px row)', cls: 'nrdb-view-density--default', top: '12px', bottom: '8px' }
+    ]
+    densities.forEach(({ name, cls, top, bottom }) => {
+        it(`derives textarea padding from the row height at ${name}`, () => {
+            cy.get('.nrdb-app')
+                .invoke('removeClass', 'nrdb-view-density--compact nrdb-view-density--comfortable nrdb-view-density--default')
+                .invoke('addClass', cls)
+            cy.get('#nrdb-ui-widget-c1d2e3f4a5b60718 textarea')
+                .parents('.v-field').first()
+                .find('.v-field__input')
+                .should('have.css', 'padding-top', top)
+                .and('have.css', 'padding-bottom', bottom)
+        })
     })
 })

--- a/cypress/tests/widgets/text-input.spec.js
+++ b/cypress/tests/widgets/text-input.spec.js
@@ -15,4 +15,19 @@ describe('Node/-RED Dashboard 2.0 - Text Input Widget', () => {
         cy.get('#nrdb-ui-widget-ab3346b81a7cf742 .nrdb-ui-text-field').trigger('mouseover')
         cy.get('.v-tooltip').should('contain', 'Tooltip Text')
     })
+
+    // Test case: Renders the textarea (multiline) mode correctly
+    it('renders the Text Input widget in textarea mode', () => {
+        cy.get('#nrdb-ui-widget-c1d2e3f4a5b60718 textarea').should('exist')
+        cy.get('#nrdb-ui-widget-c1d2e3f4a5b60718 .v-field__field label').should('contain', 'Marking Notes')
+    })
+
+    // Regression test for #2008: textarea must keep its top padding so the
+    // floating label doesn't overlap the text (not collapsed to the global 2px).
+    it('keeps top padding in textarea mode so the label does not overlap the text', () => {
+        cy.get('#nrdb-ui-widget-c1d2e3f4a5b60718 textarea')
+            .parents('.v-field').first()
+            .find('.v-field__input')
+            .should('have.css', 'padding-top', '12px')
+    })
 })

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -179,9 +179,10 @@ export default {
 <style lang="scss">
 .nrdb-ui-textarea {
     height: 100%; /* Ensure the textarea takes full height */
+    --v-input-padding-top: max(4px, calc(var(--widget-row-height) / 2 - 12px));
     &.v-input .v-field--variant-outlined {
-        --v-field-input-padding-top: 12px;
-        --v-field-input-padding-bottom: 12px;
+        --v-field-input-padding-top: max(4px, calc(var(--widget-row-height) / 2 - 12px));
+        --v-field-input-padding-bottom: max(0px, calc(var(--widget-row-height) / 2 - 16px));
     }
     &.v-input--horizontal{
         &:has(textarea) {

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -179,6 +179,10 @@ export default {
 <style lang="scss">
 .nrdb-ui-textarea {
     height: 100%; /* Ensure the textarea takes full height */
+    &.v-input .v-field--variant-outlined {
+        --v-field-input-padding-top: 12px;
+        --v-field-input-padding-bottom: 12px;
+    }
     &.v-input--horizontal{
         &:has(textarea) {
             grid-template-rows: auto 0;


### PR DESCRIPTION


## Description

In `textarea` (multi-line) mode, the global outlined-field rule that compresses input padding to `2px` for compact single-line inputs left the floating label overlapping the first line of text. This restores adequate top/bottom padding scoped to the `textarea` only (single-line inputs keep their compact spacing), and adds a Cypress regression test asserting the padding isn't collapsed.

## Related Issue(s)

Resolves #2008

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

