### PR TITLE
[454 + 1538] Default theme presets + fixes for dark themes 

### DIFF
--- a/cypress/fixtures/flows/dashboard-themes.json
+++ b/cypress/fixtures/flows/dashboard-themes.json
@@ -1,0 +1,136 @@
+[
+    {
+        "id": "dashboard-themes-tab",
+        "type": "tab",
+        "label": "Themes",
+        "disabled": false,
+        "info": ""
+    },
+    {
+        "id": "dashboard-ui-base",
+        "type": "ui-base",
+        "name": "UI Name",
+        "path": "/dashboard",
+        "includeClientData": true,
+        "acceptsClientConfig": [
+            "ui-notification",
+            "ui-control"
+        ]
+    },
+    {
+        "id": "dashboard-theme-light",
+        "type": "ui-theme",
+        "name": "Light",
+        "colors": {
+            "surface": "#fcfcfd",
+            "primary": "#0d74ce",
+            "bgPage": "#f9f9fb",
+            "groupBg": "#ffffff",
+            "groupOutline": "#d9d9e0"
+        }
+    },
+    {
+        "id": "dashboard-theme-dark",
+        "type": "ui-theme",
+        "name": "Dark",
+        "colors": {
+            "surface": "#18191b",
+            "primary": "#0d74ce",
+            "bgPage": "#111113",
+            "groupBg": "#212225",
+            "groupOutline": "#363a3f"
+        }
+    },
+    {
+        "id": "dashboard-ui-page-1",
+        "type": "ui-page",
+        "name": "Light",
+        "ui": "dashboard-ui-base",
+        "path": "/page1",
+        "icon": "",
+        "layout": "grid",
+        "theme": "dashboard-theme-light",
+        "order": 1,
+        "className": "",
+        "visible": "true",
+        "disabled": false
+    },
+    {
+        "id": "dashboard-ui-page-2",
+        "type": "ui-page",
+        "name": "Dark",
+        "ui": "dashboard-ui-base",
+        "path": "/page2",
+        "icon": "",
+        "layout": "grid",
+        "theme": "dashboard-theme-dark",
+        "order": 2,
+        "className": "",
+        "visible": "true",
+        "disabled": false
+    },
+    {
+        "id": "dashboard-group-1",
+        "type": "ui-group",
+        "name": "G1",
+        "page": "dashboard-ui-page-1",
+        "width": "6",
+        "height": "1",
+        "order": 1,
+        "showTitle": true,
+        "className": "",
+        "visible": "true",
+        "disabled": "false"
+    },
+    {
+        "id": "dashboard-group-2",
+        "type": "ui-group",
+        "name": "G2",
+        "page": "dashboard-ui-page-2",
+        "width": "6",
+        "height": "1",
+        "order": 1,
+        "showTitle": true,
+        "className": "",
+        "visible": "true",
+        "disabled": "false"
+    },
+    {
+        "id": "dashboard-text-1",
+        "type": "ui-text",
+        "z": "dashboard-themes-tab",
+        "group": "dashboard-group-1",
+        "order": 1,
+        "width": 6,
+        "height": 1,
+        "name": "",
+        "label": "Themed",
+        "format": "",
+        "layout": "row-left",
+        "style": false,
+        "font": "",
+        "fontSize": 16,
+        "color": "",
+        "className": "",
+        "wires": []
+    },
+    {
+        "id": "dashboard-text-2",
+        "type": "ui-text",
+        "z": "dashboard-themes-tab",
+        "group": "dashboard-group-2",
+        "order": 1,
+        "width": 6,
+        "height": 1,
+        "name": "",
+        "label": "Themed",
+        "format": "",
+        "layout": "row-left",
+        "style": false,
+        "font": "",
+        "fontSize": 16,
+        "color": "",
+        "className": "",
+        "wires": []
+    }
+]

