### PR TITLE
[1344] Undesirable reconnection behaviour 

### DIFF
--- a/test/ui/reconnect-interval.spec.js
+++ b/test/ui/reconnect-interval.spec.js
@@ -1,0 +1,40 @@
+const should = require('should') // eslint-disable-line no-unused-vars
+
+const { nextReconnectInterval } = require('../../ui/src/util/reconnect-interval.js')
+
+const noJitter = () => 0.5
+
+describe('nextReconnectInterval', function () {
+    describe('count-based escalation', function () {
+        it('uses 2.5s for the first few attempts', function () {
+            nextReconnectInterval(0, noJitter).should.equal(2500)
+            nextReconnectInterval(3, noJitter).should.equal(2500)
+        })
+
+        it('escalates to 5s after 4 attempts', function () {
+            nextReconnectInterval(4, noJitter).should.equal(5000)
+            nextReconnectInterval(13, noJitter).should.equal(5000)
+        })
+
+        it('caps at 30s from 14 attempts on, and never gives up', function () {
+            nextReconnectInterval(14, noJitter).should.equal(30000)
+            nextReconnectInterval(1000, noJitter).should.equal(30000)
+        })
+    })
+
+    describe('jitter', function () {
+        it('stays within ±50% of the base interval', function () {
+            for (const rc of [0, 4, 14]) {
+                const base = nextReconnectInterval(rc, noJitter)
+                nextReconnectInterval(rc, () => 0).should.equal(base * 0.5)
+                nextReconnectInterval(rc, () => 1).should.equal(base * 1.5)
+            }
+        })
+
+        it('varies the delay across clients (desync)', function () {
+            const a = nextReconnectInterval(0, () => 0.1)
+            const b = nextReconnectInterval(0, () => 0.9)
+            a.should.not.equal(b)
+        })
+    })
+})

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -9,6 +9,7 @@ import { io } from 'socket.io-client'
 import router from './router.mjs'
 import Alerts from './services/alerts.js'
 import Resize from './directives/resize.js'
+import { nextReconnectInterval } from './util/reconnect-interval'
 
 // Vuetify
 import '@mdi/font/css/materialdesignicons.css'
@@ -157,7 +158,6 @@ fetch('_setup')
         let retryCount = 0 // number of reconnection attempts made
 
         let reconnectTO = null
-        const MAX_RETRIES = 22 // 4 at 2.5 seconds, 10 at 5 secs then 8 at 30 seconds
         const editKey = host.searchParams.get('edit-key')
         const socket = io({
             ...setup.socketio,
@@ -222,8 +222,7 @@ fetch('_setup')
             }
         })
 
-        // default interval - every 2.5 seconds
-        function reconnect (interval = 2500) {
+        function reconnect () {
             if (disconnected) {
                 /** Prior to trying the socket connect, use an http fetch to check for redirection to auth proxy
                  * fetch '_setup' as that is a short json file
@@ -241,37 +240,24 @@ fetch('_setup')
                          * it has failed 3 times
                          */
                         if ((contentType && contentType.includes('application/json')) || retryCount < 2) {
-                            tryConnect(interval)
+                            tryConnect()
                         } else {
                             forcePageReload('Websocket pre-fetch failed')
                         }
                     })
                     .catch(function () {
                         // there is some sort of network failure, let the websocket connection code handle that
-                        tryConnect(interval)
+                        tryConnect()
                     })
             }
         }
 