--- a/cypress/tests/config-nodes/theme.spec.js
+++ b/cypress/tests/config-nodes/theme.spec.js
@@ -1,0 +1,15 @@
+describe('Node-RED Dashboard 2.0 - Theme', () => {
+    beforeEach(() => {
+        cy.deployFixture('dashboard-themes')
+    })
+
+    it('applies a light theme — the page renders on the light background', () => {
+        cy.visit('/dashboard/page1')
+        cy.get('.nrdb-app').should('have.css', 'background-color', 'rgb(249, 249, 251)')
+    })
+
+    it('applies a dark theme — the page renders on the dark background', () => {
+        cy.visit('/dashboard/page2')
+        cy.get('.nrdb-app').should('have.css', 'background-color', 'rgb(17, 17, 19)')
+    })
+})

--- a/nodes/config/locales/en-US/ui_base.json
+++ b/nodes/config/locales/en-US/ui_base.json
@@ -67,7 +67,15 @@
         "themes": {
             "header": "Themes",
             "theme": "Theme",
-            "defaultTheme": "Default Theme"
+            "defaultTheme": "Default Theme",
+            "presetHint": "Theme preset",
+            "presets": {
+                "light": "Light",
+                "dark": "Dark",
+                "dracula": "Dracula",
+                "nord": "Nord",
+                "sepia": "Sepia"
+            }
         },
         "colors": {
             "light": "var(--nrdb-node-light)",

--- a/nodes/config/locales/en-US/ui_theme.json
+++ b/nodes/config/locales/en-US/ui_theme.json
@@ -2,6 +2,8 @@
     "ui-theme": {
         "label": {
             "themeName": "Theme Name",
+            "preset": "Preset",
+            "custom": "Custom",
             "colors": "Colors",
             "dashboard": "Dashboard",
             "header": "Header",

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -911,7 +911,36 @@ async function showDashboardWysiwygEditor (pageId, baseId) {
         return pageNode
     }
 
-    function createThemeNode ({ name } = {}) {
+    const THEME_PRESETS = {
+        version: 1,
+        presets: {
+            light: {
+                colors: { surface: '#fcfcfd', primary: '#0d74ce', bgPage: '#f9f9fb', groupBg: '#ffffff', groupOutline: '#d9d9e0' },
+                sizes: { density: 'default', pagePadding: '12px', groupGap: '12px', groupBorderRadius: '4px', widgetGap: '12px' }
+            },
+            dark: {
+                colors: { surface: '#18191b', primary: '#0d74ce', bgPage: '#111113', groupBg: '#212225', groupOutline: '#363a3f' },
+                sizes: { density: 'default', pagePadding: '12px', groupGap: '12px', groupBorderRadius: '4px', widgetGap: '12px' }
+            },
+            dracula: {
+                colors: { surface: '#21222c', primary: '#bd93f9', bgPage: '#282a36', groupBg: '#343746', groupOutline: '#44475a' },
+                sizes: { density: 'default', pagePadding: '12px', groupGap: '12px', groupBorderRadius: '4px', widgetGap: '12px' }
+            },
+            nord: {
+                colors: { surface: '#3b4252', primary: '#88c0d0', bgPage: '#2e3440', groupBg: '#3b4252', groupOutline: '#4c566a' },
+                sizes: { density: 'default', pagePadding: '12px', groupGap: '12px', groupBorderRadius: '4px', widgetGap: '12px' }
+            },
+            sepia: {
+                colors: { surface: '#f2e5bc', primary: '#af3a03', bgPage: '#ebdbb2', groupBg: '#fbf1c7', groupOutline: '#d5c4a1' },
+                sizes: { density: 'default', pagePadding: '12px', groupGap: '12px', groupBorderRadius: '4px', widgetGap: '12px' }
+            }
+        }
+    }
+    window.NRDB_THEME_PRESETS = THEME_PRESETS
+
+    let themePreset = Object.keys(THEME_PRESETS.presets)[0]
+
+    function createThemeNode ({ name, preset = 'light' } = {}) {
         if (RED._db2debug) { console.log('dashboard 2: ui_base.html: createThemeNode', name) }
         const theme = RED.nodes.getType('ui-theme')
         let themeName = name
@@ -931,6 +960,12 @@ async function showDashboardWysiwygEditor (pageId, baseId) {
             type: 'ui-theme',
             ...mapDefaults(theme.defaults),
             name: themeName || c_('themes.defaultTheme')
+        }
+        // preset:null keeps the raw node defaults
+        const presetDef = THEME_PRESETS.presets[preset]
+        if (presetDef) {
+            themeNode.colors = { ...presetDef.colors }
+            themeNode.sizes = { ...presetDef.sizes }
         }
         return themeNode
     }
@@ -1945,11 +1980,32 @@ async function showDashboardWysiwygEditor (pageId, baseId) {
         // button group
         const buttonGroup = $('<div>', { class: 'nrdb2-sb-list-button-group' }).appendTo(themeHeader)
 
-        // add theme button
+        const presetKeys = Object.keys(THEME_PRESETS.presets)
+        const presetLabel = (k) => c_('themes.presets.' + k)
+        const themePresetButton = $('<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button"></a>').appendTo(buttonGroup)
+        function renderThemePresetButton () {
+            themePresetButton.text(presetLabel(themePreset) + ' ')
+            $('<i class="fa fa-caret-down"></i>').appendTo(themePresetButton)
+        }
+        renderThemePresetButton()
+        const themePresetTooltip = RED.popover.tooltip(themePresetButton, c_('themes.presetHint'))
+        themePresetButton.click(function (evt) {
+            evt.preventDefault()
+            themePresetTooltip.close(true)
+            RED.popover.menu({
+                options: presetKeys.map((key) => ({
+                    label: presetLabel(key),
+                    onselect: function () { themePreset = key; renderThemePresetButton() }
+                }))
+            }).show({ target: themePresetButton })
+        })
         $('<a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button"><i class="fa fa-plus"></i> ' + c_('themes.theme') + '</a>')
             .click(function (evt) {
-                themesOL.editableList('addItem')
                 evt.preventDefault()
+                const theme = createThemeNode({ preset: themePreset })
+                addNode(theme)
+                themesOL.editableList('addItem', theme)
+                RED.editor.editConfig('', theme.type, theme.id)
             })
             .appendTo(buttonGroup)
 

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -961,7 +961,6 @@ async function showDashboardWysiwygEditor (pageId, baseId) {
             ...mapDefaults(theme.defaults),
             name: themeName || c_('themes.defaultTheme')
         }
-        // preset:null keeps the raw node defaults
         const presetDef = THEME_PRESETS.presets[preset]
         if (presetDef) {
             themeNode.colors = { ...presetDef.colors }

--- a/nodes/config/ui_theme.html
+++ b/nodes/config/ui_theme.html
@@ -9,11 +9,11 @@
             // colors
             colors: {
                 value: {
-                    surface: '#ffffff',
-                    primary: '#0094CE',
-                    bgPage: '#eeeeee',
+                    surface: '#fcfcfd',
+                    primary: '#0d74ce',
+                    bgPage: '#f9f9fb',
                     groupBg: '#ffffff',
-                    groupOutline: '#cccccc'
+                    groupOutline: '#d9d9e0'
                 }
             },
             // sizes
@@ -35,13 +35,13 @@
             if (!this.colors) {
                 this.colors = {}
                 // set default values
-                this.colors.surface = '#ffffff'
-                this.colors.primary = '#0094CE'
+                this.colors.surface = '#fcfcfd'
+                this.colors.primary = '#0d74ce'
                 // pages
-                this.colors.bgPage = '#eeeeee'
+                this.colors.bgPage = '#f9f9fb'
                 // groups
                 this.colors.groupBg = '#ffffff'
-                this.colors.groupOutline = '#cccccc'
+                this.colors.groupOutline = '#d9d9e0'
             }
 
             if (!this.sizes) {
@@ -93,6 +93,47 @@
                 })
                 wrapper.css('background-color', colorPicker.val())
             })
+
+            const presets = window.NRDB_THEME_PRESETS
+            const presetSelect = $('#nrdb-theme-preset')
+            const presetColorKeys = ['surface', 'primary', 'bgPage', 'groupBg', 'groupOutline']
+            const presetName = (key) => RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.themes.presets.' + key)
+            let applyingPreset = false
+            if (presets) {
+                Object.keys(presets.presets).forEach((key) => {
+                    presetSelect.append($('<option>').val(key).text(presetName(key)))
+                })
+            }
+            presetSelect.append($('<option>').val('custom').text(RED._('@flowfuse/node-red-dashboard/ui-theme:ui-theme.label.custom')))
+            const matchPreset = function () {
+                if (!presets) { return 'custom' }
+                for (const key of Object.keys(presets.presets)) {
+                    const c = presets.presets[key].colors
+                    if (presetColorKeys.every((k) => ($('#node-config-input-' + k).val() || '').toLowerCase() === (c[k] || '').toLowerCase())) {
+                        return key
+                    }
+                }
+                return 'custom'
+            }
+            const applyPreset = function (key) {
+                const def = presets && presets.presets[key]
+                if (!def) { return }
+                applyingPreset = true
+                Object.keys(def.colors).forEach((k) => $('#node-config-input-' + k).val(def.colors[k]).trigger('change'))
+                Object.keys(def.sizes).forEach((k) => $('#node-config-input-' + k).val(def.sizes[k]))
+                applyingPreset = false
+            }
+            presetSelect.val(matchPreset())
+            presetSelect.on('change', function () {
+                const key = presetSelect.val()
+                if (key === 'custom') { return }
+                applyPreset(key)
+            })
+            presetColorKeys.forEach((k) => {
+                $('#node-config-input-' + k).on('change input', function () {
+                    if (!applyingPreset) { presetSelect.val('custom') }
+                })
+            })
         },
         oneditsave: function () {
             // update our config values from the input values
@@ -122,6 +163,10 @@
     <div class="form-row">
         <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></label>
         <input type="text" id="node-config-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-row">
+        <label for="nrdb-theme-preset"><i class="fa fa-paint-brush"></i> <span data-i18n="ui-theme.label.preset"></span></label>
+        <select id="nrdb-theme-preset"></select>
     </div>
     <h3 style="margin: 0; margin-bottom: 6px; border-bottom: 1px solid #eee; padding-bottom: 3px;" data-i18n="ui-theme.label.colors"></h3>
     <div class="form-row" style="margin-bottom: 3px;">

--- a/test/helpers/theme-presets.spec.js
+++ b/test/helpers/theme-presets.spec.js
@@ -1,0 +1,95 @@
+const fs = require('fs')
+const path = require('path')
+
+const should = require('should') // eslint-disable-line no-unused-vars
+
+// Extract THEME_PRESETS from the editor HTML — the values we actually ship.
+function loadPresets () {
+    const src = fs.readFileSync(path.join(__dirname, '../../nodes/config/ui_base.html'), 'utf8')
+    const marker = src.indexOf('const THEME_PRESETS =')
+    if (marker === -1) { throw new Error('THEME_PRESETS not found in ui_base.html') }
+    const objStart = src.indexOf('{', marker)
+    let depth = 0
+    let end = objStart
+    for (; end < src.length; end++) {
+        if (src[end] === '{') { depth++ } else if (src[end] === '}') { depth--; if (depth === 0) { end++; break } }
+    }
+    // eslint-disable-next-line no-eval
+    return eval('(' + src.slice(objStart, end) + ')')
+}
+
+// The ui-theme node defaults; asserted below to stay in sync with the light preset.
+function loadThemeNodeDefaults () {
+    const src = fs.readFileSync(path.join(__dirname, '../../nodes/config/ui_theme.html'), 'utf8')
+    const grab = (key) => {
+        const keyAt = src.indexOf(key + ': {')
+        if (keyAt === -1) { throw new Error(key + ' default not found in ui_theme.html') }
+        const valAt = src.indexOf('value: {', keyAt)
+        const objStart = src.indexOf('{', valAt)
+        let depth = 0
+        let end = objStart
+        for (; end < src.length; end++) {
+            if (src[end] === '{') { depth++ } else if (src[end] === '}') { depth--; if (depth === 0) { end++; break } }
+        }
+        // eslint-disable-next-line no-eval
+        return eval('(' + src.slice(objStart, end) + ')')
+    }
+    return { colors: grab('colors'), sizes: grab('sizes') }
+}
+
+function hexToRgb (h) {
+    h = h.replace('#', '')
+    if (h.length === 3) { h = h.split('').map(c => c + c).join('') }
+    return [0, 2, 4].map(i => parseInt(h.substr(i, 2), 16))
+}
+
+// what Baseline.vue's getContrast() renders as the on-colour (AERT brightness)
+function getContrast (bg) {
+    const [r, g, b] = hexToRgb(bg)
+    const brightness = Math.round((r * 299 + g * 587 + b * 114) / 1000)
+    return brightness > 125 ? '#000000' : '#ffffff'
+}
+
+// WCAG 2.1 relative-luminance contrast ratio
+function relLum (hex) {
+    const c = hexToRgb(hex).map(v => { v /= 255; return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4) })
+    return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2]
+}
+function contrast (a, b) {
+    const [hi, lo] = [relLum(a), relLum(b)].sort((x, y) => y - x)
+    return (hi + 0.05) / (lo + 0.05)
+}
+
+const AA = 4.5
+
+describe('theme presets accessibility', function () {
+    const presets = loadPresets().presets
+
+    it('ships light and dark presets', function () {
+        presets.should.have.property('light')
+        presets.should.have.property('dark')
+    })
+
+    describe('ui-theme node defaults', function () {
+        const defaults = loadThemeNodeDefaults()
+        it('default colors match the light preset', function () {
+            defaults.colors.should.eql(presets.light.colors)
+        })
+        it('default sizes match the light preset', function () {
+            defaults.sizes.should.eql(presets.light.sizes)
+        })
+    })
+
+    Object.keys(presets).forEach((name) => {
+        describe(name + ' preset', function () {
+            const colors = presets[name].colors
+            const surfaces = { page: colors.bgPage, group: colors.groupBg, header: colors.surface, primary: colors.primary }
+            Object.keys(surfaces).forEach((surface) => {
+                it('rendered text on the ' + surface + ' surface meets WCAG AA', function () {
+                    const bg = surfaces[surface]
+                    contrast(getContrast(bg), bg).should.be.aboveOrEqual(AA)
+                })
+            })
+        })
+    })
+})

--- a/ui/src/layouts/Baseline.vue
+++ b/ui/src/layouts/Baseline.vue
@@ -325,6 +325,8 @@ export default {
                 // widget background
                 colors.surface = this.theme.colors.groupBg
 
+                this.$vuetify.theme.themes.nrdb.dark = getContrast(this.theme.colors.bgPage) === '#ffffff'
+
                 // sizes
                 sizes['--page-padding'] = this.theme.sizes.pagePadding
                 sizes['--group-gap'] = this.theme.sizes.groupGap

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -43,15 +43,15 @@ const defaultTheme = retrieveDefaultThemeFromCache()
 const theme = {
     dark: false,
     colors: {
-        background: defaultTheme ? defaultTheme.colors.bgPage : '#fff',
-        'navigation-background': defaultTheme ? defaultTheme.colors.surface : '#ffffff',
+        background: defaultTheme ? defaultTheme.colors.bgPage : '#f9f9fb',
+        'navigation-background': defaultTheme ? defaultTheme.colors.surface : '#fcfcfd',
         'group-background': defaultTheme ? defaultTheme.colors.groupBg : '#ffffff',
-        'group-outline': defaultTheme ? defaultTheme.colors.groupOutline : '#d1d1d1',
-        primary: defaultTheme ? defaultTheme.colors.primary : '#0094CE',
+        'group-outline': defaultTheme ? defaultTheme.colors.groupOutline : '#d9d9e0',
+        primary: defaultTheme ? defaultTheme.colors.primary : '#0d74ce',
         accent: '#ff6b99',
         secondary: '#26ff8c',
         success: '#a5d64c',
-        surface: defaultTheme ? defaultTheme.colors.surface : '#ffffff',
+        surface: defaultTheme ? defaultTheme.colors.surface : '#fcfcfd',
         info: '#ff53d0',
         warning: '#ff8e00',
         error: '#ff5252'

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -283,8 +283,8 @@ main {
     margin-top: 0;
     margin-bottom: 0;
 }
-.nrdb-ui-markdown code {
-    background: #f3f3f3; /* should use theme variable? */
+.nrdb-ui-markdown :not(pre) > code {
+    background: rgba(var(--v-theme-on-group-background), 0.08);
     font-size: 0.85rem;
 }
 .nrdb-ui-markdown pre code {
@@ -295,8 +295,8 @@ main {
 }
 .nrdb-ui-markdown blockquote {
     padding-left: 1em;
-    border-left: 4px solid #d1d1d1; /* should use theme variable? */
-    color: gray; /* should use theme variable? */
+    border-left: 4px solid rgba(var(--v-theme-on-group-background), 0.2);
+    color: rgba(var(--v-theme-on-group-background), 0.6);
 }
 .nrdb-ui-markdown table {
     border-collapse: collapse;
@@ -309,11 +309,11 @@ main {
 .nrdb-ui-markdown table th {
     font-weight: bold;
     padding: 0.5em 0.5em;
-    border: 1px solid #d1d1d1; /* should use theme variable? */
+    border: 1px solid rgba(var(--v-theme-on-group-background), 0.2);
 }
 .nrdb-ui-markdown table td {
     padding: 0.5em 0.5em;
-    border: 1px solid #d1d1d1; /* should use theme variable? */
+    border: 1px solid rgba(var(--v-theme-on-group-background), 0.2);
 }
 
 /**

--- a/ui/src/util.mjs
+++ b/ui/src/util.mjs
@@ -146,7 +146,7 @@ function path (str) {
     return str.replaceAll('//', '/')
 }
 
-export function themeColor (el, token, { alpha, fallback = '' } = {}) {
+export function resolveThemeColorToRgb (el, token, { alpha, fallback = '' } = {}) {
     const rgb = el ? getComputedStyle(el).getPropertyValue('--v-theme-' + token).trim() : ''
     if (!rgb) { return fallback }
     return (alpha === undefined || alpha === null) ? `rgb(${rgb})` : `rgba(${rgb}, ${alpha})`

--- a/ui/src/util.mjs
+++ b/ui/src/util.mjs
@@ -146,6 +146,12 @@ function path (str) {
     return str.replaceAll('//', '/')
 }
 
+export function themeColor (el, token, { alpha, fallback = '' } = {}) {
+    const rgb = el ? getComputedStyle(el).getPropertyValue('--v-theme-' + token).trim() : ''
+    if (!rgb) { return fallback }
+    return (alpha === undefined || alpha === null) ? `rgb(${rgb})` : `rgba(${rgb}, ${alpha})`
+}
+
 /**
  * Load a UMD module asynchronously into the page
  *

--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -11,6 +11,8 @@ import * as echarts from 'echarts'
 import { shallowRef } from 'vue'
 import { mapState } from 'vuex'
 
+import { themeColor } from '../../util.mjs'
+
 import axisHelper from './helpers/axis.helper'
 import chartJStoECharts from './helpers/chartJsToECharts.js'
 import * as pieCharts from './helpers/pie.helper'
@@ -215,6 +217,8 @@ export default {
                 if (this.props.textColorDefault !== undefined) {
                     if (this.props.textColorDefault === false) {
                         textColor = this.props.textColor[0]
+                    } else if (this.$vuetify.theme.current.dark) {
+                        textColor = themeColor(this.$refs.chart, 'on-group-background', { fallback: textColor })
                     }
                 }
             }
@@ -222,6 +226,8 @@ export default {
                 if (this.props.gridColorDefault !== undefined) {
                     if (this.props.gridColorDefault === false) {
                         gridColor = this.props.gridColor[0]
+                    } else if (this.$vuetify.theme.current.dark) {
+                        gridColor = themeColor(this.$refs.chart, 'on-group-background', { alpha: 0.12, fallback: gridColor })
                     }
                 }
             }
@@ -630,7 +636,7 @@ export default {
                         top: this.hasTitle ? 40 : 0, // account for the title
                         itemStyle: {
                             borderWidth: 2,
-                            borderColor: '#fff'
+                            borderColor: themeColor(this.$refs.chart, 'group-background', { fallback: '#fff' })
                         }
                     }
                     if (this.props.showLegend) {

--- a/ui/src/widgets/ui-chart/UIChart.vue
+++ b/ui/src/widgets/ui-chart/UIChart.vue
@@ -11,7 +11,7 @@ import * as echarts from 'echarts'
 import { shallowRef } from 'vue'
 import { mapState } from 'vuex'
 
-import { themeColor } from '../../util.mjs'
+import { resolveThemeColorToRgb } from '../../util.mjs'
 
 import axisHelper from './helpers/axis.helper'
 import chartJStoECharts from './helpers/chartJsToECharts.js'
@@ -218,7 +218,7 @@ export default {
                     if (this.props.textColorDefault === false) {
                         textColor = this.props.textColor[0]
                     } else if (this.$vuetify.theme.current.dark) {
-                        textColor = themeColor(this.$refs.chart, 'on-group-background', { fallback: textColor })
+                        textColor = resolveThemeColorToRgb(this.$refs.chart, 'on-group-background', { fallback: textColor })
                     }
                 }
             }
@@ -227,7 +227,7 @@ export default {
                     if (this.props.gridColorDefault === false) {
                         gridColor = this.props.gridColor[0]
                     } else if (this.$vuetify.theme.current.dark) {
-                        gridColor = themeColor(this.$refs.chart, 'on-group-background', { alpha: 0.12, fallback: gridColor })
+                        gridColor = resolveThemeColorToRgb(this.$refs.chart, 'on-group-background', { alpha: 0.12, fallback: gridColor })
                     }
                 }
             }
@@ -636,7 +636,7 @@ export default {
                         top: this.hasTitle ? 40 : 0, // account for the title
                         itemStyle: {
                             borderWidth: 2,
-                            borderColor: themeColor(this.$refs.chart, 'group-background', { fallback: '#fff' })
+                            borderColor: resolveThemeColorToRgb(this.$refs.chart, 'group-background', { fallback: '#fff' })
                         }
                     }
                     if (this.props.showLegend) {

--- a/ui/src/widgets/ui-gauge/types/UIGaugeBattery.vue
+++ b/ui/src/widgets/ui-gauge/types/UIGaugeBattery.vue
@@ -136,7 +136,7 @@ export default {
     fill-opacity: 0.25;
 }
 .nrdb-ui-gauge-battery-icon.nrdb-ui-gauge-battery-icon--bg {
-    color: black;
+    color: rgb(var(--v-theme-on-group-background));
 }
 .nrdb-ui-gauge-battery-icon.nrdb-ui-gauge-battery-icon--fill {
     color: white;


### PR DESCRIPTION
## Description

- **Five built-in themes** — Light, Dark, Dracula, Nord, Sepia — each a complete, accessible (WCAG AA) colour scheme. New dashboards start on Light; pick any from a dropdown, and editing a colour branches off into Custom.
- **Dark themes that are usable.** Before, a dark palette left light-styled inputs, black-on-black native date pickers, and washed-out charts, gauges and markdown. Now everything follows the theme — legible end to end, on any dark theme you build, not just the presets.

<img width="1000" height="517" alt="dashboards-theme" src="https://github.com/user-attachments/assets/ba1a2cb5-66f9-4ef6-9311-66b70b3ab033" />

## Test plan

- [x] A new dashboard defaults to the Light preset.
- [x] The sidebar dropdown lists all five and creates the chosen one; the ui-theme editor switches a theme and drops to Custom on any colour edit.
- [x] Dark showcase pages: text, charts, gauges, markdown, and the native date picker are all legible.
- [x] `npm test` passes (all five meet WCAG AA; defaults equal the light preset).

---

## Related Issue(s)

Resolves https://github.com/FlowFuse/node-red-dashboard/issues/454
Resolves https://github.com/FlowFuse/node-red-dashboard/issues/1538
Resolves https://github.com/FlowFuse/engineering/issues/244

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