-        // default interval - every 2.5 seconds
-        function tryConnect (interval) {
+        // No give-up reload: the _setup pre-fetch handles auth-redirects, and reloading an unreachable server is useless.
+        function tryConnect () {
             socket.connect()
-            if (retryCount >= 14) {
-                // trying for over 1 minute
-                interval = 30000 // interval at 30 seconds
-            } else if (retryCount >= 4) {
-                // trying for over 10 seconds
-                interval = 5000 // interval at 5 seconds
-            }
+            const interval = nextReconnectInterval(retryCount)
             retryCount++
-            // if still within our maximum retry count
-            if (retryCount <= MAX_RETRIES) {
-                // check for a connection again in <interval> milliseconds
-                reconnectTO = setTimeout(reconnect, interval)
-            } else {
-                // we have been retrying for 5 minutes so give up and reload the page
-                forcePageReload('Too many retries')
-            }
+            reconnectTO = setTimeout(reconnect, interval)
         }
 
         /**

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -260,6 +260,14 @@ fetch('_setup')
             reconnectTO = setTimeout(reconnect, interval)
         }
 
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible' && disconnected) {
+                clearTimeout(reconnectTO)
+                retryCount = 0
+                reconnect()
+            }
+        })
+
         /**
          * Create VueJS App
          */

--- a/ui/src/main.mjs
+++ b/ui/src/main.mjs
@@ -158,6 +158,7 @@ fetch('_setup')
         let retryCount = 0 // number of reconnection attempts made
 
         let reconnectTO = null
+        let reconnecting = false
         const editKey = host.searchParams.get('edit-key')
         const socket = io({
             ...setup.socketio,
@@ -223,7 +224,8 @@ fetch('_setup')
         })
 
         function reconnect () {
-            if (disconnected) {
+            if (disconnected && !reconnecting) {
+                reconnecting = true
                 /** Prior to trying the socket connect, use an http fetch to check for redirection to auth proxy
                  * fetch '_setup' as that is a short json file
                  * use redirect: 'manual' to stop any redirection to a login page in case it causes a CORS error
@@ -249,6 +251,9 @@ fetch('_setup')
                         // there is some sort of network failure, let the websocket connection code handle that
                         tryConnect()
                     })
+                    .finally(function () {
+                        reconnecting = false
+                    })
             }
         }
 
@@ -261,7 +266,7 @@ fetch('_setup')
         }
 
         document.addEventListener('visibilitychange', () => {
-            if (document.visibilityState === 'visible' && disconnected) {
+            if (document.visibilityState === 'visible' && disconnected && !reconnecting) {
                 clearTimeout(reconnectTO)
                 retryCount = 0
                 reconnect()

--- a/ui/src/util/reconnect-interval.js
+++ b/ui/src/util/reconnect-interval.js
@@ -1,0 +1,17 @@
+function nextReconnectInterval (retryCount, randomFn = Math.random) {
+    let base = 2500
+    if (retryCount >= 14) {
+        base = 30000
+    } else if (retryCount >= 4) {
+        base = 5000
+    }
+    const deviation = base * 0.5 * (randomFn() * 2 - 1)
+    return Math.round(base + deviation)
+}
+
+export { nextReconnectInterval }
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { nextReconnectInterval }
+    module.exports.default = module.exports
+}


### PR DESCRIPTION
## Description

Screens recover on their own, with no reload and no manual intervention. For #1344's 50-screens/10-min-outage case:

- **Never give up**: it used to quit after ~5 min and reload the page, stranding screens on a dead `ERR_NAME_NOT_RESOLVED` error when the server was still down. Now it just keeps retrying and reconnects when the server's back. (Safe to drop the reload: the login-redirect case it covered is now caught by #2078.)
- **Jitter**: each screen waits a slightly random amount before retrying, so 50 of them don't hit the server at the same instant.
- **Count-based**: retry pace tracks the number of attempts, not the clock, so a phone asleep for hours retries right away on wake instead of stalling.
- **Fast-wake**: a tab returning to the foreground reconnects immediately instead of waiting out the retry timer (and never fires two reconnects at once).

<details><summary> 🧪 Test plan</summary>

For testing I tried to emulate the real-life conditions this runs under: Android suspend/wake, auth-proxy session expiry, a server outage across many screens as closely as the environment allows. Lmk if we think this is enough.

- [x] **Normal reconnect**: killed and restarted the server (*a normal restart/deploy*); reconnected on its own, no reload
- [x] **Never gives up**: left the server down 10+ min; kept retrying, never reloaded to an error page
- [x] **Auto-recovery**: brought the server back after the outage; reconnected by itself, no refresh
- [x] **Fast-wake**: froze then woke the tab via `chrome://discards` (*a phone suspending and resuming a backgrounded tab*); reconnected the instant it woke
- [x] **Logged-out path still works**: faked an expired login, so the server returns a login page instead of data (via a DevTools override); it reloaded to the login screen instead of retrying forever, so dropping the give-up didn't strand a logged-out user
- [x] **Jitter**: unit test (can't run 50 real screens); two clients get different retry delays, within ±50%
- [x] **No needless reconnect when healthy**: switched tabs while connected; nothing fired, no reconnect
- [x] **No duplicate reconnect chains**: a tab waking mid-retry doesn't kick off a second reconnect.


</details>

## Related Issue(s)

Resolves https://github.com/FlowFuse/node-red-dashboard/issues/1344

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

